### PR TITLE
Recreates AbstractMultiResource extracting duplicated code from 4 contracts

### DIFF
--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -378,14 +378,14 @@ contract RMRKEquippable is RMRKNesting, AbstractMultiResource, IRMRKEquippable {
         virtual
         returns (ExtendedResource memory)
     {
-        Resource memory resource = getResource(resourceId);
+        string memory meta = getResourceMeta(resourceId);
 
         return
             ExtendedResource({
-                id: resource.id,
-                equippableRefId: _equippableRefIds[resource.id],
-                baseAddress: _baseAddresses[resource.id],
-                metadataURI: resource.metadataURI
+                id: resourceId,
+                equippableRefId: _equippableRefIds[resourceId],
+                baseAddress: _baseAddresses[resourceId],
+                metadataURI: meta
             });
     }
 

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -33,8 +33,8 @@ contract RMRKEquippable is RMRKNesting, AbstractMultiResource, IRMRKEquippable {
     // Mapping from token ID to approver address to approved address for resources
     // The approver is necessary so approvals are invalidated for nested children on transfer
     // WARNING: If a child NFT returns the original root owner, old permissions would be active again
-    mapping(uint256 => mapping(address => address)) private _tokenApprovalsForResources;
-
+    mapping(uint256 => mapping(address => address))
+        private _tokenApprovalsForResources;
 
     // ------------------- EQUIPPABLE --------------
     //Mapping of uint64 resource ID to corresponding base address
@@ -203,11 +203,7 @@ contract RMRKEquippable is RMRKNesting, AbstractMultiResource, IRMRKEquippable {
         emit ApprovalForResources(owner, to, tokenId);
     }
 
-    function _cleanApprovals(uint256 tokenId)
-        internal
-        virtual
-        override
-    {
+    function _cleanApprovals(uint256 tokenId) internal virtual override {
         _approveForResources(address(0), tokenId);
     }
 

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -393,14 +393,14 @@ contract RMRKExternalEquip is AbstractMultiResource, IRMRKExternalEquip {
         virtual
         returns (ExtendedResource memory)
     {
-        Resource memory resource = getResource(resourceId);
+        string memory meta = getResourceMeta(resourceId);
 
         return
             ExtendedResource({
-                id: resource.id,
-                equippableRefId: _equippableRefIds[resource.id],
-                baseAddress: _baseAddresses[resource.id],
-                metadataURI: resource.metadataURI
+                id: resourceId,
+                equippableRefId: _equippableRefIds[resourceId],
+                baseAddress: _baseAddresses[resourceId],
+                metadataURI: meta
             });
     }
 

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -42,7 +42,8 @@ contract RMRKExternalEquip is AbstractMultiResource, IRMRKExternalEquip {
     // Mapping from token ID to approver address to approved address for resources
     // The approver is necessary so approvals are invalidated for nested children on transfer
     // WARNING: If a child NFT returns the original root owner, old permissions would be active again
-    mapping(uint256 => mapping(address => address)) private _tokenApprovalsForResources;
+    mapping(uint256 => mapping(address => address))
+        private _tokenApprovalsForResources;
 
     // ------------------- Equippable --------------
 
@@ -167,7 +168,6 @@ contract RMRKExternalEquip is AbstractMultiResource, IRMRKExternalEquip {
     {
         _setPriority(tokenId, priorities);
     }
-
 
     // ----------------------- APPROVALS FOR RESOURCES ------------------------
 

--- a/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
@@ -73,11 +73,7 @@ contract RMRKNestingExternalEquip is IRMRKNestingExternalEquip, RMRKNesting {
         return _isApprovedOrOwner(spender, tokenId);
     }
 
-    function _cleanApprovals(uint256 tokenId)
-        internal
-        virtual
-        override
-    {
+    function _cleanApprovals(uint256 tokenId) internal virtual override {
         IRMRKMultiResource(_equippableAddress).approveForResources(
             address(0),
             tokenId

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "./IRMRKMultiResource.sol";
+import "../library/RMRKLib.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+
+error RMRKApproveForResourcesToCaller();
+error RMRKBadPriorityListLength();
+error RMRKIndexOutOfRange();
+error RMRKMaxPendingResourcesReached();
+error RMRKNoResourceMatchingId();
+error RMRKResourceAlreadyExists();
+error RMRKWriteToZero();
+
+
+abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
+
+    using RMRKLib for uint64[];
+
+    //mapping of uint64 Ids to resource object
+    mapping(uint64 => string) private _resources;
+
+    //mapping of tokenId to new resource, to resource to be replaced
+    mapping(uint256 => mapping(uint64 => uint64)) private _resourceOverwrites;
+
+    //mapping of tokenId to all resources
+    mapping(uint256 => uint64[]) private _activeResources;
+
+    //mapping of tokenId to an array of resource priorities
+    mapping(uint256 => uint16[]) private _activeResourcePriorities;
+
+    //Double mapping of tokenId to active resources
+    mapping(uint256 => mapping(uint64 => bool)) private _tokenResources;
+
+    //mapping of tokenId to all resources by priority
+    mapping(uint256 => uint64[]) private _pendingResources;
+
+    //List of all resources
+    uint64[] private _allResources;
+
+    // Mapping from owner to operator approvals for resources
+    mapping(address => mapping(address => bool)) private _operatorApprovalsForResources;
+
+    /**
+    * @notice Fetches resource data by resourceID
+    * @dev Resources are stored by reference mapping _resources[resourceId]
+    * @param resourceId The resourceID to query
+    * @return Resource returns a Resource struct
+    */
+    function getResource(
+        uint64 resourceId
+    ) public view virtual returns (Resource memory)
+    {
+        string memory resourceData = _resources[resourceId];
+        if (bytes(resourceData).length == 0) revert RMRKNoResourceMatchingId();
+        Resource memory resource = Resource({
+            id: resourceId,
+            metadataURI: resourceData
+        });
+        return resource;
+    }
+
+    /**
+    * @notice Returns array of all resource IDs.
+    * @return uint64 array of all resource IDs.
+    */
+    function getAllResources() public view virtual returns (uint64[] memory) {
+        return _allResources;
+    }
+
+    /**
+    * @notice Returns active resource IDs for a given token
+    * @dev  Resources data is stored by reference mapping _resource[resourceId]
+    * @param tokenId the token ID to query
+    * @return uint64[] active resource IDs
+    */
+    function getActiveResources(
+        uint256 tokenId
+    ) public view virtual returns(uint64[] memory) {
+        return _activeResources[tokenId];
+    }
+
+    /**
+    * @notice Returns pending resource IDs for a given token
+    * @dev Pending resources data is stored by reference mapping _pendingResource[resourceId]
+    * @param tokenId the token ID to query
+    * @return uint64[] pending resource IDs
+    */
+    function getPendingResources(
+        uint256 tokenId
+    ) public view virtual returns(uint64[] memory) {
+        return _pendingResources[tokenId];
+    }
+
+    /**
+    * @notice Returns active resource priorities
+    * @dev Resource priorities are a non-sequential array of uint16 values with an array size equal to active resource priorites.
+    * @param tokenId the token ID to query
+    * @return uint16[] active resource priorities
+    */
+    function getActiveResourcePriorities(
+        uint256 tokenId
+    ) public view virtual returns(uint16[] memory) {
+        return _activeResourcePriorities[tokenId];
+    }
+
+    /**
+    *  @notice Returns the resource ID that will be replaced (if any) if a given resourceID is accepted from the pending resources array.
+    *  @param tokenId the tokenId with the resource to query
+    *  @param resourceId the pending resourceID which will be accepted
+    *  @return uint64 the resourceId which will be replacted
+    */
+    function getResourceOverwrites(
+        uint256 tokenId,
+        uint64 resourceId
+    ) public view virtual returns(uint64) {
+        return _resourceOverwrites[tokenId][resourceId];
+    }
+
+    /**
+    * @notice Returns the bool status `operator`'s status for managing resources on `owner`'s tokens.
+    * @param owner the tokenId to query
+    * @param operator the tokenId to query
+    * @return address the address of the approved account.
+    */
+    function isApprovedForAllForResources(address owner, address operator) public virtual view returns (bool) {
+        return _operatorApprovalsForResources[owner][operator];
+    }
+
+    function setApprovalForAllForResources(address operator, bool approved)
+        public
+        virtual
+    {
+        address owner = _msgSender();
+        if (owner == operator) revert RMRKApproveForResourcesToCaller();
+
+        _operatorApprovalsForResources[owner][operator] = approved;
+        emit ApprovalForAllForResources(owner, operator, approved);
+    }
+
+    function _acceptResource(uint256 tokenId, uint256 index) internal {
+        if(index >= _pendingResources[tokenId].length) revert RMRKIndexOutOfRange();
+        uint64 resourceId = _pendingResources[tokenId][index];
+        _pendingResources[tokenId].removeItemByIndex(index);
+
+        uint64 overwrite = _resourceOverwrites[tokenId][resourceId];
+        if (overwrite != uint64(0)) {
+            // We could check here that the resource to overwrite actually exists but it is probably harmless.
+            _activeResources[tokenId].removeItemByValue(overwrite);
+            emit ResourceOverwritten(tokenId, overwrite, resourceId);
+            delete(_resourceOverwrites[tokenId][resourceId]);
+        }
+        _activeResources[tokenId].push(resourceId);
+        //Push 0 value of uint16 to array, e.g., uninitialized
+        _activeResourcePriorities[tokenId].push(uint16(0));
+        emit ResourceAccepted(tokenId, resourceId);
+    }
+
+    function _rejectResource(uint256 tokenId, uint256 index) internal {
+        if(index >= _pendingResources[tokenId].length) revert RMRKIndexOutOfRange();
+        uint64 resourceId = _pendingResources[tokenId][index];
+        _pendingResources[tokenId].removeItemByIndex(index);
+        _tokenResources[tokenId][resourceId] = false;
+        delete(_resourceOverwrites[tokenId][resourceId]);
+
+        emit ResourceRejected(tokenId, resourceId);
+    }
+
+    function _rejectAllResources(uint256 tokenId) internal {
+        uint256 len = _pendingResources[tokenId].length;
+        for (uint i; i<len;) {
+            uint64 resourceId = _pendingResources[tokenId][i];
+            delete _resourceOverwrites[tokenId][resourceId];
+            unchecked {++i;}
+        }
+
+        delete(_pendingResources[tokenId]);
+        emit ResourceRejected(tokenId, uint64(0));
+    }
+
+    function _setPriority(
+        uint256 tokenId,
+        uint16[] memory priorities
+    ) internal {
+        uint256 length = priorities.length;
+        if(length != _activeResources[tokenId].length) revert RMRKBadPriorityListLength();
+        _activeResourcePriorities[tokenId] = priorities;
+
+        emit ResourcePrioritySet(tokenId);
+    }
+
+    function _addResourceEntry(
+        uint64 id,
+        string memory metadataURI
+    ) internal {
+        if(id == uint64(0))
+            revert RMRKWriteToZero();
+        if(bytes(_resources[id]).length > 0)
+            revert RMRKResourceAlreadyExists();
+        _resources[id] = metadataURI;
+        _allResources.push(id);
+
+
+        emit ResourceSet(id);
+    }
+
+    function _addResourceToToken(
+        uint256 tokenId,
+        uint64 resourceId,
+        uint64 overwrites
+    ) internal {
+        if(_tokenResources[tokenId][resourceId])
+            revert RMRKResourceAlreadyExists();
+
+        if(bytes(_resources[resourceId]).length == 0)
+            revert RMRKNoResourceMatchingId();
+
+        if(_pendingResources[tokenId].length >= 128)
+            revert RMRKMaxPendingResourcesReached();
+
+        _tokenResources[tokenId][resourceId] = true;
+
+        _pendingResources[tokenId].push(resourceId);
+
+        if (overwrites != uint64(0)) {
+            _resourceOverwrites[tokenId][resourceId] = overwrites;
+            emit ResourceOverwriteProposed(tokenId, resourceId, overwrites);
+        }
+
+        emit ResourceAddedToToken(tokenId, resourceId);
+    }
+}

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -14,9 +14,7 @@ error RMRKNoResourceMatchingId();
 error RMRKResourceAlreadyExists();
 error RMRKWriteToZero();
 
-
 abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
-
     using RMRKLib for uint64[];
 
     //mapping of uint64 Ids to resource object
@@ -41,17 +39,20 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     uint64[] private _allResources;
 
     // Mapping from owner to operator approvals for resources
-    mapping(address => mapping(address => bool)) private _operatorApprovalsForResources;
+    mapping(address => mapping(address => bool))
+        private _operatorApprovalsForResources;
 
     /**
-    * @notice Fetches resource data by resourceID
-    * @dev Resources are stored by reference mapping _resources[resourceId]
-    * @param resourceId The resourceID to query
-    * @return Resource returns a Resource struct
-    */
-    function getResource(
-        uint64 resourceId
-    ) public view virtual returns (Resource memory)
+     * @notice Fetches resource data by resourceID
+     * @dev Resources are stored by reference mapping _resources[resourceId]
+     * @param resourceId The resourceID to query
+     * @return Resource returns a Resource struct
+     */
+    function getResource(uint64 resourceId)
+        public
+        view
+        virtual
+        returns (Resource memory)
     {
         string memory resourceData = _resources[resourceId];
         if (bytes(resourceData).length == 0) revert RMRKNoResourceMatchingId();
@@ -63,69 +64,85 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     }
 
     /**
-    * @notice Returns array of all resource IDs.
-    * @return uint64 array of all resource IDs.
-    */
+     * @notice Returns array of all resource IDs.
+     * @return uint64 array of all resource IDs.
+     */
     function getAllResources() public view virtual returns (uint64[] memory) {
         return _allResources;
     }
 
     /**
-    * @notice Returns active resource IDs for a given token
-    * @dev  Resources data is stored by reference mapping _resource[resourceId]
-    * @param tokenId the token ID to query
-    * @return uint64[] active resource IDs
-    */
-    function getActiveResources(
-        uint256 tokenId
-    ) public view virtual returns(uint64[] memory) {
+     * @notice Returns active resource IDs for a given token
+     * @dev  Resources data is stored by reference mapping _resource[resourceId]
+     * @param tokenId the token ID to query
+     * @return uint64[] active resource IDs
+     */
+    function getActiveResources(uint256 tokenId)
+        public
+        view
+        virtual
+        returns (uint64[] memory)
+    {
         return _activeResources[tokenId];
     }
 
     /**
-    * @notice Returns pending resource IDs for a given token
-    * @dev Pending resources data is stored by reference mapping _pendingResource[resourceId]
-    * @param tokenId the token ID to query
-    * @return uint64[] pending resource IDs
-    */
-    function getPendingResources(
-        uint256 tokenId
-    ) public view virtual returns(uint64[] memory) {
+     * @notice Returns pending resource IDs for a given token
+     * @dev Pending resources data is stored by reference mapping _pendingResource[resourceId]
+     * @param tokenId the token ID to query
+     * @return uint64[] pending resource IDs
+     */
+    function getPendingResources(uint256 tokenId)
+        public
+        view
+        virtual
+        returns (uint64[] memory)
+    {
         return _pendingResources[tokenId];
     }
 
     /**
-    * @notice Returns active resource priorities
-    * @dev Resource priorities are a non-sequential array of uint16 values with an array size equal to active resource priorites.
-    * @param tokenId the token ID to query
-    * @return uint16[] active resource priorities
-    */
-    function getActiveResourcePriorities(
-        uint256 tokenId
-    ) public view virtual returns(uint16[] memory) {
+     * @notice Returns active resource priorities
+     * @dev Resource priorities are a non-sequential array of uint16 values with an array size equal to active resource priorites.
+     * @param tokenId the token ID to query
+     * @return uint16[] active resource priorities
+     */
+    function getActiveResourcePriorities(uint256 tokenId)
+        public
+        view
+        virtual
+        returns (uint16[] memory)
+    {
         return _activeResourcePriorities[tokenId];
     }
 
     /**
-    *  @notice Returns the resource ID that will be replaced (if any) if a given resourceID is accepted from the pending resources array.
-    *  @param tokenId the tokenId with the resource to query
-    *  @param resourceId the pending resourceID which will be accepted
-    *  @return uint64 the resourceId which will be replacted
-    */
-    function getResourceOverwrites(
-        uint256 tokenId,
-        uint64 resourceId
-    ) public view virtual returns(uint64) {
+     *  @notice Returns the resource ID that will be replaced (if any) if a given resourceID is accepted from the pending resources array.
+     *  @param tokenId the tokenId with the resource to query
+     *  @param resourceId the pending resourceID which will be accepted
+     *  @return uint64 the resourceId which will be replacted
+     */
+    function getResourceOverwrites(uint256 tokenId, uint64 resourceId)
+        public
+        view
+        virtual
+        returns (uint64)
+    {
         return _resourceOverwrites[tokenId][resourceId];
     }
 
     /**
-    * @notice Returns the bool status `operator`'s status for managing resources on `owner`'s tokens.
-    * @param owner the tokenId to query
-    * @param operator the tokenId to query
-    * @return address the address of the approved account.
-    */
-    function isApprovedForAllForResources(address owner, address operator) public virtual view returns (bool) {
+     * @notice Returns the bool status `operator`'s status for managing resources on `owner`'s tokens.
+     * @param owner the tokenId to query
+     * @param operator the tokenId to query
+     * @return address the address of the approved account.
+     */
+    function isApprovedForAllForResources(address owner, address operator)
+        public
+        view
+        virtual
+        returns (bool)
+    {
         return _operatorApprovalsForResources[owner][operator];
     }
 
@@ -141,7 +158,8 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     }
 
     function _acceptResource(uint256 tokenId, uint256 index) internal {
-        if(index >= _pendingResources[tokenId].length) revert RMRKIndexOutOfRange();
+        if (index >= _pendingResources[tokenId].length)
+            revert RMRKIndexOutOfRange();
         uint64 resourceId = _pendingResources[tokenId][index];
         _pendingResources[tokenId].removeItemByIndex(index);
 
@@ -150,7 +168,7 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
             // We could check here that the resource to overwrite actually exists but it is probably harmless.
             _activeResources[tokenId].removeItemByValue(overwrite);
             emit ResourceOverwritten(tokenId, overwrite, resourceId);
-            delete(_resourceOverwrites[tokenId][resourceId]);
+            delete (_resourceOverwrites[tokenId][resourceId]);
         }
         _activeResources[tokenId].push(resourceId);
         //Push 0 value of uint16 to array, e.g., uninitialized
@@ -159,49 +177,47 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     }
 
     function _rejectResource(uint256 tokenId, uint256 index) internal {
-        if(index >= _pendingResources[tokenId].length) revert RMRKIndexOutOfRange();
+        if (index >= _pendingResources[tokenId].length)
+            revert RMRKIndexOutOfRange();
         uint64 resourceId = _pendingResources[tokenId][index];
         _pendingResources[tokenId].removeItemByIndex(index);
         _tokenResources[tokenId][resourceId] = false;
-        delete(_resourceOverwrites[tokenId][resourceId]);
+        delete (_resourceOverwrites[tokenId][resourceId]);
 
         emit ResourceRejected(tokenId, resourceId);
     }
 
     function _rejectAllResources(uint256 tokenId) internal {
         uint256 len = _pendingResources[tokenId].length;
-        for (uint i; i<len;) {
+        for (uint256 i; i < len; ) {
             uint64 resourceId = _pendingResources[tokenId][i];
             delete _resourceOverwrites[tokenId][resourceId];
-            unchecked {++i;}
+            unchecked {
+                ++i;
+            }
         }
 
-        delete(_pendingResources[tokenId]);
+        delete (_pendingResources[tokenId]);
         emit ResourceRejected(tokenId, uint64(0));
     }
 
-    function _setPriority(
-        uint256 tokenId,
-        uint16[] memory priorities
-    ) internal {
+    function _setPriority(uint256 tokenId, uint16[] memory priorities)
+        internal
+    {
         uint256 length = priorities.length;
-        if(length != _activeResources[tokenId].length) revert RMRKBadPriorityListLength();
+        if (length != _activeResources[tokenId].length)
+            revert RMRKBadPriorityListLength();
         _activeResourcePriorities[tokenId] = priorities;
 
         emit ResourcePrioritySet(tokenId);
     }
 
-    function _addResourceEntry(
-        uint64 id,
-        string memory metadataURI
-    ) internal {
-        if(id == uint64(0))
-            revert RMRKWriteToZero();
-        if(bytes(_resources[id]).length > 0)
+    function _addResourceEntry(uint64 id, string memory metadataURI) internal {
+        if (id == uint64(0)) revert RMRKWriteToZero();
+        if (bytes(_resources[id]).length > 0)
             revert RMRKResourceAlreadyExists();
         _resources[id] = metadataURI;
         _allResources.push(id);
-
 
         emit ResourceSet(id);
     }
@@ -211,13 +227,13 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
         uint64 resourceId,
         uint64 overwrites
     ) internal {
-        if(_tokenResources[tokenId][resourceId])
+        if (_tokenResources[tokenId][resourceId])
             revert RMRKResourceAlreadyExists();
 
-        if(bytes(_resources[resourceId]).length == 0)
+        if (bytes(_resources[resourceId]).length == 0)
             revert RMRKNoResourceMatchingId();
 
-        if(_pendingResources[tokenId].length >= 128)
+        if (_pendingResources[tokenId].length >= 128)
             revert RMRKMaxPendingResourcesReached();
 
         _tokenResources[tokenId][resourceId] = true;

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -60,6 +60,26 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     }
 
     /**
+     * @notice Fetches resource data for the token's active resource with the given index.
+     * @dev Resources are stored by reference mapping _resources[resourceId]
+     * @dev Can be overriden to implement enumerate, fallback or other custom logic
+     * @param tokenId the token ID to query
+     * @param resourceIndex from the token's active resources
+     * @return string with the meta
+     */
+    function getResourceMetaForToken(uint256 tokenId, uint64 resourceIndex)
+        public
+        view
+        virtual
+        returns (string memory)
+    {
+        if (resourceIndex >= getActiveResources(tokenId).length)
+            revert RMRKIndexOutOfRange();
+        uint64 resourceId = getActiveResources(tokenId)[resourceIndex];
+        return getResourceMeta(resourceId);
+    }
+
+    /**
      * @notice Returns array of all resource IDs.
      * @return uint64 array of all resource IDs.
      */

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -46,21 +46,17 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
      * @notice Fetches resource data by resourceID
      * @dev Resources are stored by reference mapping _resources[resourceId]
      * @param resourceId The resourceID to query
-     * @return Resource returns a Resource struct
+     * @return string with the meta
      */
-    function getResource(uint64 resourceId)
+    function getResourceMeta(uint64 resourceId)
         public
         view
         virtual
-        returns (Resource memory)
+        returns (string memory)
     {
-        string memory resourceData = _resources[resourceId];
-        if (bytes(resourceData).length == 0) revert RMRKNoResourceMatchingId();
-        Resource memory resource = Resource({
-            id: resourceId,
-            metadataURI: resourceData
-        });
-        return resource;
+        string memory meta = _resources[resourceId];
+        if (bytes(meta).length == 0) revert RMRKNoResourceMatchingId();
+        return meta;
     }
 
     /**

--- a/contracts/RMRK/multiresource/IRMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/IRMRKMultiResource.sol
@@ -186,6 +186,16 @@ interface IRMRKMultiResource is IERC165 {
         returns (string memory);
 
     /**
+     * @notice Fetches resource data for the token's active resource with the given index.
+     * @dev Resources are stored by reference mapping _resources[resourceId]
+     * @dev Can be overriden to implement enumerate, fallback or other custom logic
+     */
+    function getResourceMetaForToken(uint256 tokenId, uint64 resourceIndex)
+        external
+        view
+        returns (string memory);
+
+    /**
      * @notice Returns the ids of all stored resources
      */
     function getAllResources() external view returns (uint64[] memory);

--- a/contracts/RMRK/multiresource/IRMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/IRMRKMultiResource.sol
@@ -138,7 +138,7 @@ interface IRMRKMultiResource is IERC165 {
 
     /**
      * @notice Returns IDs of active resources of `tokenId`.
-     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResource(resourceId)`
+     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResourceMeta(resourceId)`
      */
     function getActiveResources(uint256 tokenId)
         external
@@ -147,7 +147,7 @@ interface IRMRKMultiResource is IERC165 {
 
     /**
      * @notice Returns IDs of pending resources of `tokenId`.
-     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResource(resourceId)`
+     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResourceMeta(resourceId)`
      */
     function getPendingResources(uint256 tokenId)
         external
@@ -166,7 +166,7 @@ interface IRMRKMultiResource is IERC165 {
     /**
      * @notice Returns the resource which will be overridden if resourceId is accepted from
      * a pending resource array on `tokenId`.
-     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResource(resourceId)`
+     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResourceMeta(resourceId)`
      */
     function getResourceOverwrites(uint256 tokenId, uint64 resourceId)
         external
@@ -180,10 +180,10 @@ interface IRMRKMultiResource is IERC165 {
      * Custom data is intended to be stored as generic bytes and decode by various protocols on an as-needed basis
      *
      */
-    function getResource(uint64 resourceId)
+    function getResourceMeta(uint64 resourceId)
         external
         view
-        returns (Resource memory);
+        returns (string memory);
 
     /**
      * @notice Returns the ids of all stored resources

--- a/contracts/RMRK/multiresource/RMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/RMRKMultiResource.sol
@@ -7,18 +7,14 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "./IRMRKMultiResource.sol";
-import "../library/RMRKLib.sol";
+import "./AbstractMultiResource.sol";
 import "../core/RMRKCore.sol";
 // import "hardhat/console.sol";
 
 error ERC721AddressZeroIsNotaValidOwner();
 error ERC721ApprovalToCurrentOwner();
 error ERC721ApproveCallerIsNotOwnerNorApprovedForAll();
-error ERC721ApprovedQueryForNonexistentToken();
 error ERC721ApproveToCaller();
 error ERC721InvalidTokenId();
 error ERC721MintToTheZeroAddress();
@@ -27,30 +23,20 @@ error ERC721TokenAlreadyMinted();
 error ERC721TransferFromIncorrectOwner();
 error ERC721TransferToNonReceiverImplementer();
 error ERC721TransferToTheZeroAddress();
-error RMRKBadPriorityListLength();
-error RMRKIndexOutOfRange();
-error RMRKMaxPendingResourcesReached();
-error RMRKNoResourceMatchingId();
-error RMRKResourceAlreadyExists();
-error RMRKWriteToZero();
 error RMRKNotApprovedForResourcesOrOwner();
 error RMRKApprovalForResourcesToCurrentOwner();
 error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
-error RMRKApproveForResourcesToCaller();
 
 /**
  * @dev Implementation of RMRK Multiresource contract, on top of ERC721.
  */
 contract RMRKMultiResource is
-    Context,
     IERC165,
     IERC721,
-    IRMRKMultiResource,
+    AbstractMultiResource,
     RMRKCore
 {
     using Address for address;
-    using Strings for uint256;
-    using RMRKLib for uint64[];
 
     // Mapping from token ID to owner address
     mapping(uint256 => address) private _owners;
@@ -65,33 +51,9 @@ contract RMRKMultiResource is
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
     // ------------------- RESOURCES --------------
-    //mapping of uint64 Ids to resource object
-    mapping(uint64 => string) private _resources;
-
-    //mapping of tokenId to new resource, to resource to be replaced
-    mapping(uint256 => mapping(uint64 => uint64)) private _resourceOverwrites;
-
-    //mapping of tokenId to all resources
-    mapping(uint256 => uint64[]) private _activeResources;
-
-    //mapping of tokenId to an array of resource priorities
-    mapping(uint256 => uint16[]) private _activeResourcePriorities;
-
-    //Double mapping of tokenId to active resources
-    mapping(uint256 => mapping(uint64 => bool)) private _tokenResources;
-
-    //mapping of tokenId to all resources by priority
-    mapping(uint256 => uint64[]) private _pendingResources;
-
-    //List of all resources
-    uint64[] private _allResources;
 
     // Mapping from token ID to approved address for resources
     mapping(uint256 => address) private _tokenApprovalsForResources;
-
-    // Mapping from owner to operator approvals for resources
-    mapping(address => mapping(address => bool))
-        private _operatorApprovalsForResources;
 
     // -------------------------- ERC721 MODIFIERS ----------------------------
 
@@ -539,86 +501,12 @@ contract RMRKMultiResource is
 
     // ------------------------------- RESOURCES ------------------------------
 
-    // --------------------------- GETTING RESOURCES --------------------------
-
-    function getResource(uint64 resourceId)
-        public
-        view
-        virtual
-        returns (Resource memory)
-    {
-        string memory resourceData = _resources[resourceId];
-        if (bytes(resourceData).length == 0) revert RMRKNoResourceMatchingId();
-        Resource memory resource = Resource({
-            id: resourceId,
-            metadataURI: resourceData
-        });
-        return resource;
-    }
-
-    function getAllResources() public view virtual returns (uint64[] memory) {
-        return _allResources;
-    }
-
-    function getActiveResources(uint256 tokenId)
-        public
-        view
-        virtual
-        returns (uint64[] memory)
-    {
-        return _activeResources[tokenId];
-    }
-
-    function getPendingResources(uint256 tokenId)
-        public
-        view
-        virtual
-        returns (uint64[] memory)
-    {
-        return _pendingResources[tokenId];
-    }
-
-    function getActiveResourcePriorities(uint256 tokenId)
-        public
-        view
-        virtual
-        returns (uint16[] memory)
-    {
-        return _activeResourcePriorities[tokenId];
-    }
-
-    function getResourceOverwrites(uint256 tokenId, uint64 resourceId)
-        public
-        view
-        virtual
-        returns (uint64)
-    {
-        return _resourceOverwrites[tokenId][resourceId];
-    }
-
-    // --------------------------- HANDLING RESOURCES -------------------------
-
     function acceptResource(uint256 tokenId, uint256 index)
         public
         virtual
         onlyApprovedForResourcesOrOwner(tokenId)
     {
-        if (index >= _pendingResources[tokenId].length)
-            revert RMRKIndexOutOfRange();
-        uint64 resourceId = _pendingResources[tokenId][index];
-        _pendingResources[tokenId].removeItemByIndex(index);
-
-        uint64 overwrite = _resourceOverwrites[tokenId][resourceId];
-        if (overwrite != uint64(0)) {
-            // We could check here that the resource to overwrite actually exists but it is probably harmless.
-            _activeResources[tokenId].removeItemByValue(overwrite);
-            emit ResourceOverwritten(tokenId, overwrite, resourceId);
-            delete (_resourceOverwrites[tokenId][resourceId]);
-        }
-        _activeResources[tokenId].push(resourceId);
-        //Push 0 value of uint16 to array, e.g., uninitialized
-        _activeResourcePriorities[tokenId].push(uint16(0));
-        emit ResourceAccepted(tokenId, resourceId);
+        _acceptResource(tokenId, index);
     }
 
     function rejectResource(uint256 tokenId, uint256 index)
@@ -626,14 +514,7 @@ contract RMRKMultiResource is
         virtual
         onlyApprovedForResourcesOrOwner(tokenId)
     {
-        if (index >= _pendingResources[tokenId].length)
-            revert RMRKIndexOutOfRange();
-        uint64 resourceId = _pendingResources[tokenId][index];
-        _pendingResources[tokenId].removeItemByIndex(index);
-        delete _tokenResources[tokenId][resourceId];
-        delete (_resourceOverwrites[tokenId][resourceId]);
-
-        emit ResourceRejected(tokenId, resourceId);
+        _rejectResource(tokenId, index);
     }
 
     function rejectAllResources(uint256 tokenId)
@@ -641,17 +522,7 @@ contract RMRKMultiResource is
         virtual
         onlyApprovedForResourcesOrOwner(tokenId)
     {
-        uint256 len = _pendingResources[tokenId].length;
-        for (uint256 i; i < len; ) {
-            uint64 resourceId = _pendingResources[tokenId][i];
-            delete _resourceOverwrites[tokenId][resourceId];
-            unchecked {
-                ++i;
-            }
-        }
-
-        delete (_pendingResources[tokenId]);
-        emit ResourceRejected(tokenId, uint64(0));
+        _rejectAllResources(tokenId);
     }
 
     function setPriority(uint256 tokenId, uint16[] calldata priorities)
@@ -659,50 +530,7 @@ contract RMRKMultiResource is
         virtual
         onlyApprovedForResourcesOrOwner(tokenId)
     {
-        uint256 length = priorities.length;
-        if (length != _activeResources[tokenId].length)
-            revert RMRKBadPriorityListLength();
-        _activeResourcePriorities[tokenId] = priorities;
-
-        emit ResourcePrioritySet(tokenId);
-    }
-
-    // This is expected to be implemented with custom guard:
-    function _addResourceEntry(uint64 id, string memory metadataURI) internal {
-        if (id == uint64(0)) revert RMRKWriteToZero();
-        if (bytes(_resources[id]).length != 0)
-            revert RMRKResourceAlreadyExists();
-        _resources[id] = metadataURI;
-        _allResources.push(id);
-
-        emit ResourceSet(id);
-    }
-
-    // This is expected to be implemented with custom guard:
-    function _addResourceToToken(
-        uint256 tokenId,
-        uint64 resourceId,
-        uint64 overwrites
-    ) internal {
-        if (_tokenResources[tokenId][resourceId])
-            revert RMRKResourceAlreadyExists();
-
-        if (bytes(_resources[resourceId]).length == 0)
-            revert RMRKNoResourceMatchingId();
-
-        if (_pendingResources[tokenId].length >= 128)
-            revert RMRKMaxPendingResourcesReached();
-
-        _tokenResources[tokenId][resourceId] = true;
-
-        _pendingResources[tokenId].push(resourceId);
-
-        if (overwrites != uint64(0)) {
-            _resourceOverwrites[tokenId][resourceId] = overwrites;
-            emit ResourceOverwriteProposed(tokenId, resourceId, overwrites);
-        }
-
-        emit ResourceAddedToToken(tokenId, resourceId);
+        _setPriority(tokenId, priorities);
     }
 
     // ----------------------- APPROVALS FOR RESOURCES ------------------------
@@ -718,6 +546,14 @@ contract RMRKMultiResource is
         _approveForResources(to, tokenId);
     }
 
+    function _approveForResources(address to, uint256 tokenId)
+        internal
+        virtual
+    {
+        _tokenApprovalsForResources[tokenId] = to;
+        emit ApprovalForResources(ownerOf(tokenId), to, tokenId);
+    }
+
     function getApprovedForResources(uint256 tokenId)
         public
         view
@@ -726,33 +562,5 @@ contract RMRKMultiResource is
     {
         _requireMinted(tokenId);
         return _tokenApprovalsForResources[tokenId];
-    }
-
-    function setApprovalForAllForResources(address operator, bool approved)
-        public
-        virtual
-    {
-        address owner = _msgSender();
-        if (owner == operator) revert RMRKApproveForResourcesToCaller();
-
-        _operatorApprovalsForResources[owner][operator] = approved;
-        emit ApprovalForAllForResources(owner, operator, approved);
-    }
-
-    function isApprovedForAllForResources(address owner, address operator)
-        public
-        view
-        virtual
-        returns (bool)
-    {
-        return _operatorApprovalsForResources[owner][operator];
-    }
-
-    function _approveForResources(address to, uint256 tokenId)
-        internal
-        virtual
-    {
-        _tokenApprovalsForResources[tokenId] = to;
-        emit ApprovalForResources(ownerOf(tokenId), to, tokenId);
     }
 }

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -448,7 +448,11 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
      */
 
     //update for reentrancy
-    function burn(uint256 tokenId) public virtual onlyApprovedOrDirectOwner(tokenId) {
+    function burn(uint256 tokenId)
+        public
+        virtual
+        onlyApprovedOrDirectOwner(tokenId)
+    {
         (address _RMRKOwner, , ) = rmrkOwnerOf(tokenId);
         address owner = ownerOf(tokenId);
         _balances[_RMRKOwner] -= 1;

--- a/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
@@ -24,13 +24,13 @@ error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
  */
 
 contract RMRKNestingMultiResource is RMRKNesting, AbstractMultiResource {
-
     // ------------------- RESOURCES --------------
 
     // Mapping from token ID to approver address to approved address for resources
     // The approver is necessary so approvals are invalidated for nested children on transfer
     // WARNING: If a child NFT returns the original root owner, old permissions would be active again
-    mapping(uint256 => mapping(address => address)) private _tokenApprovalsForResources;
+    mapping(uint256 => mapping(address => address))
+        private _tokenApprovalsForResources;
 
     function _onlyApprovedForResourcesOrOwner(uint256 tokenId) private view {
         if (!_isApprovedForResourcesOrOwner(_msgSender(), tokenId))
@@ -134,11 +134,7 @@ contract RMRKNestingMultiResource is RMRKNesting, AbstractMultiResource {
         emit ApprovalForResources(owner, to, tokenId);
     }
 
-    function _cleanApprovals(uint256 tokenId)
-        internal
-        virtual
-        override
-    {
+    function _cleanApprovals(uint256 tokenId) internal virtual override {
         _approveForResources(address(0), tokenId);
     }
 

--- a/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
@@ -4,73 +4,33 @@
 
 pragma solidity ^0.8.15;
 
-import "../multiresource/IRMRKMultiResource.sol";
+import "../multiresource/AbstractMultiResource.sol";
 import "./IRMRKNesting.sol";
-import "../library/RMRKLib.sol";
 import "./RMRKNesting.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
 // import "hardhat/console.sol";
 
 // MultiResource
-error RMRKBadPriorityListLength();
-error RMRKIndexOutOfRange();
-error RMRKMaxPendingResourcesReached();
-error RMRKNoResourceMatchingId();
-error RMRKResourceAlreadyExists();
-error RMRKWriteToZero();
 error RMRKNotApprovedForResourcesOrOwner();
 error RMRKApprovalForResourcesToCurrentOwner();
 error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
-error RMRKApproveForResourcesToCaller();
 
 /**
  * @dev Mid-level contract implementing multiresource on top of nesting.
  *
  */
 
-contract RMRKNestingMultiResource is RMRKNesting, IRMRKMultiResource {
-    using RMRKLib for uint256;
-    using Address for address;
-    using Strings for uint256;
-    using RMRKLib for uint64[];
-    using RMRKLib for uint128[];
+contract RMRKNestingMultiResource is RMRKNesting, AbstractMultiResource {
 
     // ------------------- RESOURCES --------------
-    //mapping of uint64 Ids to resource object
-    mapping(uint64 => string) private _resources;
-
-    //mapping of tokenId to new resource, to resource to be replaced
-    mapping(uint256 => mapping(uint64 => uint64)) private _resourceOverwrites;
-
-    //mapping of tokenId to all resources
-    mapping(uint256 => uint64[]) private _activeResources;
-
-    //mapping of tokenId to an array of resource priorities
-    mapping(uint256 => uint16[]) private _activeResourcePriorities;
-
-    //Double mapping of tokenId to active resources
-    mapping(uint256 => mapping(uint64 => bool)) private _tokenResources;
-
-    //mapping of tokenId to all resources by priority
-    mapping(uint256 => uint64[]) private _pendingResources;
-
-    //List of all resources
-    uint64[] private _allResources;
 
     // Mapping from token ID to approver address to approved address for resources
     // The approver is necessary so approvals are invalidated for nested children on transfer
     // WARNING: If a child NFT returns the original root owner, old permissions would be active again
     mapping(uint256 => mapping(address => address)) private _tokenApprovalsForResources;
-
-    // Mapping from owner to operator approvals for resources
-    mapping(address => mapping(address => bool))
-        private _operatorApprovalsForResources;
 
     function _onlyApprovedForResourcesOrOwner(uint256 tokenId) private view {
         if (!_isApprovedForResourcesOrOwner(_msgSender(), tokenId))
@@ -108,63 +68,6 @@ contract RMRKNestingMultiResource is RMRKNesting, IRMRKMultiResource {
 
     // ------------------------------- RESOURCES ------------------------------
 
-    // --------------------------- GETTING RESOURCES --------------------------
-
-    function getResource(uint64 resourceId)
-        public
-        view
-        virtual
-        returns (Resource memory)
-    {
-        string memory resourceData = _resources[resourceId];
-        if (bytes(resourceData).length == 0) revert RMRKNoResourceMatchingId();
-        Resource memory resource = Resource({
-            id: resourceId,
-            metadataURI: resourceData
-        });
-        return resource;
-    }
-
-    function getAllResources() public view virtual returns (uint64[] memory) {
-        return _allResources;
-    }
-
-    function getActiveResources(uint256 tokenId)
-        public
-        view
-        virtual
-        returns (uint64[] memory)
-    {
-        return _activeResources[tokenId];
-    }
-
-    function getPendingResources(uint256 tokenId)
-        public
-        view
-        virtual
-        returns (uint64[] memory)
-    {
-        return _pendingResources[tokenId];
-    }
-
-    function getActiveResourcePriorities(uint256 tokenId)
-        public
-        view
-        virtual
-        returns (uint16[] memory)
-    {
-        return _activeResourcePriorities[tokenId];
-    }
-
-    function getResourceOverwrites(uint256 tokenId, uint64 resourceId)
-        public
-        view
-        virtual
-        returns (uint64)
-    {
-        return _resourceOverwrites[tokenId][resourceId];
-    }
-
     // --------------------------- HANDLING RESOURCES -------------------------
 
     function acceptResource(uint256 tokenId, uint256 index)
@@ -199,99 +102,6 @@ contract RMRKNestingMultiResource is RMRKNesting, IRMRKMultiResource {
         _setPriority(tokenId, priorities);
     }
 
-    function _acceptResource(uint256 tokenId, uint256 index) internal {
-        if (index >= _pendingResources[tokenId].length)
-            revert RMRKIndexOutOfRange();
-        uint64 resourceId = _pendingResources[tokenId][index];
-        _pendingResources[tokenId].removeItemByIndex(index);
-
-        uint64 overwrite = _resourceOverwrites[tokenId][resourceId];
-        if (overwrite != uint64(0)) {
-            // We could check here that the resource to overwrite actually exists but it is probably harmless.
-            _activeResources[tokenId].removeItemByValue(overwrite);
-            emit ResourceOverwritten(tokenId, overwrite, resourceId);
-            delete (_resourceOverwrites[tokenId][resourceId]);
-        }
-        _activeResources[tokenId].push(resourceId);
-        //Push 0 value of uint16 to array, e.g., uninitialized
-        _activeResourcePriorities[tokenId].push(uint16(0));
-        emit ResourceAccepted(tokenId, resourceId);
-    }
-
-    function _rejectResource(uint256 tokenId, uint256 index) internal {
-        if (index >= _pendingResources[tokenId].length)
-            revert RMRKIndexOutOfRange();
-        uint64 resourceId = _pendingResources[tokenId][index];
-        _pendingResources[tokenId].removeItemByIndex(index);
-        delete _tokenResources[tokenId][resourceId];
-        delete (_resourceOverwrites[tokenId][resourceId]);
-
-        emit ResourceRejected(tokenId, resourceId);
-    }
-
-    function _rejectAllResources(uint256 tokenId) internal {
-        uint256 len = _pendingResources[tokenId].length;
-        for (uint256 i; i < len; ) {
-            uint64 resourceId = _pendingResources[tokenId][i];
-            delete _resourceOverwrites[tokenId][resourceId];
-            unchecked {
-                ++i;
-            }
-        }
-
-        delete (_pendingResources[tokenId]);
-        emit ResourceRejected(tokenId, uint64(0));
-    }
-
-    function _setPriority(uint256 tokenId, uint16[] calldata priorities)
-        internal
-    {
-        uint256 length = priorities.length;
-        if (length != _activeResources[tokenId].length)
-            revert RMRKBadPriorityListLength();
-        _activeResourcePriorities[tokenId] = priorities;
-
-        emit ResourcePrioritySet(tokenId);
-    }
-
-    // This is expected to be implemented with custom guard:
-    function _addResourceEntry(uint64 id, string memory metadataURI) internal {
-        if (id == uint64(0)) revert RMRKWriteToZero();
-        if (bytes(_resources[id]).length != 0)
-            revert RMRKResourceAlreadyExists();
-        _resources[id] = metadataURI;
-        _allResources.push(id);
-
-        emit ResourceSet(id);
-    }
-
-    // This is expected to be implemented with custom guard:
-    function _addResourceToToken(
-        uint256 tokenId,
-        uint64 resourceId,
-        uint64 overwrites
-    ) internal {
-        if (_tokenResources[tokenId][resourceId])
-            revert RMRKResourceAlreadyExists();
-
-        if (bytes(_resources[resourceId]).length == 0)
-            revert RMRKNoResourceMatchingId();
-
-        if (_pendingResources[tokenId].length >= 128)
-            revert RMRKMaxPendingResourcesReached();
-
-        _tokenResources[tokenId][resourceId] = true;
-
-        _pendingResources[tokenId].push(resourceId);
-
-        if (overwrites != uint64(0)) {
-            _resourceOverwrites[tokenId][resourceId] = overwrites;
-            emit ResourceOverwriteProposed(tokenId, resourceId, overwrites);
-        }
-
-        emit ResourceAddedToToken(tokenId, resourceId);
-    }
-
     // ----------------------- APPROVALS FOR RESOURCES ------------------------
 
     function approveForResources(address to, uint256 tokenId) public virtual {
@@ -313,26 +123,6 @@ contract RMRKNestingMultiResource is RMRKNesting, IRMRKMultiResource {
     {
         _requireMinted(tokenId);
         return _tokenApprovalsForResources[tokenId][ownerOf(tokenId)];
-    }
-
-    function setApprovalForAllForResources(address operator, bool approved)
-        public
-        virtual
-    {
-        address owner = _msgSender();
-        if (owner == operator) revert RMRKApproveForResourcesToCaller();
-
-        _operatorApprovalsForResources[owner][operator] = approved;
-        emit ApprovalForAllForResources(owner, operator, approved);
-    }
-
-    function isApprovedForAllForResources(address owner, address operator)
-        public
-        view
-        virtual
-        returns (bool)
-    {
-        return _operatorApprovalsForResources[owner][operator];
     }
 
     function _approveForResources(address to, uint256 tokenId)

--- a/contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol
@@ -18,7 +18,7 @@ interface IRMRKMultiResourceRenderUtils is IERC165 {
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view returns (IRMRKMultiResource.Resource memory);
+    ) external view returns (string memory);
 
     /**
      * @notice Returns `Resource` object at `index` of active resource array on `tokenId`
@@ -32,7 +32,7 @@ interface IRMRKMultiResourceRenderUtils is IERC165 {
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view returns (IRMRKMultiResource.Resource memory);
+    ) external view returns (string memory);
 
     /**
      * @notice Returns `Resource` objects for the given ids
@@ -44,5 +44,5 @@ interface IRMRKMultiResourceRenderUtils is IERC165 {
     function getResourcesById(address target, uint64[] calldata resourceIds)
         external
         view
-        returns (IRMRKMultiResource.Resource[] memory);
+        returns (string[] memory);
 }

--- a/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
@@ -49,8 +49,7 @@ contract RMRKMultiResourceRenderUtils is IRMRKMultiResourceRenderUtils {
     {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint256 len = resourceIds.length;
-        string[]
-            memory resources = new string[](len);
+        string[] memory resources = new string[](len);
         for (uint256 i; i < len; ) {
             resources[i] = target_.getResourceMeta(resourceIds[i]);
             unchecked {

--- a/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
@@ -25,34 +25,34 @@ contract RMRKMultiResourceRenderUtils is IRMRKMultiResourceRenderUtils {
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view virtual returns (IRMRKMultiResource.Resource memory) {
+    ) external view virtual returns (string memory) {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint64 resourceId = target_.getActiveResources(tokenId)[index];
-        return target_.getResource(resourceId);
+        return target_.getResourceMeta(resourceId);
     }
 
     function getPendingResourceByIndex(
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view virtual returns (IRMRKMultiResource.Resource memory) {
+    ) external view virtual returns (string memory) {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint64 resourceId = target_.getPendingResources(tokenId)[index];
-        return target_.getResource(resourceId);
+        return target_.getResourceMeta(resourceId);
     }
 
     function getResourcesById(address target, uint64[] calldata resourceIds)
         public
         view
         virtual
-        returns (IRMRKMultiResource.Resource[] memory)
+        returns (string[] memory)
     {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint256 len = resourceIds.length;
-        IRMRKMultiResource.Resource[]
-            memory resources = new IRMRKMultiResource.Resource[](len);
+        string[]
+            memory resources = new string[](len);
         for (uint256 i; i < len; ) {
-            resources[i] = target_.getResource(resourceIds[i]);
+            resources[i] = target_.getResourceMeta(resourceIds[i]);
             unchecked {
                 ++i;
             }

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -193,10 +193,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullPendingExtendedResources === undefined) {
         const pendingResources = await chunkyEquip.getPendingResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, pendingResources)).to.be.eql(
-          [
-            [resId, metaURIDefault],
-            [resId2, metaURIDefault],
-          ],
+          [metaURIDefault, metaURIDefault],
         );
       } else {
         const pending = await chunkyEquip.getFullPendingExtendedResources(tokenId);
@@ -289,7 +286,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.eql([
-          [resId, metaURIDefault],
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.eql([
@@ -323,8 +320,8 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.eql([
-          [resId2, metaURIDefault],
-          [resId, metaURIDefault],
+          metaURIDefault,
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.eql([
@@ -412,7 +409,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.be.eql([
-          [resId2, metaURIDefault],
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.be.eql([
@@ -434,7 +431,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.be.eql([
-          [resId, metaURIDefault],
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.be.eql([

--- a/test/behavior/multiresource.ts
+++ b/test/behavior/multiresource.ts
@@ -35,7 +35,7 @@ async function shouldBehaveLikeMultiResource(
     });
 
     it('can support IMultiResource', async function () {
-      expect(await this.token.supportsInterface('0x1c21cc26')).to.equal(true);
+      expect(await this.token.supportsInterface('0xc65a6425')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -214,6 +214,13 @@ async function shouldBehaveLikeMultiResource(
         expect(await this.renderUtils.getResourceByIndex(this.token.address, tokenId, 0)).to.eql(
           resData1,
         );
+
+        // Other ways of getting the token info:
+        if (this.token.tokenURI !== undefined) {
+          expect(await this.token.tokenURI(tokenId)).equal('');
+        }
+        expect(await this.token.getResourceMeta(resId1)).equal(resData1);
+        expect(await this.token.getResourceMetaForToken(tokenId, 0)).equal(resData1);
       });
 
       it('can get all resources', async function () {

--- a/test/behavior/multiresource.ts
+++ b/test/behavior/multiresource.ts
@@ -35,7 +35,7 @@ async function shouldBehaveLikeMultiResource(
     });
 
     it('can support IMultiResource', async function () {
-      expect(await this.token.supportsInterface('0xcb2f8f94')).to.equal(true);
+      expect(await this.token.supportsInterface('0x1c21cc26')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -134,7 +134,7 @@ async function shouldBehaveLikeMultiResource(
         activeResources = await this.token.getActiveResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, activeResources),
-        ).to.be.eql([[resId2, metaURIDefault]]);
+        ).to.be.eql([metaURIDefault]);
         // Overwrite should be gone
         expect(await this.token.getResourceOverwrites(tokenId, pendingResources[0])).to.eql(bn(0));
       });
@@ -148,7 +148,7 @@ async function shouldBehaveLikeMultiResource(
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, activeResources),
-        ).to.be.eql([[resId, metaURIDefault]]);
+        ).to.be.eql([metaURIDefault]);
       });
 
       it('can reject resource and overwrites are cleared', async function () {
@@ -197,10 +197,7 @@ async function shouldBehaveLikeMultiResource(
         let pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([
-          [resId1, resData1],
-          [resId2, resData2],
-        ]);
+        ).to.eql([resData1, resData2]);
 
         await expect(this.token.connect(tokenOwner).acceptResource(tokenId, 0))
           .to.emit(this.token, 'ResourceAccepted')
@@ -208,16 +205,15 @@ async function shouldBehaveLikeMultiResource(
 
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(await this.renderUtils.getResourcesById(this.token.address, activeResources)).to.eql(
-          [[resId1, resData1]],
+          [resData1],
         );
         pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
-        expect(await this.renderUtils.getResourceByIndex(this.token.address, tokenId, 0)).to.eql([
-          resId1,
+        ).to.eql([resData2]);
+        expect(await this.renderUtils.getResourceByIndex(this.token.address, tokenId, 0)).to.eql(
           resData1,
-        ]);
+        );
       });
 
       it('can get all resources', async function () {
@@ -239,10 +235,7 @@ async function shouldBehaveLikeMultiResource(
           this.token.address,
           activeResources,
         );
-        expect(accepted).to.eql([
-          [resId2, resData2],
-          [resId1, resData1],
-        ]);
+        expect(accepted).to.eql([resData2, resData1]);
       });
 
       it('can accept resource if approved', async function () {
@@ -251,7 +244,7 @@ async function shouldBehaveLikeMultiResource(
 
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(await this.renderUtils.getResourcesById(this.token.address, activeResources)).to.eql(
-          [[resId1, resData1]],
+          [resData1],
         );
       });
 
@@ -261,7 +254,7 @@ async function shouldBehaveLikeMultiResource(
 
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(await this.renderUtils.getResourcesById(this.token.address, activeResources)).to.eql(
-          [[resId1, resData1]],
+          [resData1],
         );
       });
 
@@ -293,10 +286,7 @@ async function shouldBehaveLikeMultiResource(
         let pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([
-          [resId1, resData1],
-          [resId2, resData2],
-        ]);
+        ).to.eql([resData1, resData2]);
 
         await expect(this.token.connect(tokenOwner).rejectResource(tokenId, 0))
           .to.emit(this.token, 'ResourceRejected')
@@ -306,7 +296,7 @@ async function shouldBehaveLikeMultiResource(
         pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
+        ).to.eql([resData2]);
       });
 
       it('can reject resource if approved', async function () {
@@ -317,7 +307,7 @@ async function shouldBehaveLikeMultiResource(
         const pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
+        ).to.eql([resData2]);
       });
 
       it('can reject resource if approved for all', async function () {
@@ -328,7 +318,7 @@ async function shouldBehaveLikeMultiResource(
         const pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
+        ).to.eql([resData2]);
       });
 
       it('can reject all resources', async function () {

--- a/test/externalEquip.ts
+++ b/test/externalEquip.ts
@@ -209,7 +209,7 @@ async function multiResourceFixture() {
 
 // --------------- EQUIPPABLE BEHAVIOR -----------------------
 
-describe('EquippableMock with Parts', async () => {
+describe('ExternalEquippableMock with Parts', async () => {
   beforeEach(async function () {
     const { base, neon, neonEquip, mask, maskEquip, view } = await loadFixture(partsFixture);
 
@@ -224,7 +224,7 @@ describe('EquippableMock with Parts', async () => {
   shouldBehaveLikeEquippableWithParts();
 });
 
-describe('EquippableMock with Slots', async () => {
+describe('ExternalEquippableMock with Slots', async () => {
   beforeEach(async function () {
     const {
       base,
@@ -254,7 +254,7 @@ describe('EquippableMock with Slots', async () => {
   shouldBehaveLikeEquippableWithSlots(nestMintFromMock);
 });
 
-describe('EquippableMock Resources', async () => {
+describe('ExternalEquippableMock Resources', async () => {
   beforeEach(async function () {
     const { nesting, equip, renderUtils } = await loadFixture(resourcesFixture);
     this.nesting = nesting;
@@ -293,7 +293,7 @@ describe('EquippableMock Resources', async () => {
 
 // --------------- MULTI RESOURCE BEHAVIOR -----------------------
 
-describe('EquippableMock MR behavior', async () => {
+describe('ExternalEquippableMock MR behavior', async () => {
   let nextTokenId = 1;
   let nesting: Contract;
   let equip: Contract;

--- a/test/implementations/equippable.ts
+++ b/test/implementations/equippable.ts
@@ -144,7 +144,7 @@ async function equipFixture() {
 
 // --------------- EQUIPPABLE BEHAVIOR -----------------------
 
-describe('EquippableMock with Parts', async () => {
+describe('RMRKEquippableImpl with Parts', async () => {
   beforeEach(async function () {
     const { base, neon, mask, view } = await loadFixture(partsFixture);
 
@@ -159,7 +159,7 @@ describe('EquippableMock with Parts', async () => {
   shouldBehaveLikeEquippableWithParts();
 });
 
-describe('EquippableMock with Slots', async () => {
+describe('RMRKEquippableImpl with Slots', async () => {
   beforeEach(async function () {
     const { base, soldier, weapon, weaponGem, background, view } = await loadFixture(slotsFixture);
 
@@ -178,7 +178,7 @@ describe('EquippableMock with Slots', async () => {
   shouldBehaveLikeEquippableWithSlots(nestMintFromImpl);
 });
 
-describe('EquippableMock Resources', async () => {
+describe('RMRKEquippableImpl Resources', async () => {
   beforeEach(async function () {
     const { equip, renderUtils } = await loadFixture(resourcesFixture);
     this.nesting = equip;
@@ -200,7 +200,7 @@ describe('EquippableMock Resources', async () => {
 
 // --------------- MULTI RESOURCE BEHAVIOR -----------------------
 
-describe('EquippableMock MR behavior', async () => {
+describe('RMRKEquippableImpl MR behavior', async () => {
   let equip: Contract;
   let renderUtils: Contract;
 
@@ -220,7 +220,7 @@ describe('EquippableMock MR behavior', async () => {
 
 // --------------- MULTI RESOURCE BEHAVIOR END ------------------------
 
-describe('EquippableMock Minting', async function () {
+describe('RMRKEquippableImpl Minting', async function () {
   beforeEach(async function () {
     const { equip } = await loadFixture(equipFixture);
     this.token = equip;

--- a/test/implementations/multiresource.ts
+++ b/test/implementations/multiresource.ts
@@ -89,8 +89,8 @@ describe('MultiResourceImpl Other Behavior', async () => {
       await token.connect(owner).addResourceEntry(defaultResource1, []);
       await token.connect(owner).addResourceEntry(defaultResource2, []);
 
-      expect(await token.getResource(1)).to.eql([bn(1), defaultResource1]);
-      expect(await token.getResource(2)).to.eql([bn(2), defaultResource2]);
+      expect(await token.getResourceMeta(1)).to.eql(defaultResource1);
+      expect(await token.getResourceMeta(2)).to.eql(defaultResource2);
     });
   });
 });

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -63,7 +63,7 @@ describe('MultiResourceMock Other Behavior', async function () {
 
     it('cannot get non existing resource', async function () {
       const id = bn(9999);
-      await expect(token.getResource(id)).to.be.revertedWithCustomError(
+      await expect(token.getResourceMeta(id)).to.be.revertedWithCustomError(
         token,
         'RMRKNoResourceMatchingId',
       );
@@ -119,14 +119,13 @@ describe('MultiResourceMock Other Behavior', async function () {
 
       const pendingIds = await token.getPendingResources(tokenId);
       expect(await renderUtils.getResourcesById(token.address, pendingIds)).to.be.eql([
-        [resId, 'data1'],
-        [resId2, 'data2'],
+        'data1',
+        'data2',
       ]);
 
-      expect(await renderUtils.getPendingResourceByIndex(token.address, tokenId, 0)).to.eql([
-        resId,
+      expect(await renderUtils.getPendingResourceByIndex(token.address, tokenId, 0)).to.eql(
         'data1',
-      ]);
+      );
     });
 
     it('cannot add non existing resource to token', async function () {

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -78,23 +78,21 @@ describe('Render Utils', async function () {
     });
 
     it('can get active resource by index', async function () {
-      expect(await renderUtils.getResourceByIndex(equip.address, tokenId, 0)).to.eql([
-        resId,
+      expect(await renderUtils.getResourceByIndex(equip.address, tokenId, 0)).to.eql(
         'ipfs://res1.jpg',
-      ]);
+      );
     });
 
     it('can get pending resource by index', async function () {
-      expect(await renderUtils.getPendingResourceByIndex(equip.address, tokenId, 0)).to.eql([
-        resId2,
+      expect(await renderUtils.getPendingResourceByIndex(equip.address, tokenId, 0)).to.eql(
         'ipfs://res2.jpg',
-      ]);
+      );
     });
 
     it('can get resources by id', async function () {
       expect(await renderUtils.getResourcesById(equip.address, [resId, resId2])).to.eql([
-        [resId, 'ipfs://res1.jpg'],
-        [resId2, 'ipfs://res2.jpg'],
+        'ipfs://res1.jpg',
+        'ipfs://res2.jpg',
       ]);
     });
   });


### PR DESCRIPTION
This was done in the past but removed to make contracts easier to understand. We kind of regret.
The approvals for resources are not included on the Abstract since the implementation defers, on contracts using nesting approvals need to have 2 levels.

The only negative side effect from this is that code is slightly harder to understand, because part of the implementation is in another file, and some people might not be familiarized with the concept of an abstract class.
The good side is that we maintain a code of >200 lines in a single place instead of 4.