### PR TITLE
Clean resource approvals on transfer and burn

### DIFF
--- a/contracts/RMRK/RMRKEquippable.sol
+++ b/contracts/RMRK/RMRKEquippable.sol
@@ -478,7 +478,10 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
         if(to == owner)
             revert RMRKApprovalForResourcesToCurrentOwner();
 
-        if(_msgSender() != owner && !isApprovedForAllForResources(owner, _msgSender()))
+        // We want to bypass the check if the caller is the linked nesting contract and it's simply removing approvals
+        bool isNestingCallToRemoveApprovals = (_msgSender() == _nestingAddress &&  to == address(0));
+
+        if(!isNestingCallToRemoveApprovals && _msgSender() != owner && !isApprovedForAllForResources(owner, _msgSender()))
             revert RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
         _approveForResources(owner, to, tokenId);
     }

--- a/contracts/RMRK/RMRKEquippable.sol
+++ b/contracts/RMRK/RMRKEquippable.sol
@@ -492,4 +492,8 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
             revert RMRKApproveForResourcesToCaller();
         _setApprovalForAllForResources(owner, operator, approved);
     }
+
+    function _exists(uint256 tokenId) internal override view virtual returns (bool) {
+        return _ownerOf(tokenId) != address(0);
+    }
 }

--- a/contracts/RMRK/RMRKMultiResource.sol
+++ b/contracts/RMRK/RMRKMultiResource.sol
@@ -105,4 +105,14 @@ contract RMRKMultiResource is ERC721, MultiResourceAbstract {
         _setApprovalForAllForResources(owner, operator, approved);
     }
 
+    // Other
+
+    function _requireMinted(uint256 tokenId) internal view virtual override(ERC721, MultiResourceAbstract) {
+        ERC721._requireMinted(tokenId);
+    }
+
+    function _exists(uint256 tokenId) internal view virtual override(ERC721, MultiResourceAbstract) returns (bool) {
+        return ERC721._exists(tokenId);
+    }
+
 }

--- a/contracts/RMRK/RMRKNesting.sol
+++ b/contracts/RMRK/RMRKNesting.sol
@@ -179,6 +179,7 @@ contract RMRKNesting is ERC721, IRMRKNesting {
     function _burnForOwner(uint256 tokenId, address rootOwner) private {
         _beforeTokenTransfer(rootOwner, address(0), tokenId);
         _approve(address(0), tokenId);
+        _cleanApprovals(address(0), tokenId);
         _balances[rootOwner] -= 1;
 
         Child[] memory children = childrenOf(tokenId);
@@ -309,6 +310,7 @@ contract RMRKNesting is ERC721, IRMRKNesting {
 
         // Clear approvals from the previous owner
         _approve(address(0), tokenId);
+        _cleanApprovals(to, tokenId);
 
         if(!destinationIsNft) {
             _balances[to] += 1;
@@ -323,6 +325,8 @@ contract RMRKNesting is ERC721, IRMRKNesting {
         emit Transfer(from, to, tokenId);
         _afterTokenTransfer(from, to, tokenId);
     }
+
+    function _cleanApprovals(address owner, uint256 tokenId) internal virtual {}
 
     ////////////////////////////////////////
     //      CHILD MANAGEMENT INTERNAL

--- a/contracts/RMRK/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/RMRKNestingMultiResource.sol
@@ -82,4 +82,8 @@ contract RMRKNestingMultiResource is MultiResourceAbstract, RMRKNesting {
             revert RMRKApproveForResourcesToCaller();
         _setApprovalForAllForResources(owner, operator, approved);
     }
+
+    function _cleanApprovals(address owner, uint256 tokenId) internal override virtual {
+        _approveForResources(owner, address(0), tokenId);
+    }
 }

--- a/contracts/RMRK/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/RMRKNestingMultiResource.sol
@@ -86,4 +86,14 @@ contract RMRKNestingMultiResource is MultiResourceAbstract, RMRKNesting {
     function _cleanApprovals(address owner, uint256 tokenId) internal override virtual {
         _approveForResources(owner, address(0), tokenId);
     }
+
+    // Other
+
+    function _requireMinted(uint256 tokenId) internal view virtual override(ERC721, MultiResourceAbstract) {
+        ERC721._requireMinted(tokenId);
+    }
+
+    function _exists(uint256 tokenId) internal view virtual override(RMRKNesting, MultiResourceAbstract) returns (bool) {
+        return RMRKNesting._exists(tokenId);
+    }
 }

--- a/contracts/RMRK/RMRKNestingWithEquippable.sol
+++ b/contracts/RMRK/RMRKNestingWithEquippable.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//Generally all interactions should propagate downstream
+
+pragma solidity ^0.8.15;
+
+import "../RMRK/interfaces/IRMRKNestingWithEquippable.sol";
+import "../RMRK/interfaces/IRMRKMultiResource.sol";
+import "../RMRK/RMRKNesting.sol";
+/* import "hardhat/console.sol"; */
+
+
+contract RMRKNestingWithEquippable is IRMRKNestingWithEquippable, RMRKNesting {
+
+    address private _equippableAddress;
+
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) RMRKNesting(name_, symbol_) {}
+
+    function _setEquippableAddress(address equippable) internal virtual {
+        _equippableAddress = equippable;
+    }
+
+    function getEquippablesAddress() external virtual view returns (address) {
+        return _equippableAddress;
+    }
+
+    function isApprovedOrOwner(address spender, uint256 tokenId) external virtual view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
+
+    function _cleanApprovals(address, uint256 tokenId) internal override virtual {
+        IRMRKMultiResource(_equippableAddress).approveForResources(address(0), tokenId);
+    }
+}

--- a/contracts/RMRK/abstracts/MultiResourceAbstract.sol
+++ b/contracts/RMRK/abstracts/MultiResourceAbstract.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 
 error RMRKBadPriorityListLength();
 error RMRKIndexOutOfRange();
+error RMRKInvalidTokenId();
 error RMRKMaxPendingResourcesReached();
 error RMRKNoResourceMatchingId();
 error RMRKResourceAlreadyExists();
@@ -301,7 +302,7 @@ abstract contract MultiResourceAbstract is Context, IRMRKMultiResource {
     // Approvals
 
     function getApprovedForResources(uint256 tokenId) public virtual view returns (address) {
-        // TODO: Do we want to add require minted here?
+        _requireMinted(tokenId);
         return _tokenApprovalsForResources[tokenId];
     }
 
@@ -385,5 +386,15 @@ abstract contract MultiResourceAbstract is Context, IRMRKMultiResource {
         }
         return resources;
     }
+
+        /**
+     * @dev Reverts if the `tokenId` has not been minted yet.
+     */
+    function _requireMinted(uint256 tokenId) internal view virtual {
+        if(!_exists(tokenId))
+            revert RMRKInvalidTokenId();
+    }
+
+    function _exists(uint256 tokenId) internal view virtual returns (bool);
 
 }

--- a/contracts/mocks/RMRKNestingWithEquippableMock.sol
+++ b/contracts/mocks/RMRKNestingWithEquippableMock.sol
@@ -4,16 +4,16 @@ pragma solidity ^0.8.15;
 
 import "../RMRK/access/RMRKIssuable.sol";
 import "../RMRK/interfaces/IRMRKNestingReceiver.sol";
-import "../RMRK/RMRKNesting.sol";
+import "../RMRK/RMRKNestingWithEquippable.sol";
 // import "hardhat/console.sol";
 
 //Minimal public implementation of IRMRKNesting for testing.
-contract RMRKNestingMock is  RMRKIssuable, IRMRKNestingReceiver, RMRKNesting {
+contract RMRKNestingWithEquippableMock is  RMRKIssuable, IRMRKNestingReceiver, RMRKNestingWithEquippable {
 
     constructor(
         string memory name_,
         string memory symbol_
-    ) RMRKNesting(name_, symbol_) {}
+    ) RMRKNestingWithEquippable(name_, symbol_) {}
 
     function safeMint(address to, uint256 tokenId) public {
         _safeMint(to, tokenId);
@@ -52,6 +52,10 @@ contract RMRKNestingMock is  RMRKIssuable, IRMRKNestingReceiver, RMRKNesting {
         bytes calldata
     ) external pure returns (bytes4) {
         return IRMRKNestingReceiver.onRMRKNestingReceived.selector;
+    }
+
+    function setEquippableAddress(address equippable) external onlyIssuer {
+        _setEquippableAddress(equippable);
     }
 
 }

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -970,9 +970,9 @@ async function shouldBehaveLikeEquippableResources(
         chunky,
         'ERC721InvalidTokenId',
       );
-      // FIXME: This should be consistent (i.e. revert)
-      expect(await chunkyEquip.getApprovedForResources(tokenId)).to.eql(
-        ethers.constants.AddressZero,
+      await expect(chunkyEquip.getApprovedForResources(tokenId)).to.be.revertedWithCustomError(
+        chunky,
+        'ERC721InvalidTokenId',
       );
     });
   });

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -32,8 +32,10 @@ async function shouldBehaveLikeEquippableResources(
 
     const ChnkEqup = await ethers.getContractFactory(equippableContractName);
     chunkyEquip = await ChnkEqup.deploy();
-    chunkyEquip.setNestingAddress(chunky.address);
     await chunkyEquip.deployed();
+
+    await chunky.setEquippableAddress(chunkyEquip.address);
+    await chunkyEquip.setNestingAddress(chunky.address);
   });
 
   describe('Init', async function () {
@@ -927,6 +929,28 @@ async function shouldBehaveLikeEquippableResources(
       expect(
         await chunkyEquip.tokenURIForCustomValue(tokenId, customDataOtherKey, customDataTypeValueA),
       ).to.eql('fallback404');
+    });
+  });
+
+  describe('Approval Cleaning', async function () {
+    it('cleans token and resources approvals on transfer', async function () {
+      const tokenId = 1;
+      const tokenOwner = addrs[1];
+      const newOwner = addrs[2];
+      const approved = addrs[3];
+      await chunky['mint(address,uint256)'](tokenOwner.address, tokenId);
+      await chunky.connect(tokenOwner).approve(approved.address, tokenId);
+      await chunkyEquip.connect(tokenOwner).approveForResources(approved.address, tokenId);
+
+      expect(await chunky.getApproved(tokenId)).to.eql(approved.address);
+      expect(await chunkyEquip.getApprovedForResources(tokenId)).to.eql(approved.address);
+
+      await chunky.connect(tokenOwner).transfer(newOwner.address, tokenId);
+
+      expect(await chunky.getApproved(tokenId)).to.eql(ethers.constants.AddressZero);
+      expect(await chunkyEquip.getApprovedForResources(tokenId)).to.eql(
+        ethers.constants.AddressZero,
+      );
     });
   });
 

--- a/test/equippable.ts
+++ b/test/equippable.ts
@@ -5,7 +5,7 @@ import shouldBehaveLikeEquippableWithSlots from './behavior/equippableSlots';
 describe('Equippable with Parts', async () => {
   shouldBehaveLikeEquippableWithParts(
     'RMRKEquippableMock',
-    'RMRKNestingMock',
+    'RMRKNestingWithEquippableMock',
     'RMRKBaseStorageMock',
   );
 });
@@ -13,11 +13,11 @@ describe('Equippable with Parts', async () => {
 describe('Equippable with Slots', async () => {
   shouldBehaveLikeEquippableWithSlots(
     'RMRKEquippableMock',
-    'RMRKNestingMock',
+    'RMRKNestingWithEquippableMock',
     'RMRKBaseStorageMock',
   );
 });
 
 describe('Equippable Resources', async () => {
-  shouldBehaveLikeEquippableResources('RMRKEquippableMock', 'RMRKNestingMock');
+  shouldBehaveLikeEquippableResources('RMRKEquippableMock', 'RMRKNestingWithEquippableMock');
 });

--- a/test/nestingMultiResource.ts
+++ b/test/nestingMultiResource.ts
@@ -101,8 +101,10 @@ describe('Nesting MR', function () {
         chunky,
         'ERC721InvalidTokenId',
       );
-      // FIXME: This should be consistent (i.e. revert)
-      expect(await chunky.getApprovedForResources(tokenId)).to.eql(ethers.constants.AddressZero);
+      await expect(chunky.getApprovedForResources(tokenId)).to.be.revertedWithCustomError(
+        chunky,
+        'ERC721InvalidTokenId',
+      );
     });
   });
 });

--- a/test/nestingMultiResource.ts
+++ b/test/nestingMultiResource.ts
@@ -48,6 +48,65 @@ describe('MultiResource', function () {
   shouldBehaveLikeMultiResource(name, symbol);
 });
 
+describe('Nesting MR', function () {
+  let addrs: SignerWithAddress[];
+  let chunky: Contract;
+
+  const name = 'ownerChunky';
+  const symbol = 'CHNKY';
+
+  beforeEach(async function () {
+    const [, ...signersAddr] = await ethers.getSigners();
+    addrs = signersAddr;
+
+    const CHNKY = await ethers.getContractFactory('RMRKNestingMultiResourceMock');
+    chunky = await CHNKY.deploy(name, symbol);
+    await chunky.deployed();
+    this.parentToken = chunky;
+  });
+
+  describe('Approval Cleaning', async function () {
+    it('cleans token and resources approvals on transfer', async function () {
+      const tokenId = 1;
+      const tokenOwner = addrs[1];
+      const newOwner = addrs[2];
+      const approved = addrs[3];
+      await chunky['mint(address,uint256)'](tokenOwner.address, tokenId);
+      await chunky.connect(tokenOwner).approve(approved.address, tokenId);
+      await chunky.connect(tokenOwner).approveForResources(approved.address, tokenId);
+
+      expect(await chunky.getApproved(tokenId)).to.eql(approved.address);
+      expect(await chunky.getApprovedForResources(tokenId)).to.eql(approved.address);
+
+      await chunky.connect(tokenOwner).transfer(newOwner.address, tokenId);
+
+      expect(await chunky.getApproved(tokenId)).to.eql(ethers.constants.AddressZero);
+      expect(await chunky.getApprovedForResources(tokenId)).to.eql(ethers.constants.AddressZero);
+    });
+
+    it('cleans token and resources approvals on burn', async function () {
+      const tokenId = 1;
+      const tokenOwner = addrs[1];
+      const approved = addrs[3];
+      await chunky['mint(address,uint256)'](tokenOwner.address, tokenId);
+      await chunky.connect(tokenOwner).approve(approved.address, tokenId);
+      await chunky.connect(tokenOwner).approveForResources(approved.address, tokenId);
+
+      expect(await chunky.getApproved(tokenId)).to.eql(approved.address);
+      expect(await chunky.getApprovedForResources(tokenId)).to.eql(approved.address);
+
+      await chunky.connect(tokenOwner).burn(tokenId);
+
+      await expect(chunky.getApproved(tokenId)).to.be.revertedWithCustomError(
+        chunky,
+        'ERC721InvalidTokenId',
+      );
+      // FIXME: This should be consistent (i.e. revert)
+      expect(await chunky.getApprovedForResources(tokenId)).to.eql(ethers.constants.AddressZero);
+    });
+  });
+});
+
 describe('Issuer', function () {
   let owner: SignerWithAddress;
   let addrs: SignerWithAddress[];


### PR DESCRIPTION
Resource approvals are cleaned after transfer or burn using a hook
   
The hook is implemented on RMRKNestingWithEquippable (new) and RMRKNestingMultiResource
Splits RMRKNestingMock into a simple one with INestingReceiver and RMRKNestingWithEquippableMock.