### PR TITLE
Adds additional level on approvals

### DIFF
--- a/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
@@ -73,7 +73,7 @@ contract RMRKNestingExternalEquip is IRMRKNestingExternalEquip, RMRKNesting {
         return _isApprovedOrOwner(spender, tokenId);
     }
 
-    function _cleanApprovals(address, uint256 tokenId)
+    function _cleanApprovals(uint256 tokenId)
         internal
         virtual
         override


### PR DESCRIPTION
The problem:
When transfering a token with nested children, the children approvals are not updated, it would be very expensive to do so and malicious children may prevent it. This affects the regular approval and the approval for resources with the following vulnerability:
1. I approve a child token to a secondary address of mine
2. Sell the parent
3. I could do changes on resources for child (approved for resources)
4. If the child is later unnested, I could transfer it using the approved address.

Solution:
Instead of keeping track of approvals per token (token->approved), we add an extra level which is the approver. New mapping is token->approver->approved.
When checking if an address is approved, we check against the token Id and current owner, so if the root owner changes, permissions are invalidated.
WARNING: If the root owner eventually goes back to the original approver, these permissions would be valid again.