### PR TITLE
Refactoring of approvals

### DIFF
--- a/contracts/RMRK/RMRKEquippable.sol
+++ b/contracts/RMRK/RMRKEquippable.sol
@@ -95,8 +95,8 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
     }
 
     function _onlyOwnerOrApproved(uint tokenId) internal view {
-        // FIXME: This should call also checked for approvals, maybe we need to add a method to check it to IRMRKNestingWithEquippable
-        if(_msgSender() != _ownerOf(tokenId)) revert ERC721NotApprovedOrOwner();
+        if (!IRMRKNestingWithEquippable(_nestingAddress).isApprovedOrOwner(_msgSender(), tokenId))
+            revert ERC721NotApprovedOrOwner();
     }
 
     modifier onlyOwnerOrApproved(uint256 tokenId) {

--- a/contracts/RMRK/RMRKEquippable.sol
+++ b/contracts/RMRK/RMRKEquippable.sol
@@ -94,12 +94,13 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
         return IRMRKNesting(_nestingAddress).ownerOf(tokenId);
     }
 
-    function _onlyTokenOwner(uint tokenId) internal view {
+    function _onlyOwnerOrApproved(uint tokenId) internal view {
+        // FIXME: This should call also checked for approvals, maybe we need to add a method to check it to IRMRKNestingWithEquippable
         if(_msgSender() != _ownerOf(tokenId)) revert ERC721NotApprovedOrOwner();
     }
 
-    modifier onlyTokenOwner(uint256 tokenId) {
-        _onlyTokenOwner(tokenId);
+    modifier onlyOwnerOrApproved(uint256 tokenId) {
+        _onlyOwnerOrApproved(tokenId);
         _;
     }
 
@@ -139,7 +140,7 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
         uint64 slotPartId,
         uint256 childIndex,
         uint64 childResourceId
-    ) external onlyTokenOwner(tokenId) {
+    ) external onlyOwnerOrApproved(tokenId) {
         _equip(tokenId, resourceId, slotPartId, childIndex, childResourceId);
     }
 
@@ -179,7 +180,7 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
         uint256 tokenId,
         uint64 resourceId,
         uint64 slotPartId
-    ) external onlyTokenOwner(tokenId) {
+    ) external onlyOwnerOrApproved(tokenId) {
         _unequip(tokenId, resourceId, slotPartId);
     }
 
@@ -203,7 +204,7 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
         uint64 slotPartId,
         uint256 childIndex,
         uint64 childResourceId
-    ) external onlyTokenOwner(tokenId) {
+    ) external onlyOwnerOrApproved(tokenId) {
         _unequip(tokenId, resourceId, slotPartId);
         _equip(tokenId, resourceId, slotPartId, childIndex, childResourceId);
     }

--- a/contracts/RMRK/RMRKMultiResource.sol
+++ b/contracts/RMRK/RMRKMultiResource.sol
@@ -20,6 +20,21 @@ contract RMRKMultiResource is ERC721, MultiResourceAbstract {
 
     constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {}
 
+    function _isApprovedForResourcesOrOwner(address user, uint256 tokenId) internal view virtual returns (bool) {
+        address owner = ownerOf(tokenId);
+        return (user == owner || isApprovedForAllForResources(owner, user) || getApprovedForResources(tokenId) == user);
+    }
+
+    function _onlyApprovedForResourcesOrOwner(uint256 tokenId) private view {
+        if(!_isApprovedForResourcesOrOwner(_msgSender(), tokenId))
+            revert RMRKNotApprovedForResourcesOrOwner();
+    }
+
+    modifier onlyApprovedForResourcesOrOwner(uint256 tokenId) {
+        _onlyApprovedForResourcesOrOwner(tokenId);
+        _;
+    }
+
     ////////////////////////////////////////
     //        ERC-721 COMPLIANCE
     ////////////////////////////////////////
@@ -47,32 +62,47 @@ contract RMRKMultiResource is ERC721, MultiResourceAbstract {
     function acceptResource(
         uint256 tokenId,
         uint256 index
-    ) external virtual onlyApprovedOrOwner(tokenId) {
-        // FIXME: clean approvals and test
+    ) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _acceptResource(tokenId, index);
     }
 
     function rejectResource(
         uint256 tokenId,
         uint256 index
-    ) external virtual onlyApprovedOrOwner(tokenId) {
-        // FIXME: clean approvals and test
+    ) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _rejectResource(tokenId, index);
     }
 
     function rejectAllResources(
         uint256 tokenId
-    ) external virtual onlyApprovedOrOwner(tokenId) {
-        // FIXME: clean approvals and test
+    ) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _rejectAllResources(tokenId);
     }
 
     function setPriority(
         uint256 tokenId,
         uint16[] memory priorities
-    ) external virtual onlyApprovedOrOwner(tokenId) {
-        // FIXME: clean approvals and test
+    ) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _setPriority(tokenId, priorities);
+    }
+
+    // Approvals
+
+    function approveForResources(address to, uint256 tokenId) external virtual {
+        address owner = ownerOf(tokenId);
+        if(to == owner)
+            revert RMRKApprovalForResourcesToCurrentOwner();
+
+        if(_msgSender() != owner && !isApprovedForAllForResources(owner, _msgSender()))
+            revert RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
+        _approveForResources(owner, to, tokenId);
+    }
+
+    function setApprovalForAllForResources(address operator, bool approved) external virtual {
+        address owner = _msgSender();
+        if(owner == operator)
+            revert RMRKApproveForResourcesToCaller();
+        _setApprovalForAllForResources(owner, operator, approved);
     }
 
 }

--- a/contracts/RMRK/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/RMRKNestingMultiResource.sol
@@ -18,6 +18,21 @@ contract RMRKNestingMultiResource is MultiResourceAbstract, RMRKNesting {
 
     constructor(string memory name_, string memory symbol_)
         RMRKNesting(name_, symbol_){}
+
+    function _isApprovedForResourcesOrOwner(address user, uint256 tokenId) internal view virtual returns (bool) {
+        address owner = ownerOf(tokenId);
+        return (user == owner || isApprovedForAllForResources(owner, user) || getApprovedForResources(tokenId) == user);
+    }
+
+    function _onlyApprovedForResourcesOrOwner(uint256 tokenId) private view {
+        if(!_isApprovedForResourcesOrOwner(_msgSender(), tokenId))
+            revert RMRKNotApprovedForResourcesOrOwner();
+    }
+
+    modifier onlyApprovedForResourcesOrOwner(uint256 tokenId) {
+        _onlyApprovedForResourcesOrOwner(tokenId);
+        _;
+    }
     
     function supportsInterface(bytes4 interfaceId) public override virtual view returns (bool) {
         return (
@@ -26,31 +41,19 @@ contract RMRKNestingMultiResource is MultiResourceAbstract, RMRKNesting {
         );
     }
 
-    function acceptResource(uint256 tokenId, uint256 index) external virtual {
-        if (!_isApprovedOrOwner(_msgSender(), tokenId))
-            revert ERC721NotApprovedOrOwner();
-        // FIXME: clean approvals and test
+    function acceptResource(uint256 tokenId, uint256 index) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _acceptResource(tokenId, index);
     }
 
-    function rejectResource(uint256 tokenId, uint256 index) external virtual {
-        if (!_isApprovedOrOwner(_msgSender(), tokenId))
-            revert ERC721NotApprovedOrOwner();
-        // FIXME: clean approvals and test
+    function rejectResource(uint256 tokenId, uint256 index) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _rejectResource(tokenId, index);
     }
 
-    function rejectAllResources(uint256 tokenId) external virtual {
-        if (!_isApprovedOrOwner(_msgSender(), tokenId))
-            revert ERC721NotApprovedOrOwner();
-        // FIXME: clean approvals and test
+    function rejectAllResources(uint256 tokenId) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _rejectAllResources(tokenId);
     }
 
-    function setPriority(uint256 tokenId, uint16[] memory priorities) external virtual {
-        if (!_isApprovedOrOwner(_msgSender(), tokenId))
-            revert ERC721NotApprovedOrOwner();
-        // FIXME: clean approvals and test
+    function setPriority(uint256 tokenId, uint16[] memory priorities) external virtual onlyApprovedForResourcesOrOwner(tokenId) {
         _setPriority(tokenId, priorities);
     }
 
@@ -59,5 +62,24 @@ contract RMRKNestingMultiResource is MultiResourceAbstract, RMRKNesting {
             MultiResourceAbstract
         ) returns (string memory) {
         return _tokenURIAtIndex(tokenId, 0);
+    }
+
+    // Approvals
+
+    function approveForResources(address to, uint256 tokenId) external virtual {
+        address owner = ownerOf(tokenId);
+        if(to == owner)
+            revert RMRKApprovalForResourcesToCurrentOwner();
+
+        if(_msgSender() != owner && !isApprovedForAllForResources(owner, _msgSender()))
+            revert RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
+        _approveForResources(owner, to, tokenId);
+    }
+
+    function setApprovalForAllForResources(address operator, bool approved) external virtual {
+        address owner = _msgSender();
+        if(owner == operator)
+            revert RMRKApproveForResourcesToCaller();
+        _setApprovalForAllForResources(owner, operator, approved);
     }
 }

--- a/contracts/RMRK/abstracts/MultiResourceAbstract.sol
+++ b/contracts/RMRK/abstracts/MultiResourceAbstract.sol
@@ -14,6 +14,10 @@ error RMRKNoResourceMatchingId();
 error RMRKResourceAlreadyExists();
 error RMRKResourceNotFoundInStorage();
 error RMRKWriteToZero();
+error RMRKNotApprovedForResourcesOrOwner();
+error RMRKApprovalForResourcesToCurrentOwner();
+error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
+error RMRKApproveForResourcesToCaller();
 
 
 abstract contract MultiResourceAbstract is Context, IRMRKMultiResource {
@@ -51,6 +55,12 @@ abstract contract MultiResourceAbstract is Context, IRMRKMultiResource {
 
     //fallback URI
     string internal _fallbackURI;
+
+    // Mapping from token ID to approved address for resources
+    mapping(uint256 => address) internal _tokenApprovalsForResources;
+
+    // Mapping from owner to operator approvals for resources
+    mapping(address => mapping(address => bool)) internal _operatorApprovalsForResources;
 
     function getResource(
         uint64 resourceId
@@ -286,6 +296,33 @@ abstract contract MultiResourceAbstract is Context, IRMRKMultiResource {
         bool state
     ) internal {
         _tokenEnumeratedResource[resourceId] = state;
+    }
+
+    // Approvals
+
+    function getApprovedForResources(uint256 tokenId) public virtual view returns (address) {
+        // TODO: Do we want to add require minted here?
+        return _tokenApprovalsForResources[tokenId];
+    }
+
+    function isApprovedForAllForResources(address owner, address operator) public virtual view returns (bool) {
+        return _operatorApprovalsForResources[owner][operator];
+    }
+
+    // Cannot be fully implemented since ownership is not defined at this level
+    function _approveForResources(address owner, address to, uint256 tokenId) internal virtual {
+        _tokenApprovalsForResources[tokenId] = to;
+        emit ApprovalForResources(owner, to, tokenId);
+    }
+
+    // Cannot be fully implemented since ownership is not defined at this level
+    function _setApprovalForAllForResources(
+        address owner,
+        address operator,
+        bool approved
+    ) internal virtual {
+        _operatorApprovalsForResources[owner][operator] = approved;
+        emit ApprovalForAllForResources(owner, operator, approved);
     }
 
     // Utilities

--- a/contracts/RMRK/interfaces/IRMRKMultiResource.sol
+++ b/contracts/RMRK/interfaces/IRMRKMultiResource.sol
@@ -35,6 +35,9 @@ interface IRMRKMultiResource {
         uint128 customResourceId
     );
 
+    event ApprovalForResources(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    event ApprovalForAllForResources(address indexed owner, address indexed operator, bool approved);
 
     struct Resource {
         uint64 id; //8 bytes
@@ -95,4 +98,14 @@ interface IRMRKMultiResource {
     function getFullPendingResources(
         uint256 tokenId
     ) external view returns (Resource[] memory);
+
+    // Approvals
+
+    function approveForResources(address to, uint256 tokenId) external;
+
+    function getApprovedForResources(uint256 tokenId) external view returns (address);
+
+    function setApprovalForAllForResources(address operator, bool approved) external;
+
+    function isApprovedForAllForResources(address owner, address operator) external view returns (bool);
 }

--- a/contracts/RMRK/interfaces/IRMRKNestingWithEquippable.sol
+++ b/contracts/RMRK/interfaces/IRMRKNestingWithEquippable.sol
@@ -11,4 +11,5 @@ interface IRMRKNestingWithEquippable {
 
     function getEquippablesAddress() external view returns (address);
 
+    function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool);
 }

--- a/contracts/implementations/RMRKNestingImpl.sol
+++ b/contracts/implementations/RMRKNestingImpl.sol
@@ -69,4 +69,8 @@ contract RMRKNestingImpl is OwnableLock, RMRKMintingUtils, IRMRKNestingWithEquip
         return _equippableAddress;
     }
 
+    function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
+
 }

--- a/contracts/mocks/RMRKNestingMock.sol
+++ b/contracts/mocks/RMRKNestingMock.sol
@@ -64,4 +64,8 @@ contract RMRKNestingMock is  RMRKIssuable, IRMRKNestingReceiver, IRMRKNestingWit
     function getEquippablesAddress() external view returns (address) {
         return _equippableAddress;
     }
+
+    function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
 }

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -454,7 +454,7 @@ async function shouldBehaveLikeEquippableResources(
       await chunkyEquip.addResourceToToken(tokenId, resId, 0);
       await expect(
         chunkyEquip.connect(addrs[1]).acceptResource(tokenId, 0),
-      ).to.be.revertedWithCustomError(chunkyEquip, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(chunkyEquip, 'RMRKNotApprovedForResourcesOrOwner');
     });
 
     it('cannot accept non existing resource', async function () {
@@ -678,10 +678,10 @@ async function shouldBehaveLikeEquippableResources(
 
       await expect(
         chunkyEquip.connect(addrs[1]).rejectResource(tokenId, 0),
-      ).to.be.revertedWithCustomError(chunkyEquip, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(chunkyEquip, 'RMRKNotApprovedForResourcesOrOwner');
       await expect(
         chunkyEquip.connect(addrs[1]).rejectAllResources(tokenId),
-      ).to.be.revertedWithCustomError(chunkyEquip, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(chunkyEquip, 'RMRKNotApprovedForResourcesOrOwner');
     });
 
     it('cannot reject non existing resource', async function () {
@@ -727,7 +727,7 @@ async function shouldBehaveLikeEquippableResources(
       await addResourcesToToken(tokenId);
       await expect(
         chunkyEquip.connect(addrs[1]).setPriority(tokenId, [2, 1]),
-      ).to.be.revertedWithCustomError(chunkyEquip, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(chunkyEquip, 'RMRKNotApprovedForResourcesOrOwner');
     });
 
     it('cannot set different number of priorities', async function () {

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -415,12 +415,12 @@ async function shouldBehaveLikeEquippableResources(
     });
 
     // approved not implemented yet
-    it.skip('can accept resource if approved', async function () {
+    it('can accept resource if approved', async function () {
       const resId = BigNumber.from(1);
       const tokenId = 1;
       const approvedAddress = addrs[1];
       await chunky['mint(address,uint256)'](owner.address, tokenId);
-      await chunky.approve(approvedAddress.address, tokenId);
+      await chunkyEquip.approveForResources(approvedAddress.address, tokenId);
       await addResources([resId]);
 
       await chunkyEquip.addResourceToToken(tokenId, resId, 0);
@@ -553,14 +553,13 @@ async function shouldBehaveLikeEquippableResources(
       expect(await chunkyEquip.getResourceOverwrites(tokenId, resId2)).to.eql(BigNumber.from(0));
     });
 
-    // FIXME: approve not implemented yet
-    it.skip('can reject resource if approved', async function () {
+    it('can reject resource if approved', async function () {
       const resId = BigNumber.from(1);
       const approvedAddress = addrs[1];
       const tokenId = 1;
 
       await chunky['mint(address,uint256)'](owner.address, tokenId);
-      await chunky.approve(approvedAddress.address, tokenId);
+      await chunkyEquip.approveForResources(approvedAddress.address, tokenId);
       await addResources([resId]);
       await chunkyEquip.addResourceToToken(tokenId, resId, 0);
 
@@ -629,15 +628,14 @@ async function shouldBehaveLikeEquippableResources(
       expect(await chunkyEquip.getResourceOverwrites(1, 2)).to.eql(BigNumber.from(0));
     });
 
-    // FIXME: approve not implemented yet
-    it.skip('can reject all resources if approved', async function () {
+    it('can reject all resources if approved', async function () {
       const resId = BigNumber.from(1);
       const resId2 = BigNumber.from(2);
       const tokenId = 1;
       const approvedAddress = addrs[1];
 
       await chunky['mint(address,uint256)'](owner.address, tokenId);
-      await chunky.approve(approvedAddress.address, tokenId);
+      await chunkyEquip.approveForResources(approvedAddress.address, tokenId);
       await addResources([resId, resId2]);
       await chunkyEquip.addResourceToToken(tokenId, resId, 0);
       await chunkyEquip.addResourceToToken(tokenId, resId2, 0);
@@ -707,13 +705,12 @@ async function shouldBehaveLikeEquippableResources(
       expect(await chunkyEquip.getActiveResourcePriorities(tokenId)).to.be.eql([2, 1]);
     });
 
-    // FIXME: approve not implemented yet
-    it.skip('can set and get priorities if approved', async function () {
+    it('can set and get priorities if approved', async function () {
       const tokenId = 1;
       const approvedAddress = addrs[1];
 
       await addResourcesToToken(tokenId);
-      await chunky.approve(approvedAddress.address, tokenId);
+      await chunkyEquip.approveForResources(approvedAddress.address, tokenId);
 
       expect(await chunkyEquip.getActiveResourcePriorities(tokenId)).to.be.eql([0, 0]);
       await expect(chunkyEquip.connect(approvedAddress).setPriority(tokenId, [2, 1]))

--- a/test/behavior/equippableSlots.ts
+++ b/test/behavior/equippableSlots.ts
@@ -199,6 +199,31 @@ async function shouldBehaveLikeEquippableWithSlots(
       expect(await weaponEquip.isEquipped(weapons[0])).to.eql(true);
     });
 
+    it('can equip weapon if approved', async function () {
+      // Weapon is child on index 0, background on index 1
+      const approved = addrs[1];
+      const childIndex = 0;
+      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
+      await soldier.connect(addrs[0]).approve(approved.address, soldiers[0]);
+      await soldierEquip
+        .connect(approved)
+        .equip(soldiers[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
+      // All part slots are included on the response:
+      const expectedSlots = [bn(partIdForWeapon), bn(partIdForBackground)];
+      // If a slot has nothing equipped, it returns an empty equip:
+      const expectedEquips = [
+        [bn(soldierResId), bn(weaponResId), bn(weapons[0]), weaponEquip.address],
+        [bn(0), bn(0), bn(0), ethers.constants.AddressZero],
+      ];
+      expect(await soldierEquip.getEquipped(soldiers[0], soldierResId)).to.eql([
+        expectedSlots,
+        expectedEquips,
+      ]);
+
+      // Child is marked as equipped:
+      expect(await weaponEquip.isEquipped(weapons[0])).to.eql(true);
+    });
+
     it('can equip weapon and background', async function () {
       // Weapon is child on index 0, background on index 1
       const weaponChildIndex = 0;

--- a/test/behavior/multiresource.ts
+++ b/test/behavior/multiresource.ts
@@ -36,7 +36,7 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
     });
 
     it('can support IMultiResource', async function () {
-      expect(await this.token.supportsInterface('0xb925bcaf')).to.equal(true);
+      expect(await this.token.supportsInterface('0x4d6339c8')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -270,7 +270,7 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
       const tokenId = 1;
       const approvedAddress = addrs[1];
       await this.token['mint(address,uint256)'](owner.address, tokenId);
-      await this.token.approve(approvedAddress.address, tokenId);
+      await this.token.approveForResources(approvedAddress.address, tokenId);
       await addResources(this.token, [resId]);
 
       await this.token.addResourceToToken(tokenId, resId, 0);
@@ -295,7 +295,21 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
       );
     });
 
-    it('cannot accept resource if not owner', async function () {
+    it('cannot accept resource if not owner or approved', async function () {
+      const resId = BigNumber.from(1);
+      const tokenId = 1;
+      const approvedAddress = addrs[1];
+      await this.token['mint(address,uint256)'](owner.address, tokenId);
+      await this.token.approve(approvedAddress.address, tokenId);
+      await addResources(this.token, [resId]);
+
+      await this.token.addResourceToToken(tokenId, resId, 0);
+      await expect(
+        this.token.connect(addrs[1]).acceptResource(tokenId, 0),
+      ).to.be.revertedWithCustomError(this.token, 'RMRKNotApprovedForResourcesOrOwner');
+    });
+
+    it('cannot accept resource if not approved for resource', async function () {
       const resId = BigNumber.from(1);
       const tokenId = 1;
 
@@ -304,7 +318,7 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
       await this.token.addResourceToToken(tokenId, resId, 0);
       await expect(
         this.token.connect(addrs[1]).acceptResource(tokenId, 0),
-      ).to.be.revertedWithCustomError(this.token, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(this.token, 'RMRKNotApprovedForResourcesOrOwner');
     });
 
     it('cannot accept non existing resource', async function () {
@@ -409,7 +423,7 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
       const tokenId = 1;
 
       await this.token['mint(address,uint256)'](owner.address, tokenId);
-      await this.token.approve(approvedAddress.address, tokenId);
+      await this.token.approveForResources(approvedAddress.address, tokenId);
       await addResources(this.token, [resId]);
       await this.token.addResourceToToken(tokenId, resId, 0);
 
@@ -482,7 +496,7 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
       const approvedAddress = addrs[1];
 
       await this.token['mint(address,uint256)'](owner.address, tokenId);
-      await this.token.approve(approvedAddress.address, tokenId);
+      await this.token.approveForResources(approvedAddress.address, tokenId);
       await addResources(this.token, [resId, resId2]);
       await this.token.addResourceToToken(tokenId, resId, 0);
       await this.token.addResourceToToken(tokenId, resId2, 0);
@@ -523,10 +537,10 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
 
       await expect(
         this.token.connect(addrs[1]).rejectResource(tokenId, 0),
-      ).to.be.revertedWithCustomError(this.token, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(this.token, 'RMRKNotApprovedForResourcesOrOwner');
       await expect(
         this.token.connect(addrs[1]).rejectAllResources(tokenId),
-      ).to.be.revertedWithCustomError(this.token, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(this.token, 'RMRKNotApprovedForResourcesOrOwner');
     });
 
     it('cannot reject non existing resource', async function () {
@@ -557,7 +571,7 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
       const approvedAddress = addrs[1];
 
       await addResourcesToToken(this.token, tokenId);
-      await this.token.approve(approvedAddress.address, tokenId);
+      await this.token.approveForResources(approvedAddress.address, tokenId);
 
       expect(await this.token.getActiveResourcePriorities(tokenId)).to.be.eql([0, 0]);
       await expect(this.token.connect(approvedAddress).setPriority(tokenId, [2, 1]))
@@ -571,7 +585,7 @@ async function shouldBehaveLikeMultiResource(name: string, symbol: string) {
       await addResourcesToToken(this.token, tokenId);
       await expect(
         this.token.connect(addrs[1]).setPriority(tokenId, [2, 1]),
-      ).to.be.revertedWithCustomError(this.token, 'ERC721NotApprovedOrOwner');
+      ).to.be.revertedWithCustomError(this.token, 'RMRKNotApprovedForResourcesOrOwner');
     });
 
     it('cannot set different number of priorities', async function () {

--- a/test/behavior/nesting.ts
+++ b/test/behavior/nesting.ts
@@ -359,29 +359,25 @@ async function shouldBehaveLikeNesting(
 
   describe('Accept child', async function () {
     it('can accept child', async function () {
-      const childId = 1;
+      const accepter = addrs[1]; // owner of parent token
       const parentId = 11;
+      await checkAcceptChildFromAddress(accepter, parentId);
+    });
 
-      // Another address can mint
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        childId,
-        parentId,
-        mintNestData,
-      );
+    it('can accept child if approved', async function () {
+      const tokenOwner = addrs[1];
+      const approved = addrs[2];
+      const parentId = 11;
+      await ownerChunky.connect(tokenOwner).approve(approved.address, parentId);
+      await checkAcceptChildFromAddress(approved, parentId);
+    });
 
-      // owner accepts the child at index 0 into the child array
-      await ownerChunky.connect(addrs[1]).acceptChild(parentId, 0);
-
-      const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
-      expect(pendingChildren).to.eql([]);
-
-      const children = await ownerChunky.childrenOf(parentId);
-      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address]]);
-      expect(await ownerChunky.childOf(parentId, 0)).to.eql([
-        BigNumber.from(childId),
-        petMonkey.address,
-      ]);
+    it('can accept child if approved for all', async function () {
+      const tokenOwner = addrs[1];
+      const approved = addrs[2];
+      const parentId = 11;
+      await ownerChunky.connect(tokenOwner).setApprovalForAll(approved.address, true);
+      await checkAcceptChildFromAddress(approved, parentId);
     });
 
     it('cannot accept not owned child', async function () {
@@ -402,30 +398,6 @@ async function shouldBehaveLikeNesting(
       ).to.be.revertedWithCustomError(ownerChunky, 'ERC721NotApprovedOrOwner');
     });
 
-    it('can accept child from approved address (not owner)', async function () {
-      const childId = 1;
-      const parentId = 11;
-      const approvedAddress = addrs[2];
-
-      await ownerChunky.connect(addrs[1]).approve(approvedAddress.address, parentId);
-
-      // Another address can mint
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        childId,
-        parentId,
-        mintNestData,
-      );
-
-      await ownerChunky.connect(approvedAddress).acceptChild(parentId, 0);
-
-      const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
-      expect(pendingChildren).to.eql([]);
-
-      const children = await ownerChunky.childrenOf(parentId);
-      expect(children).to.eql([[BigNumber.from(childId), petMonkey.address]]);
-    });
-
     it('cannot accept children for non existing index', async () => {
       const parentId = 11;
       await expect(
@@ -436,17 +408,25 @@ async function shouldBehaveLikeNesting(
 
   describe('Reject child', async function () {
     it('can reject one pending child', async function () {
+      const rejecter = addrs[1]; // owner of parent token
       const parentId = 11;
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        1,
-        parentId,
-        mintNestData,
-      );
+      await checkRejectChildFromAddress(rejecter, parentId);
+    });
 
-      await ownerChunky.connect(addrs[1]).rejectChild(parentId, 0);
-      const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
-      expect(pendingChildren).to.eql([]);
+    it('can reject child if approved', async function () {
+      const tokenOwner = addrs[1];
+      const rejecter = addrs[2];
+      const parentId = 11;
+      await ownerChunky.connect(tokenOwner).approve(rejecter.address, parentId);
+      await checkRejectChildFromAddress(rejecter, parentId);
+    });
+
+    it('can reject child if approved for all', async function () {
+      const tokenOwner = addrs[1];
+      const rejecter = addrs[2];
+      const parentId = 11;
+      await ownerChunky.connect(tokenOwner).setApprovalForAll(rejecter.address, true);
+      await checkRejectChildFromAddress(rejecter, parentId);
     });
 
     it('cannot reject not owned pending child', async function () {
@@ -464,47 +444,26 @@ async function shouldBehaveLikeNesting(
       ).to.be.revertedWithCustomError(ownerChunky, 'ERC721NotApprovedOrOwner');
     });
 
-    it('can reject child from approved address (not owner)', async function () {
+    it('can reject all pending children', async function () {
+      const rejecter = addrs[1]; // owner of parent token
       const parentId = 11;
-      const approvedAddress = addrs[2];
-
-      await ownerChunky.connect(addrs[1]).approve(approvedAddress.address, parentId);
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        1,
-        parentId,
-        mintNestData,
-      );
-
-      await ownerChunky.connect(approvedAddress).rejectChild(parentId, 0);
-      const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
-      expect(pendingChildren).to.eql([]);
+      await checkRejectAllPendingChildrenFromAddress(rejecter, parentId);
     });
 
-    it('can reject all pending children', async function () {
+    it('can reject all pending children if approved', async function () {
+      const tokenOwner = addrs[1];
+      const rejecter = addrs[2];
       const parentId = 11;
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        1,
-        parentId,
-        mintNestData,
-      );
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        2,
-        parentId,
-        mintNestData,
-      );
+      await ownerChunky.connect(tokenOwner).approve(rejecter.address, parentId);
+      await checkRejectAllPendingChildrenFromAddress(rejecter, parentId);
+    });
 
-      let pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
-      expect(pendingChildren).to.eql([
-        [BigNumber.from(1), petMonkey.address],
-        [BigNumber.from(2), petMonkey.address],
-      ]);
-
-      await ownerChunky.connect(addrs[1]).rejectAllChildren(parentId);
-      pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
-      expect(pendingChildren).to.eql([]);
+    it('can reject all pending children if approved for all', async function () {
+      const tokenOwner = addrs[1];
+      const rejecter = addrs[2];
+      const parentId = 11;
+      await ownerChunky.connect(tokenOwner).setApprovalForAll(rejecter.address, true);
+      await checkRejectAllPendingChildrenFromAddress(rejecter, parentId);
     });
 
     it('cannot reject all pending children for not owned pending child', async function () {
@@ -561,18 +520,25 @@ async function shouldBehaveLikeNesting(
 
   describe('Remove child', async function () {
     it('can remove one child', async function () {
+      const remover = addrs[1]; // owner of parent token
       const parentId = 11;
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        1,
-        parentId,
-        mintNestData,
-      );
-      await ownerChunky.connect(addrs[1]).acceptChild(parentId, 0);
+      await checkRemoveChildFromAddress(remover, parentId);
+    });
 
-      await ownerChunky.connect(addrs[1]).removeChild(parentId, 0);
-      const children = await ownerChunky.childrenOf(parentId);
-      expect(children).to.eql([]);
+    it('can remove one child if approved', async function () {
+      const tokenOwner = addrs[1];
+      const remover = addrs[2];
+      const parentId = 11;
+      await ownerChunky.connect(tokenOwner).approve(remover.address, parentId);
+      await checkRemoveChildFromAddress(remover, parentId);
+    });
+
+    it('can remove one child if approved for all', async function () {
+      const tokenOwner = addrs[1];
+      const remover = addrs[2];
+      const parentId = 11;
+      await ownerChunky.connect(tokenOwner).setApprovalForAll(remover.address, true);
+      await checkRemoveChildFromAddress(remover, parentId);
     });
 
     it('cannot remove not owned child', async function () {
@@ -589,24 +555,6 @@ async function shouldBehaveLikeNesting(
       await expect(
         ownerChunky.connect(addrs[0]).removeChild(parentId, 0),
       ).to.be.revertedWithCustomError(ownerChunky, 'ERC721NotApprovedOrOwner');
-    });
-
-    it('can remove child from approved address (not owner)', async function () {
-      const parentId = 11;
-      const approvedAddress = addrs[2];
-
-      await ownerChunky.connect(addrs[1]).approve(approvedAddress.address, parentId);
-      await petMonkey['mint(address,uint256,uint256,bytes)'](
-        ownerChunky.address,
-        1,
-        parentId,
-        mintNestData,
-      );
-      await ownerChunky.connect(addrs[1]).acceptChild(parentId, 0);
-
-      await ownerChunky.connect(approvedAddress).removeChild(parentId, 0);
-      const children = await ownerChunky.childrenOf(parentId);
-      expect(children).to.eql([]);
     });
 
     it('cannot remove children for non existing index', async () => {
@@ -771,17 +719,23 @@ async function shouldBehaveLikeNesting(
   describe('Unnesting', async function () {
     it('can unnest child and new owner is root owner', async function () {
       const { childId, parentId, firstOwner } = await mintTofirstOwner(true);
-      await expect(petMonkey.connect(firstOwner).unnestSelf(childId, 0))
-        .to.emit(ownerChunky, 'ChildUnnested')
-        .withArgs(parentId, 0);
+      await checkUnnestFromAddress(childId, parentId, firstOwner, firstOwner);
+    });
 
-      // New owner of child
-      expect(await petMonkey.ownerOf(childId)).to.eql(firstOwner.address);
-      expect(await petMonkey.rmrkOwnerOf(childId)).to.eql([
-        firstOwner.address,
-        BigNumber.from(0),
-        false,
-      ]);
+    it('can unnest child if approved', async function () {
+      const { childId, parentId, firstOwner } = await mintTofirstOwner(true);
+      const unnester = addrs[2];
+      // Since unnest is child scoped, approval must be on the child contract to child id
+      await petMonkey.connect(firstOwner).approve(unnester.address, childId);
+      await checkUnnestFromAddress(childId, parentId, firstOwner, unnester);
+    });
+
+    it('can unnest child if approved for all', async function () {
+      const { childId, parentId, firstOwner } = await mintTofirstOwner(true);
+      const unnester = addrs[2];
+      // Since unnest is child scoped, approval must be on the child contract to child id
+      await petMonkey.connect(firstOwner).setApprovalForAll(unnester.address, true);
+      await checkUnnestFromAddress(childId, parentId, firstOwner, unnester);
     });
 
     it('cannot unnest from parent directly', async function () {
@@ -1051,6 +1005,113 @@ async function shouldBehaveLikeNesting(
 
     const pending = await contract.pendingChildrenOf(tokenId);
     expect(pending).to.eql(expectedPending);
+  }
+
+  async function checkAcceptChildFromAddress(
+    accepter: SignerWithAddress,
+    parentId: number,
+  ): Promise<void> {
+    const childId = 1;
+
+    await petMonkey['mint(address,uint256,uint256,bytes)'](
+      ownerChunky.address,
+      childId,
+      parentId,
+      mintNestData,
+    );
+
+    // owner accepts the child at index 0 into the child array
+    await ownerChunky.connect(accepter).acceptChild(parentId, 0);
+
+    const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
+    expect(pendingChildren).to.eql([]);
+
+    const children = await ownerChunky.childrenOf(parentId);
+    expect(children).to.eql([[BigNumber.from(childId), petMonkey.address]]);
+    expect(await ownerChunky.childOf(parentId, 0)).to.eql([
+      BigNumber.from(childId),
+      petMonkey.address,
+    ]);
+  }
+
+  async function checkRejectChildFromAddress(
+    rejecter: SignerWithAddress,
+    parentId: number,
+  ): Promise<void> {
+    await petMonkey['mint(address,uint256,uint256,bytes)'](
+      ownerChunky.address,
+      1,
+      parentId,
+      mintNestData,
+    );
+
+    await ownerChunky.connect(rejecter).rejectChild(parentId, 0);
+    const pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
+    expect(pendingChildren).to.eql([]);
+  }
+
+  async function checkRejectAllPendingChildrenFromAddress(
+    rejecter: SignerWithAddress,
+    parentId: number,
+  ): Promise<void> {
+    await petMonkey['mint(address,uint256,uint256,bytes)'](
+      ownerChunky.address,
+      1,
+      parentId,
+      mintNestData,
+    );
+    await petMonkey['mint(address,uint256,uint256,bytes)'](
+      ownerChunky.address,
+      2,
+      parentId,
+      mintNestData,
+    );
+
+    let pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
+    expect(pendingChildren).to.eql([
+      [BigNumber.from(1), petMonkey.address],
+      [BigNumber.from(2), petMonkey.address],
+    ]);
+
+    await ownerChunky.connect(rejecter).rejectAllChildren(parentId);
+    pendingChildren = await ownerChunky.pendingChildrenOf(parentId);
+    expect(pendingChildren).to.eql([]);
+  }
+
+  async function checkRemoveChildFromAddress(
+    remover: SignerWithAddress,
+    parentId: number,
+  ): Promise<void> {
+    await petMonkey['mint(address,uint256,uint256,bytes)'](
+      ownerChunky.address,
+      1,
+      parentId,
+      mintNestData,
+    );
+    await ownerChunky.connect(addrs[1]).acceptChild(parentId, 0);
+
+    await ownerChunky.connect(remover).removeChild(parentId, 0);
+    const children = await ownerChunky.childrenOf(parentId);
+    expect(children).to.eql([]);
+  }
+
+  async function checkUnnestFromAddress(
+    childId: number,
+    parentId: number,
+    firstOwner: SignerWithAddress,
+    unnester: SignerWithAddress,
+  ): Promise<void> {
+    await expect(petMonkey.connect(unnester).unnestSelf(childId, 0))
+      .to.emit(ownerChunky, 'ChildUnnested')
+      .withArgs(parentId, 0);
+
+    // New owner of child
+    expect(await petMonkey.ownerOf(childId)).to.eql(firstOwner.address);
+    expect(await petMonkey.rmrkOwnerOf(childId)).to.eql([
+      firstOwner.address,
+      BigNumber.from(0),
+      false,
+    ]);
   }
 }
 


### PR DESCRIPTION
Resources now have independent approvals which apply to accepting, rejecting and setting priorities on resources.
On Equippables: equip, unequip and replace equip use the nesting permissions. For this a new method was added to the `IRMRKNestingWithEquippable` interface: `isApprovedOrOwner` so permissions can be fully checked with a single external call.
Tests for added for nesting, resources and resources on equippable for both approvals and approvals for all.