### PR TITLE
Fixes inconsistency on parent nft when burning a nested child,

### DIFF
--- a/contracts/RMRK/RMRKEquippable.sol
+++ b/contracts/RMRK/RMRKEquippable.sol
@@ -278,6 +278,16 @@ contract RMRKEquippable is IRMRKEquippable, MultiResourceAbstract {
         }
     }
 
+    function forgetEquipment(
+        uint256 tokenId,
+        uint64 resourceId,
+        uint64 slotId
+    ) external onlyOwnerOrApproved(tokenId) {
+        address targetBaseAddress = _baseAddresses[resourceId];
+        delete _equipments[tokenId][targetBaseAddress][slotId];
+        // FIXME: Shall it emit an event?
+    }
+
     //Gate for equippable array in here by check of slotPartDefinition to slotPartId
     function composeEquippables(
         uint tokenId,

--- a/contracts/RMRK/RMRKNestingWithEquippable.sol
+++ b/contracts/RMRK/RMRKNestingWithEquippable.sol
@@ -44,6 +44,16 @@ contract RMRKNestingWithEquippable is IRMRKNestingWithEquippable, RMRKNesting {
         _;
     }
 
+    function _onlyUnequipped(uint256 tokenId) private view {
+        if (IRMRKEquippable(_equippableAddress).isEquipped(tokenId))
+            revert RMRKMustUnequipFirst();
+    }
+
+    modifier onlyUnequipped(uint256 tokenId) {
+        _onlyUnequipped(tokenId);
+        _;
+    }
+
     function markSelfEquipped(
         uint tokenId,
         address equippingParent,
@@ -66,10 +76,14 @@ contract RMRKNestingWithEquippable is IRMRKNestingWithEquippable, RMRKNesting {
             tokenId, _equippableAddress, resourceId, slotId, equipped);
     }
 
-    function _unnestSelf(uint256 tokenId, uint256 index) internal override {
-        if (IRMRKEquippable(_equippableAddress).isEquipped(tokenId))
-            revert RMRKMustUnequipFirst();
+    // This is done on the internal level so we don't relly on every implementer rememebering this check
+    function _unnestSelf(uint256 tokenId, uint256 index) internal override onlyUnequipped(tokenId) {
         super._unnestSelf(tokenId, index);
+    }
+
+    // This is done on the internal level so we don't relly on every implementer rememebering this check
+    function _burn(uint256 tokenId) internal override onlyUnequipped(tokenId) {
+        super._burn(tokenId);
     }
 
     function _setEquippableAddress(address equippable) internal virtual {

--- a/contracts/RMRK/interfaces/IRMRKEquippable.sol
+++ b/contracts/RMRK/interfaces/IRMRKEquippable.sol
@@ -31,4 +31,10 @@ interface IRMRKEquippable is IRMRKMultiResource {
         uint64 resourceId,
         uint64 slotId
     ) external view returns (bool);
+
+    function forgetEquipment(
+        uint256 tokenId,
+        uint64 resourceId,
+        uint64 slotId
+    ) external;
 }

--- a/contracts/RMRK/interfaces/IRMRKNesting.sol
+++ b/contracts/RMRK/interfaces/IRMRKNesting.sol
@@ -60,6 +60,12 @@ interface IRMRKNesting {
         uint256 childId
     ) external;
 
+    function hasChild(
+        uint256 tokenId,
+        address childAddress,
+        uint256 childId
+    ) external view returns(bool found, bool accepted, uint index);
+
     function unnestChild(
         uint256 tokenId,
         uint256 childId,
@@ -69,6 +75,10 @@ interface IRMRKNesting {
     function unnestSelf(
         uint256 tokenId,
         uint256 indexOnParent
+    ) external;
+
+    function unnestOrphanSelf(
+        uint256 tokenId
     ) external;
 
     function childrenOf(

--- a/contracts/RMRK/interfaces/IRMRKNesting.sol
+++ b/contracts/RMRK/interfaces/IRMRKNesting.sol
@@ -54,6 +54,12 @@ interface IRMRKNesting {
         uint256 index
     ) external;
 
+    function forgetChild(
+        uint256 tokenId,
+        address childAddress,
+        uint256 childId
+    ) external;
+
     function unnestChild(
         uint256 tokenId,
         uint256 childId,

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -29,7 +29,7 @@ async function shouldBehaveLikeEquippableResources(
       expect(await chunky.supportsInterface('0x01ffc9a7')).to.equal(true);
     });
     it('can support IEquippable', async function () {
-      expect(await chunkyEquip.supportsInterface('0xc3730101')).to.equal(true);
+      expect(await chunkyEquip.supportsInterface('0x3b8a7cb9')).to.equal(true);
     });
     it('cannot support other interfaceId', async function () {
       expect(await chunkyEquip.supportsInterface('0xffffffff')).to.equal(false);

--- a/test/behavior/equippableSlots.ts
+++ b/test/behavior/equippableSlots.ts
@@ -391,14 +391,11 @@ async function shouldBehaveLikeEquippableWithSlots(
 
     it('cannot unequip if not owner', async function () {
       // Weapon is child on index 0, background on index 1
-      const childIndex = 0;
-      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
-      await soldierEquip
-        .connect(addrs[0])
-        .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
+      const soldierOwner = addrs[0];
+      const notOwner = addrs[1];
 
       await expect(
-        soldierEquip.connect(addrs[1]).unequip(soldiersIds[0], soldierResId, partIdForWeapon),
+        unequipWeaponAndCheckFromAddress(soldierOwner, notOwner),
       ).to.be.revertedWithCustomError(soldierEquip, 'ERC721NotApprovedOrOwner');
     });
   });

--- a/test/behavior/equippableSlots.ts
+++ b/test/behavior/equippableSlots.ts
@@ -362,44 +362,25 @@ async function shouldBehaveLikeEquippableWithSlots(
     it('can unequip', async function () {
       // Weapon is child on index 0, background on index 1
       const soldierOwner = addrs[0];
-      const childIndex = 0;
-      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
-
-      await soldierEquip
-        .connect(soldierOwner)
-        .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
-
-      await unequipWeaponAndCheckFromAddress(soldierOwner);
+      await unequipWeaponAndCheckFromAddress(soldierOwner, soldierOwner);
     });
 
     it('can unequip if approved', async function () {
       // Weapon is child on index 0, background on index 1
       const soldierOwner = addrs[0];
-      const childIndex = 0;
-      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
       const approved = addrs[1];
 
-      await soldierEquip
-        .connect(soldierOwner)
-        .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
-
       await soldier.connect(soldierOwner).approve(approved.address, soldiersIds[0]);
-      await unequipWeaponAndCheckFromAddress(approved);
+      await unequipWeaponAndCheckFromAddress(soldierOwner, approved);
     });
 
     it('can unequip if approved for all', async function () {
       // Weapon is child on index 0, background on index 1
       const soldierOwner = addrs[0];
-      const childIndex = 0;
-      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
       const approved = addrs[1];
 
-      await soldierEquip
-        .connect(soldierOwner)
-        .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
-
       await soldier.connect(soldierOwner).setApprovalForAll(approved.address, true);
-      await unequipWeaponAndCheckFromAddress(approved);
+      await unequipWeaponAndCheckFromAddress(soldierOwner, approved);
     });
 
     it('cannot unequip if not equipped', async function () {
@@ -503,14 +484,8 @@ async function shouldBehaveLikeEquippableWithSlots(
     it('Can unequip and unnest', async function () {
       // Weapon is child on index 0, background on index 1
       const soldierOwner = addrs[0];
-      const childIndex = 0;
-      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
 
-      await soldierEquip
-        .connect(soldierOwner)
-        .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
-
-      await unequipWeaponAndCheckFromAddress(soldierOwner);
+      await unequipWeaponAndCheckFromAddress(soldierOwner, soldierOwner);
       await weapon.connect(soldierOwner).unnestSelf(weaponsIds[0], 0);
     });
 
@@ -657,7 +632,16 @@ async function shouldBehaveLikeEquippableWithSlots(
     expect(await weaponEquip.isEquipped(weaponsIds[0])).to.eql(true);
   }
 
-  async function unequipWeaponAndCheckFromAddress(from: SignerWithAddress): Promise<void> {
+  async function unequipWeaponAndCheckFromAddress(
+    soldierOwner: SignerWithAddress,
+    from: SignerWithAddress,
+  ): Promise<void> {
+    const childIndex = 0;
+    const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
+    await soldierEquip
+      .connect(soldierOwner)
+      .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
+
     await soldierEquip.connect(from).unequip(soldiersIds[0], soldierResId, partIdForWeapon);
 
     const expectedSlots = [bn(partIdForWeapon), bn(partIdForBackground)];

--- a/test/behavior/equippableSlots.ts
+++ b/test/behavior/equippableSlots.ts
@@ -499,7 +499,7 @@ async function shouldBehaveLikeEquippableWithSlots(
     });
   });
 
-  describe('Transfer equipped', async function () {
+  describe('Forbidden operations for equipped NFTs', async function () {
     it('Can unequip and unnest', async function () {
       // Weapon is child on index 0, background on index 1
       const soldierOwner = addrs[0];
@@ -514,7 +514,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       await weapon.connect(soldierOwner).unnestSelf(weaponsIds[0], 0);
     });
 
-    it('Unnest fails if self is equipped', async function () {
+    it('cannot unnest self if equipped', async function () {
       // Weapon is child on index 0
       const childIndex = 0;
       const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
@@ -525,6 +525,33 @@ async function shouldBehaveLikeEquippableWithSlots(
       await expect(
         weapon.connect(addrs[0]).unnestSelf(weaponsIds[0], 0),
       ).to.be.revertedWithCustomError(weapon, 'RMRKMustUnequipFirst');
+    });
+
+    it('cannot transfer self if equipped', async function () {
+      // Weapon is child on index 0
+      const childIndex = 0;
+      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
+      await soldierEquip
+        .connect(addrs[0])
+        .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
+
+      await expect(
+        weapon.connect(addrs[0]).transfer(addrs[1].address, weaponsIds[0]),
+      ).to.be.revertedWithCustomError(weapon, 'RMRKMustUnnestFirst');
+    });
+
+    it('cannot burn if equipped', async function () {
+      // Weapon is child on index 0
+      const childIndex = 0;
+      const weaponResId = weaponResourcesEquip[0]; // This resource is assigned to weapon first weapon
+      await soldierEquip
+        .connect(addrs[0])
+        .equip(soldiersIds[0], soldierResId, partIdForWeapon, childIndex, weaponResId);
+
+      await expect(weapon.connect(addrs[0]).burn(weaponsIds[0])).to.be.revertedWithCustomError(
+        weapon,
+        'RMRKMustUnequipFirst',
+      );
     });
   });
 

--- a/test/behavior/nesting.ts
+++ b/test/behavior/nesting.ts
@@ -576,6 +576,9 @@ async function shouldBehaveLikeNesting(
         parent,
         'ERC721InvalidTokenId',
       );
+
+      // Grand parent forgot the burnt child:
+      expect(await parent.childrenOf(parentId)).to.eql([]);
     });
 
     async function checkBurntParent() {

--- a/test/behavior/nesting.ts
+++ b/test/behavior/nesting.ts
@@ -719,6 +719,14 @@ async function shouldBehaveLikeNesting(
       await checkForgetPendingChildFromCaller(operator, pendingChildId);
     });
 
+    it('cannot forget pending child if not approved or owner', async function () {
+      const notOwner = addrs[3];
+      const pendingChildId = await nestMint(child, parent.address, parentId);
+      await expect(
+        checkForgetPendingChildFromCaller(notOwner, pendingChildId),
+      ).to.be.revertedWithCustomError(parent, 'RMRKNotApprovedOrOwnerOrChild');
+    });
+
     async function checkChildMovedToRootOwner() {
       expect(await child.ownerOf(childId)).to.eql(tokenOwner.address);
       expect(await child.rmrkOwnerOf(childId)).to.eql([


### PR DESCRIPTION
also adds options for owners to remove references to children regardless of the state of the child.