### PR TITLE
Moves most of multirsource implementation to abstract class

### DIFF
--- a/contracts/RMRK/MultiResourceTokenAbstract.sol
+++ b/contracts/RMRK/MultiResourceTokenAbstract.sol
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.9;
+
+import "./interfaces/IMultiResource.sol";
+import "./library/MultiResourceLib.sol";
+import "./utils/Address.sol";
+import "./utils/Strings.sol";
+import "./utils/Context.sol";
+
+abstract contract MultiResourceTokenAbstract is Context, IMultiResource {
+
+    using MultiResourceLib for uint256;
+    using MultiResourceLib for bytes8[];
+    using MultiResourceLib for bytes16[];
+    using Address for address;
+    using Strings for uint256;
+
+
+    //mapping of bytes8 Ids to resource object
+    mapping(bytes8 => Resource) private _resources;
+
+    //mapping tokenId to current resource to replacing resource
+    mapping(uint256 => mapping(bytes8 => bytes8)) private _resourceOverwrites;
+
+    //mapping of tokenId to all resources
+    mapping(uint256 => bytes8[]) private _activeResources;
+
+    //mapping of tokenId to an array of resource priorities
+    mapping(uint256 => uint16[]) private _activeResourcePriorities;
+
+    //Double mapping of tokenId to active resources
+    mapping(uint256 => mapping(bytes8 => bool)) private _tokenResources;
+
+    //mapping of tokenId to all resources by priority
+    mapping(uint256 => bytes8[]) private _pendingResources;
+
+    //Mapping of bytes8 resource ID to tokenEnumeratedResource for tokenURI
+    mapping(bytes8 => bool) private _tokenEnumeratedResource;
+
+    //Mapping of bytes16 custom field to bytes data
+    mapping(bytes8 => mapping (bytes16 => bytes)) private _customResourceData;
+
+    //List of all resources
+    bytes8[] private _allResources;
+
+    //fallback URI
+    string private _fallbackURI;
+
+    function getFallbackURI() external view virtual returns (string memory) {
+        return _fallbackURI;
+    }
+
+    function _acceptResource(uint256 tokenId, uint256 index) internal {
+        require(
+            index < _pendingResources[tokenId].length,
+            "MultiResource: index out of bounds"
+        );
+        // require(
+        //     _msgSender() == ownerOf(tokenId),
+        //     "MultiResource: not owner"
+        // );
+        bytes8 resourceId = _pendingResources[tokenId][index];
+        _pendingResources[tokenId].removeItemByIndex(0);
+
+        bytes8 overwrite = _resourceOverwrites[tokenId][resourceId];
+        if (overwrite != bytes8(0)) {
+            // We could check here that the resource to overwrite actually exists but it is probably harmless.
+            _activeResources[tokenId].removeItemByValue(overwrite);
+            emit ResourceOverwritten(tokenId, overwrite);
+            delete(_resourceOverwrites[tokenId][resourceId]);
+        }
+        _activeResources[tokenId].push(resourceId);
+        //Push 0 value of uint16 to array, e.g., uninitialized
+        _activeResourcePriorities[tokenId].push(uint16(0));
+        emit ResourceAccepted(tokenId, resourceId);
+    }
+
+    function _rejectResource(uint256 tokenId, uint256 index) internal {
+        require(
+            index < _pendingResources[tokenId].length,
+            "MultiResource: index out of bounds"
+        );
+        require(
+            _pendingResources[tokenId].length > index,
+            "MultiResource: Pending child index out of range"
+        );
+        // require(
+        //     _msgSender() == ownerOf(tokenId),
+        //     "MultiResource: not owner"
+        // );
+
+        bytes8 resourceId = _pendingResources[tokenId][index];
+        _pendingResources[tokenId].removeItemByValue(resourceId);
+        _tokenResources[tokenId][resourceId] = false;
+
+        emit ResourceRejected(tokenId, resourceId);
+    }
+
+    function _rejectAllResources(uint256 tokenId) internal {
+        // require(
+        //     _msgSender() == ownerOf(tokenId),
+        //     "MultiResource: not owner"
+        // );
+        delete(_pendingResources[tokenId]);
+        emit ResourceRejected(tokenId, bytes8(0));
+    }
+
+    function _setPriority(
+        uint256 tokenId,
+        uint16[] memory priorities
+    ) internal {
+        uint256 length = priorities.length;
+        require(
+            length == _activeResources[tokenId].length,
+            "MultiResource: Bad priority list length"
+        );
+        // require(
+        //     _msgSender() == ownerOf(tokenId),
+        //     "MultiResource: not owner"
+        // );
+        _activeResourcePriorities[tokenId] = priorities;
+
+        emit ResourcePrioritySet(tokenId);
+    }
+
+    function getActiveResources(
+        uint256 tokenId
+    ) public view virtual returns(bytes8[] memory) {
+        return _activeResources[tokenId];
+    }
+
+    function getPendingResources(
+        uint256 tokenId
+    ) public view virtual returns(bytes8[] memory) {
+        return _pendingResources[tokenId];
+    }
+
+    function getActiveResourcePriorities(
+        uint256 tokenId
+    ) public view virtual returns(uint16[] memory) {
+        return _activeResourcePriorities[tokenId];
+    }
+
+    function getResourceOverwrites(
+        uint256 tokenId,
+        bytes8 resourceId
+    ) public view virtual returns(bytes8) {
+        return _resourceOverwrites[tokenId][resourceId];
+    }
+
+    function getResource(
+        bytes8 resourceId
+    ) public view virtual returns (Resource memory)
+    {
+        Resource memory resource = _resources[resourceId];
+        require(
+            resource.id != bytes8(0),
+            "RMRK: No resource matching Id"
+        );
+        return resource;
+    }
+
+    function tokenURI(
+        uint256 tokenId
+    ) public view virtual returns (string memory) {
+        return _tokenURIAtIndex(tokenId, 0);
+    }
+
+    function tokenURIAtIndex(
+        uint256 tokenId,
+        uint256 index
+    ) public view virtual returns (string memory) {
+        return _tokenURIAtIndex(tokenId, index);
+    }
+
+    function tokenURIForCustomValue(
+        uint256 tokenId,
+        bytes16 customResourceId,
+        bytes memory customResourceValue
+    ) public view virtual returns (string memory) {
+        bytes8[] memory activeResources = _activeResources[tokenId];
+        uint256 len = _activeResources[tokenId].length;
+        for (uint index; index<len;) {
+            bytes memory actualCustomResourceValue = getCustomResourceData(
+                activeResources[index],
+                customResourceId
+            );
+            if (
+                keccak256(actualCustomResourceValue) ==
+                keccak256(customResourceValue)
+            ) {
+                return _tokenURIAtIndex(tokenId, index);
+            }
+            unchecked {++index;}
+        }
+        return _fallbackURI;
+    }
+
+    function _tokenURIAtIndex(
+        uint256 tokenId,
+        uint256 index
+    ) internal view returns (string memory) {
+        if (_activeResources[tokenId].length > index)  {
+            bytes8 activeResId = _activeResources[tokenId][index];
+            string memory URI;
+            Resource memory _activeRes = getResource(activeResId);
+            if (!_tokenEnumeratedResource[activeResId]) {
+                URI = _activeRes.metadataURI;
+            }
+            else {
+                string memory baseURI = _activeRes.metadataURI;
+                URI = bytes(baseURI).length > 0 ?
+                    string(abi.encodePacked(baseURI, tokenId.toString())) : "";
+            }
+            return URI;
+        }
+        else {
+            return _fallbackURI;
+        }
+    }
+
+    // To be implemented with custom guards
+
+    function _addResourceEntry(
+        bytes8 id,
+        string memory src,
+        string memory thumb,
+        string memory metadataURI,
+        bytes16[] memory custom
+    ) internal {
+        require(id != bytes8(0), "RMRK: Write to zero");
+        require(
+            _resources[id].id == bytes8(0),
+            "RMRK: resource already exists"
+        );
+        Resource memory resource = Resource({
+            id: id,
+            src: src,
+            thumb: thumb,
+            metadataURI: metadataURI,
+            custom: custom
+        });
+        _resources[id] = resource;
+        _allResources.push(id);
+
+        emit ResourceSet(id);
+    }
+
+    function _setCustomResourceData(
+        bytes8 resourceId,
+        bytes16 customResourceId,
+        bytes memory data
+    ) internal {
+        _customResourceData[resourceId][customResourceId] = data;
+        emit ResourceCustomDataSet(resourceId, customResourceId);
+    }
+
+    function _addCustomDataToResource(
+        bytes8 resourceId,
+        bytes16 customResourceId
+    ) internal {
+        _resources[resourceId].custom.push(customResourceId);
+        emit ResourceCustomDataAdded(resourceId, customResourceId);
+    }
+
+    function _removeCustomDataFromResource(
+        bytes8 resourceId,
+        uint256 index
+    ) internal {
+        bytes16 customResourceId = _resources[resourceId].custom[index];
+        _resources[resourceId].custom.removeItemByIndex(index);
+        emit ResourceCustomDataRemoved(resourceId, customResourceId);
+    }
+
+    function _addResourceToToken(
+        uint256 tokenId,
+        bytes8 resourceId,
+        bytes8 overwrites
+    ) internal {
+
+        // require(
+        //     _owners[tokenId] != address(0),
+        //     "ERC721: owner query for nonexistent token"
+        // );
+
+        require(
+            _tokenResources[tokenId][resourceId] == false,
+            "MultiResource: Resource already exists on token"
+        );
+
+        require(
+            getResource(resourceId).id != bytes8(0),
+            "MultiResource: Resource not found in storage"
+        );
+
+        require(
+            _pendingResources[tokenId].length < 128,
+            "MultiResource: Max pending resources reached"
+        );
+
+        _tokenResources[tokenId][resourceId] = true;
+
+        _pendingResources[tokenId].push(resourceId);
+
+        if (overwrites != bytes8(0)) {
+            _resourceOverwrites[tokenId][resourceId] = overwrites;
+            emit ResourceOverwriteProposed(tokenId, resourceId, overwrites);
+        }
+
+        emit ResourceAddedToToken(tokenId, resourceId);
+    }
+
+    function _setFallbackURI(string memory fallbackURI) internal {
+        _fallbackURI = fallbackURI;
+    }
+
+    function _setTokenEnumeratedResource(
+        bytes8 resourceId,
+        bool state
+    ) internal {
+        _tokenEnumeratedResource[resourceId] = state;
+    }
+
+    // Utilities
+
+    function getResObjectByIndex(
+        uint256 tokenId,
+        uint256 index
+    ) public view virtual returns(Resource memory) {
+        bytes8 resourceId = getActiveResources(tokenId)[index];
+        return getResource(resourceId);
+    }
+
+    function getPendingResObjectByIndex(
+        uint256 tokenId,
+        uint256 index
+    ) public view virtual returns(Resource memory) {
+        bytes8 resourceId = getPendingResources(tokenId)[index];
+        return getResource(resourceId);
+    }
+
+    function getFullResources(
+        uint256 tokenId
+    ) public view virtual returns (Resource[] memory) {
+        bytes8[] memory activeResources = _activeResources[tokenId];
+        uint256 len = activeResources.length;
+        Resource[] memory resources = new Resource[](len);
+        for (uint i; i<len;) {
+            resources[i] = getResource(activeResources[i]);
+            unchecked {++i;}
+        }
+        return resources;
+    }
+
+    function getFullPendingResources(
+        uint256 tokenId
+    ) public view virtual returns (Resource[] memory) {
+        bytes8[] memory pendingResources = _pendingResources[tokenId];
+        uint256 len = pendingResources.length;
+        Resource[] memory resources = new Resource[](len);
+        for (uint i; i<len;) {
+            resources[i] = getResource(pendingResources[i]);
+            unchecked {++i;}
+        }
+        return resources;
+    }
+
+    function getAllResources() public view virtual returns (bytes8[] memory) {
+        return _allResources;
+    }
+
+    function getCustomResourceData(
+        bytes8 resourceId,
+        bytes16 customResourceId
+    ) public view virtual returns (bytes memory) {
+        return _customResourceData[resourceId][customResourceId];
+    }
+
+    function isTokenEnumeratedResource(
+        bytes8 resourceId
+    ) public view virtual returns(bool) {
+        return _tokenEnumeratedResource[resourceId];
+    }
+
+}

--- a/contracts/mocks/MultiResourceToken721Mock.sol
+++ b/contracts/mocks/MultiResourceToken721Mock.sol
@@ -2,14 +2,14 @@
 
 pragma solidity ^0.8.9;
 
-import "../RMRK/MultiResource721.sol";
+import "../RMRK/MultiResourceToken721.sol";
 
-contract MultiResource721Mock is MultiResource721 {
+contract MultiResourceToken721Mock is MultiResourceToken721 {
 
     address private _issuer;
 
     constructor(string memory name, string memory symbol)
-        MultiResource721(name, symbol)
+        MultiResourceToken721(name, symbol)
     {
         _setIssuer(_msgSender());
     }

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -1,10 +1,10 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
-import { MultiResource721Mock } from '../typechain';
+import { MultiResourceToken721Mock } from '../typechain';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 describe('MultiResource', async () => {
-  let token: MultiResource721Mock;
+  let token: MultiResourceToken721Mock;
 
   let owner: SignerWithAddress;
   let addrs: any[];
@@ -23,7 +23,7 @@ describe('MultiResource', async () => {
     owner = signersOwner;
     addrs = signersAddr;
 
-    const Token = await ethers.getContractFactory('MultiResource721Mock');
+    const Token = await ethers.getContractFactory('MultiResourceToken721Mock');
     token = await Token.deploy(name, symbol);
     await token.deployed();
   });


### PR DESCRIPTION
This is to avoid later duplication, when we create an implementation to include nesting and multiresource which must share ERC721 capabilities (ownership)