### PR TITLE
Updated `RMRKCore.sol` helper function

### DIFF
--- a/contracts/RMRK/RMRKCore.sol
+++ b/contracts/RMRK/RMRKCore.sol
@@ -833,12 +833,12 @@ contract RMRKCore is Context, IRMRKCore, AccessControl {
     }
   }
 
-  //Gas saving iterator, consider conversion to assemby
-  function u_inc(uint i) private pure returns (uint) {
+  // Gas saving iterator
+  function u_inc(uint i) private pure returns (uint r) {
     unchecked {
-        return i + 1;
+      assembly {
+        r := add(i, 1)
+      }
     }
   }
-
-
 }


### PR DESCRIPTION
rewrote `u_inc` to use assembly for incrementing a number and returning that number.