### PR TITLE
RMRKEquipable no longer inherits RMRKNesting but references it

### DIFF
--- a/contracts/RMRK/abstracts/ERC721Abstract.sol
+++ b/contracts/RMRK/abstracts/ERC721Abstract.sol
@@ -51,9 +51,13 @@ contract ERC721Abstract is Context, IERC721 {
         _symbol = symbol_;
     }
 
-    modifier onlyApprovedOrOwner(uint256 tokenId) {
+    function _onlyApprovedOrOwner(uint256 tokenId) private view {
         if(!_isApprovedOrOwner(_msgSender(), tokenId))
             revert ERC721NotApprovedOrOwner();
+    }
+
+    modifier onlyApprovedOrOwner(uint256 tokenId) {
+        _onlyApprovedOrOwner(tokenId);
         _;
     }
 

--- a/contracts/RMRK/abstracts/MultiResourceAbstract.sol
+++ b/contracts/RMRK/abstracts/MultiResourceAbstract.sol
@@ -124,14 +124,13 @@ abstract contract MultiResourceAbstract is IRMRKMultiResource, MultiResourceAbst
         return getResource(resourceId);
     }
 
-    // FIXME: Re enable functionality when enough space
-    // function getPendingResObjectByIndex(
-    //     uint256 tokenId,
-    //     uint256 index
-    // ) external view virtual returns(Resource memory) {
-    //     uint64 resourceId = getPendingResources(tokenId)[index];
-    //     return getResource(resourceId);
-    // }
+    function getPendingResObjectByIndex(
+        uint256 tokenId,
+        uint256 index
+    ) external view virtual returns(Resource memory) {
+        uint64 resourceId = getPendingResources(tokenId)[index];
+        return getResource(resourceId);
+    }
 
     function getFullResources(
         uint256 tokenId

--- a/contracts/RMRK/abstracts/NestingAbstract.sol
+++ b/contracts/RMRK/abstracts/NestingAbstract.sol
@@ -36,13 +36,6 @@ abstract contract NestingAbstract is Context, IRMRKNesting {
         bool isNft;
     }
 
-    struct Child {
-        uint256 tokenId;
-        address contractAddress;
-        uint16 slotEquipped;
-        uint64 partId;
-    }
-
     // Mapping from token ID to RMRKOwner struct
     mapping(uint256 => RMRKOwner) internal _RMRKOwners;
 
@@ -132,9 +125,7 @@ abstract contract NestingAbstract is Context, IRMRKNesting {
 
         Child memory child = Child({
             contractAddress: childTokenAddress,
-            tokenId: childTokenId,
-            slotEquipped: 0,
-            partId: 0
+            tokenId: childTokenId
         });
         _addChildToPending(parentTokenId, child);
         emit ChildProposed(parentTokenId);
@@ -257,6 +248,24 @@ abstract contract NestingAbstract is Context, IRMRKNesting {
     function pendingChildrenOf(uint256 parentTokenId) public view returns (Child[] memory) {
         Child[] memory pendingChildren = _pendingChildren[parentTokenId];
         return pendingChildren;
+    }
+
+    function childOf(
+        uint256 parentTokenId,
+        uint256 index
+    ) external view returns (Child memory) {
+        // FIXME: Check index
+        Child memory child = _pendingChildren[parentTokenId][index];
+        return child;
+    }
+
+    function pendingChildOf(
+        uint256 parentTokenId,
+        uint256 index
+    ) external view returns (Child memory) {
+        // FIXME: Check index
+        Child memory child = _pendingChildren[parentTokenId][index];
+        return child;
     }
 
     //HELPERS

--- a/contracts/RMRK/access/RMRKIssuable.sol
+++ b/contracts/RMRK/access/RMRKIssuable.sol
@@ -14,8 +14,12 @@ contract RMRKIssuable is Context {
         _setIssuer(_msgSender());
     }
 
-    modifier onlyIssuer() {
+    function _onlyIssuer() private view {
         if(_msgSender() != _issuer) revert RMRKOnlyIssuer();
+    }
+
+    modifier onlyIssuer() {
+        _onlyIssuer();
         _;
     }
 

--- a/contracts/RMRK/interfaces/IRMRKEquippableResource.sol
+++ b/contracts/RMRK/interfaces/IRMRKEquippableResource.sol
@@ -34,11 +34,10 @@ interface IRMRKEquippableResource is IRMRKMultiResourceBase {
         uint256 index
     ) external view returns(Resource memory);
 
-    // FIXME: Re enable functionality when enough space
-    // function getPendingResObjectByIndex(
-    //     uint256 tokenId,
-    //     uint256 index
-    // ) external view returns(Resource memory);
+    function getPendingResObjectByIndex(
+        uint256 tokenId,
+        uint256 index
+    ) external view returns(Resource memory);
 
     function getFullResources(
         uint256 tokenId

--- a/contracts/RMRK/interfaces/IRMRKMultiResource.sol
+++ b/contracts/RMRK/interfaces/IRMRKMultiResource.sol
@@ -21,11 +21,10 @@ interface IRMRKMultiResource is IRMRKMultiResourceBase {
         uint256 index
     ) external view returns(Resource memory);
 
-    // FIXME: Re enable functionality when enough space
-    // function getPendingResObjectByIndex(
-    //     uint256 tokenId,
-    //     uint256 index
-    // ) external view returns(Resource memory);
+    function getPendingResObjectByIndex(
+        uint256 tokenId,
+        uint256 index
+    ) external view returns(Resource memory);
 
     function getFullResources(
         uint256 tokenId

--- a/contracts/RMRK/interfaces/IRMRKNesting.sol
+++ b/contracts/RMRK/interfaces/IRMRKNesting.sol
@@ -13,6 +13,12 @@ interface IRMRKNesting {
     event ChildRemoved(uint tokenId, uint index);
     event ChildUnnested(uint parentTokenId, uint childTokenId);
 
+
+    struct Child {
+        uint256 tokenId;
+        address contractAddress;
+    }
+
     function ownerOf(uint256 tokenId)
     external view returns (address owner);
 
@@ -55,4 +61,22 @@ interface IRMRKNesting {
         uint256 tokenId,
         uint256 parentId
     ) external;
+
+    function childrenOf(
+        uint256 parentTokenId
+    ) external view returns (Child[] memory);
+
+    function pendingChildrenOf(
+        uint256 parentTokenId
+    ) external view returns (Child[] memory);
+
+    function childOf(
+        uint256 parentTokenId,
+        uint256 index
+    ) external view returns (Child memory);
+
+    function pendingChildOf(
+        uint256 parentTokenId,
+        uint256 index
+    ) external view returns (Child memory);
 }

--- a/contracts/mocks/RMRKEquippableMock.sol
+++ b/contracts/mocks/RMRKEquippableMock.sol
@@ -10,15 +10,12 @@ import "../RMRK/RMRKEquippable.sol";
 
 contract RMRKEquippableMock is RMRKIssuable, RMRKEquippable {
 
-    address private _issuer;
-
-    constructor(
-        string memory name_,
-        string memory symbol_
-    ) RMRKEquippable(name_, symbol_) {}
-
     function setFallbackURI(string memory fallbackURI) external onlyIssuer {
         _setFallbackURI(fallbackURI);
+    }
+
+    function setNestingAddress(address nestingAddress) external onlyIssuer {
+        _setNestingAddress(nestingAddress);
     }
 
     function setTokenEnumeratedResource(
@@ -28,31 +25,12 @@ contract RMRKEquippableMock is RMRKIssuable, RMRKEquippable {
         _setTokenEnumeratedResource(resourceId, state);
     }
 
-    //The preferred method here is to overload the function, but hardhat tests prevent this.
-    function mint(address to, uint256 tokenId) external {
-        _mint(to, tokenId);
-    }
-
-    function burn(uint256 tokenId) public {
-        if(!_isApprovedOrOwner(_msgSender(), tokenId)) revert ERC721NotApprovedOrOwner();
-        _burn(tokenId);
-    }
-
-    function onRMRKNestingReceived(
-        address,
-        address,
-        uint256,
-        bytes calldata
-    ) external pure returns (bytes4) {
-        return IRMRKNestingReceiver.onRMRKNestingReceived.selector;
-    }
-
     function addResourceToToken(
         uint256 tokenId,
         uint64 resourceId,
         uint64 overwrites
     ) external onlyIssuer {
-        if(ownerOf(tokenId) == address(0)) revert ERC721OwnerQueryForNonexistentToken();
+        // if(ownerOf(tokenId) == address(0)) revert ERC721OwnerQueryForNonexistentToken();
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -29,7 +29,7 @@ const config: HardhatUserConfig = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 1,
+        runs: 200,
       },
     },
   },

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -150,11 +150,11 @@ describe('MultiResource', async () => {
         [resId2, metaURIDefault, customDefault],
       ]);
 
-      // expect(await token.getPendingResObjectByIndex(tokenId, 0)).to.eql([
-      //   resId,
-      //   metaURIDefault,
-      //   customDefault,
-      // ]);
+      expect(await token.getPendingResObjectByIndex(tokenId, 0)).to.eql([
+        resId,
+        metaURIDefault,
+        customDefault,
+      ]);
     });
 
     it('cannot add non existing resource to token', async function () {

--- a/test/nesting.ts
+++ b/test/nesting.ts
@@ -20,7 +20,6 @@ describe('Nesting', async () => {
 
   const mintNestData = ethers.utils.hexZeroPad('0xabcd', 8);
   const emptyData = ethers.utils.hexZeroPad('0x', 0);
-  const partId = BigNumber.from(0);
 
   beforeEach(async function () {
     const [signersOwner, ...signersAddr] = await ethers.getSigners();
@@ -77,7 +76,7 @@ describe('Nesting', async () => {
     });
 
     it('can support INesting', async function () {
-      expect(await ownerChunky.supportsInterface('0xebb57b26')).to.equal(true);
+      expect(await ownerChunky.supportsInterface('0x47ea672d')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -248,7 +247,7 @@ describe('Nesting', async () => {
       expect(children).to.eql([]);
 
       const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
-      expect(pendingChildren).to.eql([[BigNumber.from(childId), petMonkey.address, 0, partId]]);
+      expect(pendingChildren).to.eql([[BigNumber.from(childId), petMonkey.address]]);
     });
 
     it('can mint multiple children', async function () {
@@ -280,8 +279,8 @@ describe('Nesting', async () => {
 
       const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
       expect(pendingChildren).to.eql([
-        [BigNumber.from(childId1), petMonkey.address, 0, partId],
-        [BigNumber.from(childId2), petMonkey.address, 0, partId],
+        [BigNumber.from(childId1), petMonkey.address],
+        [BigNumber.from(childId2), petMonkey.address],
       ]);
     });
 
@@ -313,10 +312,10 @@ describe('Nesting', async () => {
       const pendingChildrenOfMonkey1 = await petMonkey.pendingChildrenOf(childId);
 
       expect(pendingChildrenOfChunky10).to.eql([
-        [BigNumber.from(childId), petMonkey.address, 0, partId],
+        [BigNumber.from(childId), petMonkey.address],
       ]);
       expect(pendingChildrenOfMonkey1).to.eql([
-        [BigNumber.from(granchildId), petMonkey.address, 0, partId],
+        [BigNumber.from(granchildId), petMonkey.address],
       ]);
 
       // RMRK owner of pet 21 is pet 1
@@ -370,7 +369,7 @@ describe('Nesting', async () => {
       expect(pendingChildren).to.eql([]);
 
       const children = await ownerChunky.childrenOf(parentId);
-      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address, 0, partId]]);
+      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address]]);
     });
 
     it('cannot accept not owned child', async function () {
@@ -416,7 +415,7 @@ describe('Nesting', async () => {
       expect(pendingChildren).to.eql([]);
 
       const children = await ownerChunky.childrenOf(parentId);
-      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address, 0, partId]]);
+      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address]]);
     });
   });
 
@@ -469,8 +468,8 @@ describe('Nesting', async () => {
 
       let pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
       expect(pendingChildren).to.eql([
-        [BigNumber.from(1), petMonkey.address, 0, partId],
-        [BigNumber.from(2), petMonkey.address, 0, partId],
+        [BigNumber.from(1), petMonkey.address],
+        [BigNumber.from(2), petMonkey.address],
       ]);
 
       await ownerChunky.connect(addrs[1]).rejectAllChildren(parentId);
@@ -672,9 +671,9 @@ describe('Nesting', async () => {
       const children1 = await ownerChunky.childrenOf(parentId);
       const children2 = await petMonkey.childrenOf(childId);
 
-      expect(children1).to.eql([[BigNumber.from(childId), petMonkey.address, 0, partId]]);
+      expect(children1).to.eql([[BigNumber.from(childId), petMonkey.address]]);
 
-      expect(children2).to.eql([[BigNumber.from(granchildId), ownerChunky.address, 0, partId]]);
+      expect(children2).to.eql([[BigNumber.from(granchildId), ownerChunky.address]]);
 
       expect(await ownerChunky.rmrkOwnerOf(granchildId)).to.eql([
         petMonkey.address,
@@ -874,7 +873,7 @@ describe('Nesting', async () => {
 
       // Parent still has its children
       const children = await ownerChunky.pendingChildrenOf(parentId);
-      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address, 0, partId]]);
+      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address]]);
     });
 
     it('cannot transfer nested child', async function () {
@@ -911,10 +910,10 @@ describe('Nesting', async () => {
         );
 
       // Parent is still owner of child
-      let expected = [BigNumber.from(childId), petMonkey.address, 0, partId];
+      let expected = [BigNumber.from(childId), petMonkey.address];
       checkAcceptedAndPendingChildren(ownerChunky, parentId, [expected], []);
       // Ownership: firstOwner > newGrandparent > parent > child
-      expected = [BigNumber.from(parentId), ownerChunky.address, 0, partId];
+      expected = [BigNumber.from(parentId), ownerChunky.address];
       checkAcceptedAndPendingChildren(ownerChunky, newGrandparentId, [], [expected]);
     });
   });


### PR DESCRIPTION
RMRKNesting interface changed to include a simplified Child struct and methods to get children and pending.