### PR TITLE
ChildEquippable.markEquipped now also checks if equip is valid

### DIFF
--- a/contracts/RMRK/RMRKNesting.sol
+++ b/contracts/RMRK/RMRKNesting.sol
@@ -106,8 +106,8 @@ contract RMRKNesting is ERC721, IRMRKNesting {
     function _mint(address to, uint256 tokenId, uint256 destinationId) internal virtual {
         if(to == address(0)) revert ERC721MintToTheZeroAddress();
         if(_exists(tokenId)) revert ERC721TokenAlreadyMinted();
-        // This is redundant with following line:
-        // if(!to.isContract()) revert RMRKIsNotContract();
+        // It seems redundant, but otherwise it would revert with no error
+        if(!to.isContract()) revert RMRKIsNotContract();
         if(!IERC165(to).supportsInterface(type(IRMRKNesting).interfaceId))
             revert RMRKMintToNonRMRKImplementer();
 
@@ -288,10 +288,10 @@ contract RMRKNesting is ERC721, IRMRKNesting {
         if(ownerOf(tokenId) != from)
             revert ERC721TransferFromIncorrectOwner();
         if(_RMRKOwners[tokenId].isNft) revert RMRKMustUnnestFirst();
+        if(to == address(0)) revert ERC721TransferToTheZeroAddress();
         // Destination contract checks:
-        // First 2 are redundant with following line:
-        // if(to == address(0)) revert ERC721TransferToTheZeroAddress();
-        // if(!to.isContract()) revert RMRKIsNotContract();
+        // It seems redundant, but otherwise it would revert with no error
+        if(!to.isContract()) revert RMRKIsNotContract();
         if(!IERC165(to).supportsInterface(type(IRMRKNesting).interfaceId))
             revert RMRKNestingTransferToNonRMRKNestingImplementer();
 

--- a/contracts/RMRK/RMRKNestingWithEquippable.sol
+++ b/contracts/RMRK/RMRKNestingWithEquippable.sol
@@ -44,17 +44,26 @@ contract RMRKNestingWithEquippable is IRMRKNestingWithEquippable, RMRKNesting {
         _;
     }
 
-    function markSelfEquipped(uint tokenId, uint64 resourceId, bool equipped) external onlyParent(tokenId) {
-        IRMRKEquippable(_equippableAddress).markEquipped(tokenId, resourceId, equipped);
+    function markSelfEquipped(
+        uint tokenId,
+        address equippingParent,
+        uint64 resourceId,
+        uint64 slotId,
+        bool equipped
+    ) external onlyParent(tokenId) {
+        IRMRKEquippable(_equippableAddress).markEquipped(
+            tokenId, equippingParent, resourceId, slotId, equipped);
     }
 
     function markChildEquipped(
         address childAddress, 
         uint tokenId, 
         uint64 resourceId, 
+        uint64 slotId,
         bool equipped
     ) external onlyEquippable {
-        IRMRKNestingWithEquippable(childAddress).markSelfEquipped(tokenId, resourceId, equipped);
+        IRMRKNestingWithEquippable(childAddress).markSelfEquipped(
+            tokenId, _equippableAddress, resourceId, slotId, equipped);
     }
 
     function _unnestSelf(uint256 tokenId, uint256 index) internal override {

--- a/contracts/RMRK/interfaces/IRMRKEquippable.sol
+++ b/contracts/RMRK/interfaces/IRMRKEquippable.sol
@@ -8,7 +8,13 @@ interface IRMRKEquippable is IRMRKMultiResource {
 
     function getNestingAddress() external view returns(address);
 
-    function markEquipped(uint tokenId, uint64 resourceId, bool equipped) external;
+    function markEquipped(
+        uint tokenId,
+        address equippingParent,
+        uint64 resourceId,
+        uint64 slotId,
+        bool equipped
+    ) external;
 
     function isEquipped(uint tokenId) external view returns(bool);
 
@@ -19,5 +25,10 @@ interface IRMRKEquippable is IRMRKMultiResource {
         uint64 slotId
     ) external view returns (bool);
 
-    function canTokenBeEquippedWithResourceIntoSlot(uint tokenId, uint64 resourceId, uint64 slotId) external view returns (bool);
+    function canTokenBeEquippedWithResourceIntoSlot(
+        address parent,
+        uint tokenId,
+        uint64 resourceId,
+        uint64 slotId
+    ) external view returns (bool);
 }

--- a/contracts/RMRK/interfaces/IRMRKNestingWithEquippable.sol
+++ b/contracts/RMRK/interfaces/IRMRKNestingWithEquippable.sol
@@ -13,7 +13,19 @@ interface IRMRKNestingWithEquippable {
 
     function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool);
 
-    function markSelfEquipped(uint tokenId, uint64 resourceId, bool equipped) external;
+    function markSelfEquipped(
+        uint tokenId,
+        address equippingParent,
+        uint64 resourceId,
+        uint64 slotId,
+        bool equipped
+    ) external;
 
-    function markChildEquipped(address childAddress, uint tokenId, uint64 resourceId, bool equipped) external;
+    function markChildEquipped(
+        address childAddress,
+        uint tokenId,
+        uint64 resourceId,
+        uint64 slotId,
+        bool equipped
+    ) external;
 }

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -59,7 +59,7 @@ async function shouldBehaveLikeEquippableResources(
       expect(await chunky.supportsInterface('0x01ffc9a7')).to.equal(true);
     });
     it('can support IEquippable', async function () {
-      expect(await chunkyEquip.supportsInterface('0x9939b4d4')).to.equal(true);
+      expect(await chunkyEquip.supportsInterface('0xc3730101')).to.equal(true);
     });
     it('cannot support other interfaceId', async function () {
       expect(await chunkyEquip.supportsInterface('0xffffffff')).to.equal(false);


### PR DESCRIPTION
To  do so, the slot id must be sent from the equippable parent through all the calls
Also, the Nesting Parent must send it's equippable address to the Nesting child, (this could lie), which is then passed to the Equippable child for validation.

Even though the nesting parent can lie to the child, this could help prevent UI errors. Also, there's a known vulnerability in which a malicious nesting parent could force marking children as equipped or not even if the caller does not own the token.