### PR TITLE
Changes getResource for getResourceMeta

### DIFF
--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -378,14 +378,14 @@ contract RMRKEquippable is RMRKNesting, AbstractMultiResource, IRMRKEquippable {
         virtual
         returns (ExtendedResource memory)
     {
-        Resource memory resource = getResource(resourceId);
+        string memory meta = getResourceMeta(resourceId);
 
         return
             ExtendedResource({
-                id: resource.id,
-                equippableRefId: _equippableRefIds[resource.id],
-                baseAddress: _baseAddresses[resource.id],
-                metadataURI: resource.metadataURI
+                id: resourceId,
+                equippableRefId: _equippableRefIds[resourceId],
+                baseAddress: _baseAddresses[resourceId],
+                metadataURI: meta
             });
     }
 

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -393,14 +393,14 @@ contract RMRKExternalEquip is AbstractMultiResource, IRMRKExternalEquip {
         virtual
         returns (ExtendedResource memory)
     {
-        Resource memory resource = getResource(resourceId);
+        string memory meta = getResourceMeta(resourceId);
 
         return
             ExtendedResource({
-                id: resource.id,
-                equippableRefId: _equippableRefIds[resource.id],
-                baseAddress: _baseAddresses[resource.id],
-                metadataURI: resource.metadataURI
+                id: resourceId,
+                equippableRefId: _equippableRefIds[resourceId],
+                baseAddress: _baseAddresses[resourceId],
+                metadataURI: meta
             });
     }
 

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -60,6 +60,26 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     }
 
     /**
+     * @notice Fetches resource data for the token's active resource with the given index.
+     * @dev Resources are stored by reference mapping _resources[resourceId]
+     * @dev Can be overriden to implement enumerate, fallback or other custom logic
+     * @param tokenId the token ID to query
+     * @param resourceIndex from the token's active resources
+     * @return string with the meta
+     */
+    function getResourceMetaForToken(uint256 tokenId, uint64 resourceIndex)
+        public
+        view
+        virtual
+        returns (string memory)
+    {
+        if (resourceIndex >= getActiveResources(tokenId).length)
+            revert RMRKIndexOutOfRange();
+        uint64 resourceId = getActiveResources(tokenId)[resourceIndex];
+        return getResourceMeta(resourceId);
+    }
+
+    /**
      * @notice Returns array of all resource IDs.
      * @return uint64 array of all resource IDs.
      */

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -46,21 +46,17 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
      * @notice Fetches resource data by resourceID
      * @dev Resources are stored by reference mapping _resources[resourceId]
      * @param resourceId The resourceID to query
-     * @return Resource returns a Resource struct
+     * @return string with the meta
      */
-    function getResource(uint64 resourceId)
+    function getResourceMeta(uint64 resourceId)
         public
         view
         virtual
-        returns (Resource memory)
+        returns (string memory)
     {
-        string memory resourceData = _resources[resourceId];
-        if (bytes(resourceData).length == 0) revert RMRKNoResourceMatchingId();
-        Resource memory resource = Resource({
-            id: resourceId,
-            metadataURI: resourceData
-        });
-        return resource;
+        string memory meta = _resources[resourceId];
+        if (bytes(meta).length == 0) revert RMRKNoResourceMatchingId();
+        return meta;
     }
 
     /**

--- a/contracts/RMRK/multiresource/IRMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/IRMRKMultiResource.sol
@@ -186,6 +186,16 @@ interface IRMRKMultiResource is IERC165 {
         returns (string memory);
 
     /**
+     * @notice Fetches resource data for the token's active resource with the given index.
+     * @dev Resources are stored by reference mapping _resources[resourceId]
+     * @dev Can be overriden to implement enumerate, fallback or other custom logic
+     */
+    function getResourceMetaForToken(uint256 tokenId, uint64 resourceIndex)
+        external
+        view
+        returns (string memory);
+
+    /**
      * @notice Returns the ids of all stored resources
      */
     function getAllResources() external view returns (uint64[] memory);

--- a/contracts/RMRK/multiresource/IRMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/IRMRKMultiResource.sol
@@ -138,7 +138,7 @@ interface IRMRKMultiResource is IERC165 {
 
     /**
      * @notice Returns IDs of active resources of `tokenId`.
-     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResource(resourceId)`
+     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResourceMeta(resourceId)`
      */
     function getActiveResources(uint256 tokenId)
         external
@@ -147,7 +147,7 @@ interface IRMRKMultiResource is IERC165 {
 
     /**
      * @notice Returns IDs of pending resources of `tokenId`.
-     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResource(resourceId)`
+     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResourceMeta(resourceId)`
      */
     function getPendingResources(uint256 tokenId)
         external
@@ -166,7 +166,7 @@ interface IRMRKMultiResource is IERC165 {
     /**
      * @notice Returns the resource which will be overridden if resourceId is accepted from
      * a pending resource array on `tokenId`.
-     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResource(resourceId)`
+     * Resource data is stored by reference, in order to access the data corresponding to the id, call `getResourceMeta(resourceId)`
      */
     function getResourceOverwrites(uint256 tokenId, uint64 resourceId)
         external
@@ -180,10 +180,10 @@ interface IRMRKMultiResource is IERC165 {
      * Custom data is intended to be stored as generic bytes and decode by various protocols on an as-needed basis
      *
      */
-    function getResource(uint64 resourceId)
+    function getResourceMeta(uint64 resourceId)
         external
         view
-        returns (Resource memory);
+        returns (string memory);
 
     /**
      * @notice Returns the ids of all stored resources

--- a/contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol
@@ -18,7 +18,7 @@ interface IRMRKMultiResourceRenderUtils is IERC165 {
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view returns (IRMRKMultiResource.Resource memory);
+    ) external view returns (string memory);
 
     /**
      * @notice Returns `Resource` object at `index` of active resource array on `tokenId`
@@ -32,7 +32,7 @@ interface IRMRKMultiResourceRenderUtils is IERC165 {
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view returns (IRMRKMultiResource.Resource memory);
+    ) external view returns (string memory);
 
     /**
      * @notice Returns `Resource` objects for the given ids
@@ -44,5 +44,5 @@ interface IRMRKMultiResourceRenderUtils is IERC165 {
     function getResourcesById(address target, uint64[] calldata resourceIds)
         external
         view
-        returns (IRMRKMultiResource.Resource[] memory);
+        returns (string[] memory);
 }

--- a/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
@@ -49,8 +49,7 @@ contract RMRKMultiResourceRenderUtils is IRMRKMultiResourceRenderUtils {
     {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint256 len = resourceIds.length;
-        string[]
-            memory resources = new string[](len);
+        string[] memory resources = new string[](len);
         for (uint256 i; i < len; ) {
             resources[i] = target_.getResourceMeta(resourceIds[i]);
             unchecked {

--- a/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
@@ -25,34 +25,34 @@ contract RMRKMultiResourceRenderUtils is IRMRKMultiResourceRenderUtils {
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view virtual returns (IRMRKMultiResource.Resource memory) {
+    ) external view virtual returns (string memory) {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint64 resourceId = target_.getActiveResources(tokenId)[index];
-        return target_.getResource(resourceId);
+        return target_.getResourceMeta(resourceId);
     }
 
     function getPendingResourceByIndex(
         address target,
         uint256 tokenId,
         uint256 index
-    ) external view virtual returns (IRMRKMultiResource.Resource memory) {
+    ) external view virtual returns (string memory) {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint64 resourceId = target_.getPendingResources(tokenId)[index];
-        return target_.getResource(resourceId);
+        return target_.getResourceMeta(resourceId);
     }
 
     function getResourcesById(address target, uint64[] calldata resourceIds)
         public
         view
         virtual
-        returns (IRMRKMultiResource.Resource[] memory)
+        returns (string[] memory)
     {
         IRMRKMultiResource target_ = IRMRKMultiResource(target);
         uint256 len = resourceIds.length;
-        IRMRKMultiResource.Resource[]
-            memory resources = new IRMRKMultiResource.Resource[](len);
+        string[]
+            memory resources = new string[](len);
         for (uint256 i; i < len; ) {
-            resources[i] = target_.getResource(resourceIds[i]);
+            resources[i] = target_.getResourceMeta(resourceIds[i]);
             unchecked {
                 ++i;
             }

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -193,10 +193,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullPendingExtendedResources === undefined) {
         const pendingResources = await chunkyEquip.getPendingResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, pendingResources)).to.be.eql(
-          [
-            [resId, metaURIDefault],
-            [resId2, metaURIDefault],
-          ],
+          [metaURIDefault, metaURIDefault],
         );
       } else {
         const pending = await chunkyEquip.getFullPendingExtendedResources(tokenId);
@@ -289,7 +286,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.eql([
-          [resId, metaURIDefault],
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.eql([
@@ -323,8 +320,8 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.eql([
-          [resId2, metaURIDefault],
-          [resId, metaURIDefault],
+          metaURIDefault,
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.eql([
@@ -412,7 +409,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.be.eql([
-          [resId2, metaURIDefault],
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.be.eql([
@@ -434,7 +431,7 @@ async function shouldBehaveLikeEquippableResources(
       if (chunkyEquip.getFullExtendedResources === undefined) {
         const activeResources = await chunkyEquip.getActiveResources(tokenId);
         expect(await renderUtils.getResourcesById(chunkyEquip.address, activeResources)).to.be.eql([
-          [resId, metaURIDefault],
+          metaURIDefault,
         ]);
       } else {
         expect(await chunkyEquip.getFullExtendedResources(tokenId)).to.be.eql([

--- a/test/behavior/multiresource.ts
+++ b/test/behavior/multiresource.ts
@@ -35,7 +35,7 @@ async function shouldBehaveLikeMultiResource(
     });
 
     it('can support IMultiResource', async function () {
-      expect(await this.token.supportsInterface('0x1c21cc26')).to.equal(true);
+      expect(await this.token.supportsInterface('0xc65a6425')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -214,6 +214,13 @@ async function shouldBehaveLikeMultiResource(
         expect(await this.renderUtils.getResourceByIndex(this.token.address, tokenId, 0)).to.eql(
           resData1,
         );
+
+        // Other ways of getting the token info:
+        if (this.token.tokenURI !== undefined) {
+          expect(await this.token.tokenURI(tokenId)).equal('');
+        }
+        expect(await this.token.getResourceMeta(resId1)).equal(resData1);
+        expect(await this.token.getResourceMetaForToken(tokenId, 0)).equal(resData1);
       });
 
       it('can get all resources', async function () {

--- a/test/behavior/multiresource.ts
+++ b/test/behavior/multiresource.ts
@@ -35,7 +35,7 @@ async function shouldBehaveLikeMultiResource(
     });
 
     it('can support IMultiResource', async function () {
-      expect(await this.token.supportsInterface('0xcb2f8f94')).to.equal(true);
+      expect(await this.token.supportsInterface('0x1c21cc26')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -134,7 +134,7 @@ async function shouldBehaveLikeMultiResource(
         activeResources = await this.token.getActiveResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, activeResources),
-        ).to.be.eql([[resId2, metaURIDefault]]);
+        ).to.be.eql([metaURIDefault]);
         // Overwrite should be gone
         expect(await this.token.getResourceOverwrites(tokenId, pendingResources[0])).to.eql(bn(0));
       });
@@ -148,7 +148,7 @@ async function shouldBehaveLikeMultiResource(
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, activeResources),
-        ).to.be.eql([[resId, metaURIDefault]]);
+        ).to.be.eql([metaURIDefault]);
       });
 
       it('can reject resource and overwrites are cleared', async function () {
@@ -197,10 +197,7 @@ async function shouldBehaveLikeMultiResource(
         let pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([
-          [resId1, resData1],
-          [resId2, resData2],
-        ]);
+        ).to.eql([resData1, resData2]);
 
         await expect(this.token.connect(tokenOwner).acceptResource(tokenId, 0))
           .to.emit(this.token, 'ResourceAccepted')
@@ -208,16 +205,15 @@ async function shouldBehaveLikeMultiResource(
 
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(await this.renderUtils.getResourcesById(this.token.address, activeResources)).to.eql(
-          [[resId1, resData1]],
+          [resData1],
         );
         pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
-        expect(await this.renderUtils.getResourceByIndex(this.token.address, tokenId, 0)).to.eql([
-          resId1,
+        ).to.eql([resData2]);
+        expect(await this.renderUtils.getResourceByIndex(this.token.address, tokenId, 0)).to.eql(
           resData1,
-        ]);
+        );
       });
 
       it('can get all resources', async function () {
@@ -239,10 +235,7 @@ async function shouldBehaveLikeMultiResource(
           this.token.address,
           activeResources,
         );
-        expect(accepted).to.eql([
-          [resId2, resData2],
-          [resId1, resData1],
-        ]);
+        expect(accepted).to.eql([resData2, resData1]);
       });
 
       it('can accept resource if approved', async function () {
@@ -251,7 +244,7 @@ async function shouldBehaveLikeMultiResource(
 
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(await this.renderUtils.getResourcesById(this.token.address, activeResources)).to.eql(
-          [[resId1, resData1]],
+          [resData1],
         );
       });
 
@@ -261,7 +254,7 @@ async function shouldBehaveLikeMultiResource(
 
         const activeResources = await this.token.getActiveResources(tokenId);
         expect(await this.renderUtils.getResourcesById(this.token.address, activeResources)).to.eql(
-          [[resId1, resData1]],
+          [resData1],
         );
       });
 
@@ -293,10 +286,7 @@ async function shouldBehaveLikeMultiResource(
         let pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([
-          [resId1, resData1],
-          [resId2, resData2],
-        ]);
+        ).to.eql([resData1, resData2]);
 
         await expect(this.token.connect(tokenOwner).rejectResource(tokenId, 0))
           .to.emit(this.token, 'ResourceRejected')
@@ -306,7 +296,7 @@ async function shouldBehaveLikeMultiResource(
         pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
+        ).to.eql([resData2]);
       });
 
       it('can reject resource if approved', async function () {
@@ -317,7 +307,7 @@ async function shouldBehaveLikeMultiResource(
         const pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
+        ).to.eql([resData2]);
       });
 
       it('can reject resource if approved for all', async function () {
@@ -328,7 +318,7 @@ async function shouldBehaveLikeMultiResource(
         const pendingResources = await this.token.getPendingResources(tokenId);
         expect(
           await this.renderUtils.getResourcesById(this.token.address, pendingResources),
-        ).to.eql([[resId2, resData2]]);
+        ).to.eql([resData2]);
       });
 
       it('can reject all resources', async function () {

--- a/test/externalEquip.ts
+++ b/test/externalEquip.ts
@@ -209,7 +209,7 @@ async function multiResourceFixture() {
 
 // --------------- EQUIPPABLE BEHAVIOR -----------------------
 
-describe('EquippableMock with Parts', async () => {
+describe('ExternalEquippableMock with Parts', async () => {
   beforeEach(async function () {
     const { base, neon, neonEquip, mask, maskEquip, view } = await loadFixture(partsFixture);
 
@@ -224,7 +224,7 @@ describe('EquippableMock with Parts', async () => {
   shouldBehaveLikeEquippableWithParts();
 });
 
-describe('EquippableMock with Slots', async () => {
+describe('ExternalEquippableMock with Slots', async () => {
   beforeEach(async function () {
     const {
       base,
@@ -254,7 +254,7 @@ describe('EquippableMock with Slots', async () => {
   shouldBehaveLikeEquippableWithSlots(nestMintFromMock);
 });
 
-describe('EquippableMock Resources', async () => {
+describe('ExternalEquippableMock Resources', async () => {
   beforeEach(async function () {
     const { nesting, equip, renderUtils } = await loadFixture(resourcesFixture);
     this.nesting = nesting;
@@ -293,7 +293,7 @@ describe('EquippableMock Resources', async () => {
 
 // --------------- MULTI RESOURCE BEHAVIOR -----------------------
 
-describe('EquippableMock MR behavior', async () => {
+describe('ExternalEquippableMock MR behavior', async () => {
   let nextTokenId = 1;
   let nesting: Contract;
   let equip: Contract;

--- a/test/implementations/equippable.ts
+++ b/test/implementations/equippable.ts
@@ -144,7 +144,7 @@ async function equipFixture() {
 
 // --------------- EQUIPPABLE BEHAVIOR -----------------------
 
-describe('EquippableMock with Parts', async () => {
+describe('RMRKEquippableImpl with Parts', async () => {
   beforeEach(async function () {
     const { base, neon, mask, view } = await loadFixture(partsFixture);
 
@@ -159,7 +159,7 @@ describe('EquippableMock with Parts', async () => {
   shouldBehaveLikeEquippableWithParts();
 });
 
-describe('EquippableMock with Slots', async () => {
+describe('RMRKEquippableImpl with Slots', async () => {
   beforeEach(async function () {
     const { base, soldier, weapon, weaponGem, background, view } = await loadFixture(slotsFixture);
 
@@ -178,7 +178,7 @@ describe('EquippableMock with Slots', async () => {
   shouldBehaveLikeEquippableWithSlots(nestMintFromImpl);
 });
 
-describe('EquippableMock Resources', async () => {
+describe('RMRKEquippableImpl Resources', async () => {
   beforeEach(async function () {
     const { equip, renderUtils } = await loadFixture(resourcesFixture);
     this.nesting = equip;
@@ -200,7 +200,7 @@ describe('EquippableMock Resources', async () => {
 
 // --------------- MULTI RESOURCE BEHAVIOR -----------------------
 
-describe('EquippableMock MR behavior', async () => {
+describe('RMRKEquippableImpl MR behavior', async () => {
   let equip: Contract;
   let renderUtils: Contract;
 
@@ -220,7 +220,7 @@ describe('EquippableMock MR behavior', async () => {
 
 // --------------- MULTI RESOURCE BEHAVIOR END ------------------------
 
-describe('EquippableMock Minting', async function () {
+describe('RMRKEquippableImpl Minting', async function () {
   beforeEach(async function () {
     const { equip } = await loadFixture(equipFixture);
     this.token = equip;

--- a/test/implementations/multiresource.ts
+++ b/test/implementations/multiresource.ts
@@ -89,8 +89,8 @@ describe('MultiResourceImpl Other Behavior', async () => {
       await token.connect(owner).addResourceEntry(defaultResource1, []);
       await token.connect(owner).addResourceEntry(defaultResource2, []);
 
-      expect(await token.getResource(1)).to.eql([bn(1), defaultResource1]);
-      expect(await token.getResource(2)).to.eql([bn(2), defaultResource2]);
+      expect(await token.getResourceMeta(1)).to.eql(defaultResource1);
+      expect(await token.getResourceMeta(2)).to.eql(defaultResource2);
     });
   });
 });

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -63,7 +63,7 @@ describe('MultiResourceMock Other Behavior', async function () {
 
     it('cannot get non existing resource', async function () {
       const id = bn(9999);
-      await expect(token.getResource(id)).to.be.revertedWithCustomError(
+      await expect(token.getResourceMeta(id)).to.be.revertedWithCustomError(
         token,
         'RMRKNoResourceMatchingId',
       );
@@ -119,14 +119,13 @@ describe('MultiResourceMock Other Behavior', async function () {
 
       const pendingIds = await token.getPendingResources(tokenId);
       expect(await renderUtils.getResourcesById(token.address, pendingIds)).to.be.eql([
-        [resId, 'data1'],
-        [resId2, 'data2'],
+        'data1',
+        'data2',
       ]);
 
-      expect(await renderUtils.getPendingResourceByIndex(token.address, tokenId, 0)).to.eql([
-        resId,
+      expect(await renderUtils.getPendingResourceByIndex(token.address, tokenId, 0)).to.eql(
         'data1',
-      ]);
+      );
     });
 
     it('cannot add non existing resource to token', async function () {

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -78,23 +78,21 @@ describe('Render Utils', async function () {
     });
 
     it('can get active resource by index', async function () {
-      expect(await renderUtils.getResourceByIndex(equip.address, tokenId, 0)).to.eql([
-        resId,
+      expect(await renderUtils.getResourceByIndex(equip.address, tokenId, 0)).to.eql(
         'ipfs://res1.jpg',
-      ]);
+      );
     });
 
     it('can get pending resource by index', async function () {
-      expect(await renderUtils.getPendingResourceByIndex(equip.address, tokenId, 0)).to.eql([
-        resId2,
+      expect(await renderUtils.getPendingResourceByIndex(equip.address, tokenId, 0)).to.eql(
         'ipfs://res2.jpg',
-      ]);
+      );
     });
 
     it('can get resources by id', async function () {
       expect(await renderUtils.getResourcesById(equip.address, [resId, resId2])).to.eql([
-        [resId, 'ipfs://res1.jpg'],
-        [resId2, 'ipfs://res2.jpg'],
+        'ipfs://res1.jpg',
+        'ipfs://res2.jpg',
       ]);
     });
   });


### PR DESCRIPTION
Returning a Resource object with the redundant Id and the meta is not smart
It adds contract size, gas and makes it a bit harder for UI to use.