### PR TITLE
Adds MultiResource.getResourceMetaForToken(tokenId, resourceIndex)

### DIFF
--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -60,6 +60,26 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     }
 
     /**
+     * @notice Fetches resource data for the token's active resource with the given index.
+     * @dev Resources are stored by reference mapping _resources[resourceId]
+     * @dev Can be overriden to implement enumerate, fallback or other custom logic
+     * @param tokenId the token ID to query
+     * @param resourceIndex from the token's active resources
+     * @return string with the meta
+     */
+    function getResourceMetaForToken(uint256 tokenId, uint64 resourceIndex)
+        public
+        view
+        virtual
+        returns (string memory)
+    {
+        if (resourceIndex >= getActiveResources(tokenId).length)
+            revert RMRKIndexOutOfRange();
+        uint64 resourceId = getActiveResources(tokenId)[resourceIndex];
+        return getResourceMeta(resourceId);
+    }
+
+    /**
      * @notice Returns array of all resource IDs.
      * @return uint64 array of all resource IDs.
      */

--- a/contracts/RMRK/multiresource/IRMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/IRMRKMultiResource.sol
@@ -186,6 +186,16 @@ interface IRMRKMultiResource is IERC165 {
         returns (string memory);
 
     /**
+     * @notice Fetches resource data for the token's active resource with the given index.
+     * @dev Resources are stored by reference mapping _resources[resourceId]
+     * @dev Can be overriden to implement enumerate, fallback or other custom logic
+     */
+    function getResourceMetaForToken(uint256 tokenId, uint64 resourceIndex)
+        external
+        view
+        returns (string memory);
+
+    /**
      * @notice Returns the ids of all stored resources
      */
     function getAllResources() external view returns (uint64[] memory);

--- a/test/behavior/multiresource.ts
+++ b/test/behavior/multiresource.ts
@@ -35,7 +35,7 @@ async function shouldBehaveLikeMultiResource(
     });
 
     it('can support IMultiResource', async function () {
-      expect(await this.token.supportsInterface('0x1c21cc26')).to.equal(true);
+      expect(await this.token.supportsInterface('0xc65a6425')).to.equal(true);
     });
 
     it('cannot support other interfaceId', async function () {
@@ -214,6 +214,13 @@ async function shouldBehaveLikeMultiResource(
         expect(await this.renderUtils.getResourceByIndex(this.token.address, tokenId, 0)).to.eql(
           resData1,
         );
+
+        // Other ways of getting the token info:
+        if (this.token.tokenURI !== undefined) {
+          expect(await this.token.tokenURI(tokenId)).equal('');
+        }
+        expect(await this.token.getResourceMeta(resId1)).equal(resData1);
+        expect(await this.token.getResourceMetaForToken(tokenId, 0)).equal(resData1);
       });
 
       it('can get all resources', async function () {


### PR DESCRIPTION
The purpose of this is to have a standard function which implements can override to include custom logic such as fallback and enumerated resources.

This would be the recommended method for marketplaces and similar to access resources.