### PR TITLE
Update Nesting contracts with custom errors

### DIFF
--- a/contracts/RMRK/RMRKEquippable.sol
+++ b/contracts/RMRK/RMRKEquippable.sol
@@ -13,7 +13,7 @@ import "./library/MultiResourceLib.sol";
 import "./utils/Address.sol";
 import "./utils/Strings.sol";
 import "./utils/Context.sol";
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 error RMRKEquippableSlotIDMismatch();
 error RMRKEquippableEquipNotAllowedByBase();

--- a/contracts/RMRK/RMRKNesting.sol
+++ b/contracts/RMRK/RMRKNesting.sol
@@ -13,7 +13,7 @@ import "./library/RMRKLib.sol";
 import "./utils/Address.sol";
 import "./utils/Strings.sol";
 import "./utils/Context.sol";
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract RMRKNesting is ERC721Abstract, NestingAbstract {
 

--- a/contracts/RMRK/RMRKNesting.sol
+++ b/contracts/RMRK/RMRKNesting.sol
@@ -54,12 +54,11 @@ contract RMRKNesting is ERC721Abstract, NestingAbstract {
     }
 
     function _mintToNft(address to, uint256 tokenId, uint256 destinationId, bytes memory data) internal virtual {
-        require(to != address(0), "RMRKCore: mint to the zero address");
-        require(!_exists(tokenId), "RMRKCore: token already minted");
-        require(to.isContract(), "RMRKCore: Is not contract");
-        require(_checkRMRKNestingImplementer(_msgSender(), to, tokenId, ""),
-            "RMRKCore: Mint to non-RMRKCore implementer"
-        );
+        if(to == address(0)) revert RMRKCoreMintToTheZeroAddress();
+        if(_exists(tokenId)) revert RMRKCoreTokenAlreadyMinted();
+        if(!to.isContract()) revert RMRKCoreIsNotContract();
+        if(!_checkRMRKNestingImplementer(_msgSender(), to, tokenId, ""))
+            revert RMRKCoreMintToNonRMRKCoreImplementer();
 
         IRMRKNesting destContract = IRMRKNesting(to);
 
@@ -82,8 +81,8 @@ contract RMRKNesting is ERC721Abstract, NestingAbstract {
     }
 
     function _mintToRootOwner(address to, uint256 tokenId) internal virtual {
-        require(to != address(0), "RMRKCore: mint to the zero address");
-        require(!_exists(tokenId), "RMRKCore: token already minted");
+        if(to == address(0)) revert RMRKCoreMintToTheZeroAddress();
+        if(_exists(tokenId)) revert RMRKCoreTokenAlreadyMinted();
 
         _beforeTokenTransfer(address(0), to, tokenId);
 
@@ -243,14 +242,14 @@ contract RMRKNesting is ERC721Abstract, NestingAbstract {
         bytes memory data
     ) internal virtual {
         require(ownerOf(tokenId) == from, "RMRKCore: transfer from incorrect owner");
-        require(to != address(0), "RMRKCore: transfer to the zero address");
+        if(to == address(0)) revert RMRKCoreMintToTheZeroAddress();
 
         _beforeTokenTransfer(from, to, tokenId);
 
         // FIXME: balances are not tested and probably broken
         _balances[from] -= 1;
         RMRKOwner memory rmrkOwner = _RMRKOwners[tokenId];
-        require(!rmrkOwner.isNft, "RMRKCore: Must unnest first");
+        if(rmrkOwner.isNft) revert RMRKCoreMustUnnestFirst();
         bool destinationIsNft = _checkRMRKNestingImplementer(from, to, tokenId, data);
 
         _RMRKOwners[tokenId] = RMRKOwner({

--- a/contracts/RMRK/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/RMRKNestingMultiResource.sol
@@ -10,60 +10,49 @@ import "./abstracts/NestingAbstract.sol";
 import "./library/RMRKLib.sol";
 import "./utils/Address.sol";
 import "./utils/Strings.sol";
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract RMRKNestingMultiResource is MultiResourceAbstract, RMRKNesting {
-
     using RMRKLib for uint256;
     using Address for address;
     using Strings for uint256;
 
-    constructor(string memory name_, string memory symbol_) RMRKNesting(name_, symbol_) {
-    }
+    constructor(string memory name_, string memory symbol_)
+        RMRKNesting(name_, symbol_){}
 
     function acceptResource(uint256 tokenId, uint256 index) external virtual {
-        require(
-            _isApprovedOrOwner(_msgSender(), tokenId),
-            "MultiResource: not owner"
-        );
+        if (!_isApprovedOrOwner(_msgSender(), tokenId))
+            revert MultiResourceNotOwner();
         // FIXME: clean approvals and test
         _acceptResource(tokenId, index);
     }
 
     function rejectResource(uint256 tokenId, uint256 index) external virtual {
-        require(
-            _isApprovedOrOwner(_msgSender(), tokenId),
-            "MultiResource: not owner"
-        );
+        if (!_isApprovedOrOwner(_msgSender(), tokenId))
+            revert MultiResourceNotOwner();
         // FIXME: clean approvals and test
         _rejectResource(tokenId, index);
     }
 
     function rejectAllResources(uint256 tokenId) external virtual {
-        require(
-            _isApprovedOrOwner(_msgSender(), tokenId),
-            "MultiResource: not owner"
-        );
+        if (!_isApprovedOrOwner(_msgSender(), tokenId))
+            revert MultiResourceNotOwner();
         // FIXME: clean approvals and test
         _rejectAllResources(tokenId);
     }
 
-    function setPriority(
-        uint256 tokenId,
-        uint16[] memory priorities
-    ) external virtual {
-        require(
-            _isApprovedOrOwner(_msgSender(), tokenId),
-            "MultiResource: not owner"
-        );
+    function setPriority(uint256 tokenId, uint16[] memory priorities) external virtual {
+        if (!_isApprovedOrOwner(_msgSender(), tokenId))
+            revert MultiResourceNotOwner();
         // FIXME: clean approvals and test
         _setPriority(tokenId, priorities);
     }
 
-    function tokenURI(
-        uint256 tokenId
-    ) public view override(NestingAbstract, IRMRKMultiResourceBase, MultiResourceAbstractBase) returns (string memory) {
+    function tokenURI(uint256 tokenId) public view override(
+            NestingAbstract,
+            IRMRKMultiResourceBase,
+            MultiResourceAbstractBase
+        ) returns (string memory) {
         return _tokenURIAtIndex(tokenId, 0);
     }
-
 }

--- a/contracts/RMRK/abstracts/ERC721Abstract.sol
+++ b/contracts/RMRK/abstracts/ERC721Abstract.sol
@@ -9,7 +9,7 @@ import "../interfaces/IERC721Receiver.sol";
 import "../utils/Address.sol";
 import "../utils/Strings.sol";
 import "../utils/Context.sol";
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 contract ERC721Abstract is Context, IERC721 {
 

--- a/contracts/RMRK/abstracts/NestingAbstract.sol
+++ b/contracts/RMRK/abstracts/NestingAbstract.sol
@@ -18,6 +18,11 @@ error RMRKCoreUnnestForNonNftParent();
 error RMRKCoreUnnestFromWrongParent();
 error RMRKCoreUnnestFromWrongOwner();
 error RMRKParentChildMismatch();
+error RMRKCoreMintToTheZeroAddress();
+error RMRKCoreMustUnnestFirst();
+error RMRKCoreTokenAlreadyMinted();
+error RMRKCoreIsNotContract();
+error RMRKCoreMintToNonRMRKCoreImplementer();
 error ERC721InvalidTokenID();
 
 abstract contract NestingAbstract is Context, IRMRKNesting {

--- a/contracts/mocks/RMRKMultiResourceMock.sol
+++ b/contracts/mocks/RMRKMultiResourceMock.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.14;
 
 import "../RMRK/RMRKMultiResource.sol";
+
+error RMRKOnlyIssuer();
+error ERC721OwnerQueryForNonexistentToken();
 
 contract RMRKMultiResourceMock is RMRKMultiResource {
 
@@ -15,7 +18,7 @@ contract RMRKMultiResourceMock is RMRKMultiResource {
     }
 
     modifier onlyIssuer() {
-        require(_msgSender() == _issuer, "RMRK: Only issuer");
+        if(_msgSender() != _issuer) revert RMRKOnlyIssuer();
         _;
     }
 
@@ -47,10 +50,7 @@ contract RMRKMultiResourceMock is RMRKMultiResource {
         bytes8 resourceId,
         bytes8 overwrites
     ) external onlyIssuer {
-        require(
-            ownerOf(tokenId) != address(0),
-            "ERC721: owner query for nonexistent token"
-        );
+        if(ownerOf(tokenId) == address(0)) revert ERC721OwnerQueryForNonexistentToken();
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/mocks/RMRKNestingMock.sol
+++ b/contracts/mocks/RMRKNestingMock.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.14;
 
 import "../RMRK/RMRKNesting.sol";
 import "../RMRK/interfaces/IRMRKNestingReceiver.sol";
-import "hardhat/console.sol";
+// import "hardhat/console.sol";
 
 //Minimal public implementation of RMRKCore for testing.
+
+error RMRKCoreTransferCallerNotOwnerOrApproved();
 
 contract RMRKNestingMock is RMRKNesting, IRMRKNestingReceiver {
     constructor(
@@ -29,10 +31,7 @@ contract RMRKNestingMock is RMRKNesting, IRMRKNestingReceiver {
 
     //update for reentrancy
     function burn(uint256 tokenId) public {
-        require(
-            _isApprovedOrOwner(_msgSender(), tokenId),
-            "RMRKCore: transfer caller is not owner nor approved"
-        );
+        if(!_isApprovedOrOwner(_msgSender(), tokenId)) revert RMRKCoreTransferCallerNotOwnerOrApproved();
         _burn(tokenId);
     }
 

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -54,7 +54,7 @@ describe('MultiResource', async () => {
       const id = ethers.utils.hexZeroPad('0x1111', 8);
       await expect(
         token.connect(addrs[1]).addResourceEntry(id, metaURIDefault, customDefault),
-      ).to.be.revertedWith('RMRK: Only issuer');
+      ).to.be.revertedWith('RMRKOnlyIssuer()');
     });
 
     it('can set and get issuer', async function () {
@@ -68,7 +68,7 @@ describe('MultiResource', async () => {
     it('cannot set issuer if not issuer', async function () {
       const newIssuer = addrs[1];
       await expect(token.connect(newIssuer).setIssuer(newIssuer.address)).to.be.revertedWith(
-        'RMRK: Only issuer',
+        'RMRKOnlyIssuer()',
       );
     });
 

--- a/test/nesting.ts
+++ b/test/nesting.ts
@@ -331,7 +331,7 @@ describe('Nesting', async () => {
         petMonkey
           .connect(addrs[0])
           ['mint(address,uint256,uint256,bytes)'](ownerChunky.address, 129, tokenId, mintNestData),
-      ).to.be.revertedWith('RMRKCore: Max pending children reached');
+      ).to.be.revertedWith('RMRKCoreMaxPendingChildrenReached()');
     });
   });
 
@@ -500,7 +500,7 @@ describe('Nesting', async () => {
     it('cannot reject children for non existing index', async () => {
       const parentId = 11;
       await expect(ownerChunky.connect(addrs[1]).rejectChild(parentId, 0)).to.be.revertedWith(
-        'RMRKcore: Pending child index out of range',
+        'RMRKCorePendingChildIndexOutOfRange()',
       );
     });
   });
@@ -569,7 +569,7 @@ describe('Nesting', async () => {
       const tokenId = 1;
       await petMonkey.connect(addrs[1])['mint(address,uint256)'](addrs[1].address, tokenId);
       await expect(petMonkey.connect(addrs[0]).burn(tokenId)).to.be.revertedWith(
-        'RMRKCore: transfer caller is not owner nor approved',
+        'RMRKCoreTransferCallerNotOwnerOrApproved()',
       );
     });
 
@@ -625,7 +625,7 @@ describe('Nesting', async () => {
       await ownerChunky.connect(addrs[0]).acceptChild(parentId, 0);
 
       await expect(petMonkey.connect(addrs[1]).burn(childId)).to.be.revertedWith(
-        'RMRKCore: transfer caller is not owner nor approved',
+        'RMRKCoreTransferCallerNotOwnerOrApproved()',
       );
     });
 
@@ -766,14 +766,14 @@ describe('Nesting', async () => {
     it('cannot unnest token directly even if root owner', async function () {
       const { childId, parentId, firstOwner } = await mintTofirstOwner(true);
       await expect(petMonkey.connect(firstOwner).unnestToken(childId, parentId)).to.be.revertedWith(
-        'RMRKCore: unnest from wrong owner',
+        'RMRKCoreUnnestFromWrongOwner()',
       );
     });
 
     it('cannot unnest token not owned by an NFT', async function () {
       const { parentId, firstOwner } = await mintTofirstOwner(true);
       await expect(ownerChunky.connect(firstOwner).unnestToken(parentId, 0)).to.be.revertedWith(
-        'RMRKCore: unnest for non-NFT parent',
+        'RMRKCoreUnnestForNonNftParent()',
       );
     });
   });

--- a/test/nesting.ts
+++ b/test/nesting.ts
@@ -80,20 +80,20 @@ describe('Nesting', async () => {
     it('cannot mint already minted token', async function () {
       await petMonkey['mint(address,uint256)'](owner.address, 1);
       await expect(petMonkey['mint(address,uint256)'](owner.address, 1)).to.be.revertedWith(
-        'RMRKCore: token already minted',
+        'RMRKCoreTokenAlreadyMinted()',
       );
     });
 
     it('cannot mint to zero address', async function () {
       await expect(
         petMonkey['mint(address,uint256)']('0x0000000000000000000000000000000000000000', 1),
-      ).to.be.revertedWith('RMRKCore: mint to the zero address');
+      ).to.be.revertedWith('RMRKCoreMintToTheZeroAddress()');
     });
 
     it('cannot nest mint to a non-contract destination', async function () {
       await expect(
         petMonkey['mint(address,uint256,uint256,bytes)'](owner.address, 1, 0, mintNestData),
-      ).to.be.revertedWith('Is not contract');
+      ).to.be.revertedWith('RMRKCoreIsNotContract()');
     });
 
     it.skip('cannot nest mint to non rmrk core implementer', async function () {
@@ -129,7 +129,7 @@ describe('Nesting', async () => {
             parentId,
             mintNestData,
           ),
-      ).to.be.revertedWith('RMRKCore: token already minted');
+      ).to.be.revertedWith('RMRKCoreTokenAlreadyMinted()');
     });
 
     it('cannot nest mint already minted token to a different parent', async function () {
@@ -156,7 +156,7 @@ describe('Nesting', async () => {
             parentId,
             mintNestData,
           ),
-      ).to.be.revertedWith('RMRKCore: token already minted');
+      ).to.be.revertedWith('RMRKCoreTokenAlreadyMinted()');
     });
 
     it('cannot nest mint to zero address', async function () {
@@ -167,7 +167,7 @@ describe('Nesting', async () => {
           10,
           mintNestData,
         ),
-      ).to.be.revertedWith('RMRKCore: mint to the zero address');
+      ).to.be.revertedWith('RMRKCoreMintToTheZeroAddress()');
     });
 
     it('can mint to contract and owners are ok', async function () {
@@ -881,7 +881,7 @@ describe('Nesting', async () => {
             newParentId,
             emptyData,
           ),
-      ).to.be.revertedWith('RMRKCore: Must unnest first');
+      ).to.be.revertedWith('RMRKCoreMustUnnestFirst()');
     });
 
     it('can transfer parent token to token with same owner, family tree is ok', async function () {


### PR DESCRIPTION
I have continued with custom error updates, mostly in the NestingAbstract contract.
Also, I commented out hardhat/console.sol as I don't think we should commit it enabled and it's not used anywhere at the moment anyway.