### PR TITLE
Merges burn and burnFromParent on Nesting, solves TODO.

### DIFF
--- a/contracts/RMRK/nesting/IRMRKNesting.sol
+++ b/contracts/RMRK/nesting/IRMRKNesting.sol
@@ -88,7 +88,7 @@ interface IRMRKNesting is IERC165 {
     function burnChild(uint256 tokenId, uint256 childIndex) external;
 
     //TODO: Docs
-    function burnFromParent(uint256 tokenId) external;
+    function burn(uint256 tokenId) external;
 
     /**
      * @dev Function to be called into by other instances of RMRK nesting contracts to update the `child` struct

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -27,7 +27,6 @@ error ERC721TokenAlreadyMinted();
 error ERC721TransferFromIncorrectOwner();
 error ERC721TransferToNonReceiverImplementer();
 error ERC721TransferToTheZeroAddress();
-error RMRKCallerIsNotOwnerContract();
 error RMRKChildIndexOutOfRange();
 error RMRKIsNotContract();
 error RMRKMaxPendingChildrenReached();
@@ -477,26 +476,19 @@ contract RMRKNesting is
     //              BURNING
     ////////////////////////////////////////
 
-    //update for reentrancy
-    //Suggest delegate to _burn method, as both run same code
-    function burnFromParent(uint256 tokenId) external {
-        (address _RMRKOwner, , ) = rmrkOwnerOf(tokenId);
-        if (_RMRKOwner != _msgSender()) revert RMRKCallerIsNotOwnerContract();
-        address owner = ownerOf(tokenId);
-        _burnForOwner(tokenId, owner);
-        _balances[_RMRKOwner] -= 1;
-    }
-
     function burnChild(uint256 tokenId, uint256 index)
         public
         onlyApprovedOrDirectOwner(tokenId)
     {
         if (_children[tokenId].length <= index)
             revert RMRKChildIndexOutOfRange();
-
-        Child memory child = _children[tokenId][index];
-        IRMRKNesting(child.contractAddress).burnFromParent(child.tokenId);
+        _burnChild(tokenId, index);
         _removeChildByIndex(_children[tokenId], index);
+    }
+
+    function _burnChild(uint256 tokenId, uint256 index) private {
+        Child memory child = _children[tokenId][index];
+        IRMRKNesting(child.contractAddress).burn(child.tokenId);
     }
 
     /**
@@ -511,15 +503,12 @@ contract RMRKNesting is
      */
 
     //update for reentrancy
-    function _burn(uint256 tokenId) internal virtual {
+    function burn(uint256 tokenId) public virtual {
+        (address _RMRKOwner, , ) = rmrkOwnerOf(tokenId);
         address owner = ownerOf(tokenId);
-        (address rmrkOwner, , ) = rmrkOwnerOf(tokenId);
-        _balances[rmrkOwner] -= 1;
-        _burnForOwner(tokenId, owner);
-    }
+        _balances[_RMRKOwner] -= 1;
 
-    function _burnForOwner(uint256 tokenId, address rootOwner) private {
-        _beforeTokenTransfer(rootOwner, address(0), tokenId);
+        _beforeTokenTransfer(owner, address(0), tokenId);
         _approve(address(0), tokenId);
         _cleanApprovals(address(0), tokenId);
 
@@ -527,9 +516,7 @@ contract RMRKNesting is
 
         uint256 length = children.length; //gas savings
         for (uint256 i; i < length; ) {
-            address childContractAddress = children[i].contractAddress;
-            uint256 childTokenId = children[i].tokenId;
-            IRMRKNesting(childContractAddress).burnFromParent(childTokenId);
+            _burnChild(tokenId, i);
             unchecked {
                 ++i;
             }
@@ -537,10 +524,11 @@ contract RMRKNesting is
         delete _RMRKOwners[tokenId];
         delete _pendingChildren[tokenId];
         delete _children[tokenId];
+        // Review: is this redundant with _approve(0)
         delete _tokenApprovals[tokenId];
 
-        _afterTokenTransfer(rootOwner, address(0), tokenId);
-        emit Transfer(rootOwner, address(0), tokenId);
+        _afterTokenTransfer(owner, address(0), tokenId);
+        emit Transfer(owner, address(0), tokenId);
     }
 
     ////////////////////////////////////////
@@ -647,7 +635,6 @@ contract RMRKNesting is
             getApproved(tokenId) == spender);
     }
 
-    //TODO: Code review here -- Accepting perms that aren't always used
     function _isApprovedOrDirectOwner(address spender, uint256 tokenId)
         internal
         view
@@ -655,9 +642,11 @@ contract RMRKNesting is
         returns (bool)
     {
         (address owner, uint256 parentTokenId, ) = rmrkOwnerOf(tokenId);
+        // When the parent is an NFT, only it can do operations
         if (parentTokenId != 0) {
             return (spender == owner);
         }
+        // Otherwise, the owner or approved address can
         return (spender == owner ||
             isApprovedForAll(owner, spender) ||
             getApproved(tokenId) == spender);
@@ -677,7 +666,7 @@ contract RMRKNesting is
      * Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
      *
      * Tokens start existing when they are minted (`_mint`),
-     * and stop existing when they are burned (`_burn`).
+     * and stop existing when they are burned (`burn`).
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return _RMRKOwners[tokenId].ownerAddress != address(0);

--- a/contracts/implementations/RMRKEquippableImpl.sol
+++ b/contracts/implementations/RMRKEquippableImpl.sol
@@ -66,11 +66,6 @@ contract RMRKEquippableImpl is OwnableLock, RMRKMintingUtils, RMRKEquippable {
         return (nextToken, totalSupplyOffset);
     }
 
-    //update for reentrancy
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     function addResourceToToken(
         uint256 tokenId,
         uint64 resourceId,

--- a/contracts/implementations/RMRKNestingExternalEquipImpl.sol
+++ b/contracts/implementations/RMRKNestingExternalEquipImpl.sol
@@ -78,11 +78,6 @@ contract RMRKNestingExternalEquipImpl is
         return (nextToken, totalSupplyOffset);
     }
 
-    //update for reentrancy
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     function setEquippableAddress(address equippable) external {
         _setEquippableAddress(equippable);
     }

--- a/contracts/implementations/RMRKNestingImpl.sol
+++ b/contracts/implementations/RMRKNestingImpl.sol
@@ -78,16 +78,6 @@ contract RMRKNestingImpl is OwnableLock, RMRKMintingUtils, RMRKNesting {
         return (nextToken, totalSupplyOffset);
     }
 
-    //update for reentrancy
-    // TODO: Is this the right modifier? Parent should call burnFromParent, not this
-    // REVIEW: Fixed changed modifier from onlyApprovedOrDirectOwner to onlyApprovedOrOwner.
-    // TODO: revert if owner is not an NFT
-    // TODO: test revert if owner is not an NFT
-    // TODO: Ensure this happens in all burns
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     function transfer(address to, uint256 tokenId) public virtual {
         transferFrom(_msgSender(), to, tokenId);
     }

--- a/contracts/implementations/RMRKNestingMultiResourceImpl.sol
+++ b/contracts/implementations/RMRKNestingMultiResourceImpl.sol
@@ -87,11 +87,6 @@ contract RMRKNestingMultiResourceImpl is
         return (nextToken, totalSupplyOffset);
     }
 
-    //update for reentrancy
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     function getFallbackURI() external view virtual returns (string memory) {
         return _fallbackURI;
     }

--- a/contracts/mocks/RMRKEquippableMock.sol
+++ b/contracts/mocks/RMRKEquippableMock.sol
@@ -36,11 +36,6 @@ contract RMRKEquippableMock is RMRKEquippable {
         _nestMint(to, tokenId, destinationId);
     }
 
-    //update for reentrancy
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     // Utility transfers:
 
     function transfer(address to, uint256 tokenId) public virtual {

--- a/contracts/mocks/RMRKNestingExternalEquipMock.sol
+++ b/contracts/mocks/RMRKNestingExternalEquipMock.sol
@@ -36,11 +36,6 @@ contract RMRKNestingExternalEquipMock is RMRKNestingExternalEquip {
         _nestMint(to, tokenId, destId);
     }
 
-    //update for reentrancy
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     function setEquippableAddress(address equippable) external {
         _setEquippableAddress(equippable);
     }

--- a/contracts/mocks/RMRKNestingMock.sol
+++ b/contracts/mocks/RMRKNestingMock.sol
@@ -36,11 +36,6 @@ contract RMRKNestingMock is RMRKNesting {
         _nestMint(to, tokenId, destinationId);
     }
 
-    //update for reentrancy
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     // Utility transfers:
 
     function transfer(address to, uint256 tokenId) public virtual {

--- a/contracts/mocks/RMRKNestingMultiResourceMock.sol
+++ b/contracts/mocks/RMRKNestingMultiResourceMock.sol
@@ -24,11 +24,6 @@ contract RMRKNestingMultiResourceMock is RMRKNestingMultiResource {
         _nestMint(to, tokenId, destId);
     }
 
-    //update for reentrancy
-    function burn(uint256 tokenId) public onlyApprovedOrDirectOwner(tokenId) {
-        _burn(tokenId);
-    }
-
     function addResourceToToken(
         uint256 tokenId,
         uint64 resourceId,

--- a/test/behavior/nesting.ts
+++ b/test/behavior/nesting.ts
@@ -215,7 +215,7 @@ async function shouldBehaveLikeNesting(
     });
 
     it('can support INesting', async function () {
-      expect(await parent.supportsInterface('0x91c0ad5d')).to.equal(true);
+      expect(await parent.supportsInterface('0xf790390a')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -419,16 +419,6 @@ async function shouldBehaveLikeNesting(
       await expect(
         parent.connect(tokenOwner).burnChild(parentId, badIndex),
       ).to.be.revertedWithCustomError(parent, 'RMRKChildIndexOutOfRange');
-    });
-
-    it('cannot burn from parent directly', async function () {
-      const childId = nestMint(child, parent.address, parentId);
-      await parent.connect(tokenOwner).acceptChild(parentId, 0);
-
-      await expect(child.connect(tokenOwner).burnFromParent(childId)).to.be.revertedWithCustomError(
-        child,
-        'RMRKCallerIsNotOwnerContract',
-      );
     });
 
     it('can burn token if approved', async function () {


### PR DESCRIPTION
Internal _burn and external burnFromParent where doing exactly the same, with only slightly different rules on who could call them.
They are now one with the rule being:
1. If parent it's an NFT, only it can burn
2. Other wise, owner (user address) or approved can burn.