### PR TITLE
RMRKEquippable refactor with custom errors

### DIFF
--- a/contracts/mocks/RMRKEquippableMock.sol
+++ b/contracts/mocks/RMRKEquippableMock.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.14;
 
 import "../RMRK/RMRKEquippable.sol";
 
 //Minimal public implementation of RMRKCore for testing.
+
+error RMRKOnlyIssuer();
+error RMRKCoreTransferCallerNotOwnerOrApproved();
+error ERC721OwnerQueryForNonexistentToken();
 
 contract RMRKEquippableMock is RMRKEquippable {
 
@@ -16,7 +20,7 @@ contract RMRKEquippableMock is RMRKEquippable {
     ) RMRKEquippable(name_, symbol_) {}
 
     modifier onlyIssuer() {
-        require(_msgSender() == _issuer, "RMRK: Only issuer");
+        if(_msgSender() != _issuer) revert RMRKOnlyIssuer();
         _;
     }
 
@@ -35,10 +39,7 @@ contract RMRKEquippableMock is RMRKEquippable {
     }
 
     function burn(uint256 tokenId) public {
-        require(
-            _isApprovedOrOwner(_msgSender(), tokenId),
-            "RMRKCore: transfer caller is not owner nor approved"
-        );
+        if(!_isApprovedOrOwner(_msgSender(), tokenId)) revert RMRKCoreTransferCallerNotOwnerOrApproved();
         _burn(tokenId);
     }
 
@@ -56,10 +57,7 @@ contract RMRKEquippableMock is RMRKEquippable {
         bytes8 resourceId,
         bytes8 overwrites
     ) external onlyIssuer {
-        require(
-            ownerOf(tokenId) != address(0),
-            "ERC721: owner query for nonexistent token"
-        );
+        if(ownerOf(tokenId) == address(0)) revert ERC721OwnerQueryForNonexistentToken();
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -25,7 +25,7 @@ task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: '0.8.9',
+    version: '0.8.14',
     settings: {
       optimizer: {
         enabled: true,

--- a/test/nesting.ts
+++ b/test/nesting.ts
@@ -103,7 +103,7 @@ describe('Nesting', async () => {
     it('cannot nest mint to a non-existent token', async function () {
       await expect(
         petMonkey['mint(address,uint256,uint256,bytes)'](ownerChunky.address, 1, 0, mintNestData),
-      ).to.be.revertedWith('RMRKCore: owner query for nonexistent token');
+      ).to.be.revertedWith('RMRKCoreOwnerQueryForNonexistentToken()');
     });
 
     it('cannot nest mint already minted token', async function () {
@@ -549,7 +549,7 @@ describe('Nesting', async () => {
     it('cannot remove children for non existing index', async () => {
       const parentId = 11;
       await expect(ownerChunky.connect(addrs[1]).removeChild(parentId, 0)).to.be.revertedWith(
-        'RMRKcore: Child index out of range',
+        'RMRKCoreChildIndexOutOfRange()',
       );
     });
   });
@@ -561,7 +561,7 @@ describe('Nesting', async () => {
       await petMonkey.connect(addrs[1])['mint(address,uint256)'](addrs[1].address, tokenId);
       await petMonkey.connect(addrs[1]).burn(tokenId);
       await expect(petMonkey.ownerOf(tokenId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
     });
 
@@ -582,7 +582,7 @@ describe('Nesting', async () => {
 
       await petMonkey.connect(approvedAddress).burn(tokenId);
       await expect(petMonkey.ownerOf(tokenId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
     });
 
@@ -603,10 +603,10 @@ describe('Nesting', async () => {
 
       // no owner for token
       await expect(petMonkey.ownerOf(childId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
       await expect(petMonkey.rmrkOwnerOf(childId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
     });
 
@@ -675,17 +675,17 @@ describe('Nesting', async () => {
       await petMonkey.connect(addrs[0]).burn(childId);
 
       await expect(petMonkey.ownerOf(childId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
       await expect(petMonkey.rmrkOwnerOf(childId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
 
       await expect(ownerChunky.ownerOf(granchildId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
       await expect(ownerChunky.rmrkOwnerOf(granchildId)).to.be.revertedWith(
-        'RMRKCore: owner query for nonexistent token',
+        'RMRKCoreOwnerQueryForNonexistentToken()',
       );
     });
   });
@@ -759,7 +759,7 @@ describe('Nesting', async () => {
     it('cannot unnest not existing child', async function () {
       const { parentId, firstOwner } = await mintTofirstOwner(true);
       await expect(ownerChunky.connect(firstOwner).unnestChild(parentId, 1)).to.be.revertedWith(
-        'RMRKcore: Child index out of range',
+        'RMRKCoreChildIndexOutOfRange()',
       );
     });
 


### PR DESCRIPTION
RMRKEquippableMock was over the contract size limit so I replaced all string errors in RMRKEquippable with custom errors.
Tests are updated too and now the RMRKEquippableMock contract uses  **700** bytes less to deploy.

Please be careful when reviewing if I refactored all require conditions to IFs properly as they are inverted now.
