### PR TITLE
Adds IRMRKTypedMultiResource

### DIFF
--- a/contracts/RMRK/extension/typedMultiResource/IRMRKTypedMultiResource.sol
+++ b/contracts/RMRK/extension/typedMultiResource/IRMRKTypedMultiResource.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../multiresource/IRMRKMultiResource.sol";
+
+interface IRMRKTypedMultiResource is IRMRKMultiResource {
+    /**
+     * @notice Returns type of the resource
+     */
+    function getResourceType(uint64 resourceId)
+        external
+        view
+        returns (string memory);
+}

--- a/contracts/RMRK/extension/typedMultiResource/RMRKNestingTypedMultiResource.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKNestingTypedMultiResource.sol
@@ -3,14 +3,12 @@
 pragma solidity ^0.8.15;
 
 import "../../nesting/RMRKNestingMultiResource.sol";
-import "./IRMRKTypedMultiResource.sol";
+import "./RMRKTypedMultiResourceAbstract.sol";
 
 contract RMRKNestingTypedMultiResource is
-    IRMRKTypedMultiResource,
+    RMRKTypedMultiResourceAbstract,
     RMRKNestingMultiResource
 {
-    mapping(uint64 => string) private _resourceTypes;
-
     constructor(string memory name, string memory symbol)
         RMRKNestingMultiResource(name, symbol)
     {}
@@ -28,22 +26,5 @@ contract RMRKNestingTypedMultiResource is
         return
             RMRKNestingMultiResource.supportsInterface(interfaceId) ||
             interfaceId == type(IRMRKTypedMultiResource).interfaceId;
-    }
-
-    function _addTypedResourceEntry(
-        uint64 resourceId,
-        string memory metadataURI,
-        string memory type_
-    ) internal {
-        _addResourceEntry(resourceId, metadataURI);
-        _resourceTypes[resourceId] = type_;
-    }
-
-    function getResourceType(uint64 resourceId)
-        public
-        view
-        returns (string memory)
-    {
-        return _resourceTypes[resourceId];
     }
 }

--- a/contracts/RMRK/extension/typedMultiResource/RMRKNestingTypedMultiResource.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKNestingTypedMultiResource.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../nesting/RMRKNestingMultiResource.sol";
+import "./IRMRKTypedMultiResource.sol";
+
+contract RMRKNestingTypedMultiResource is
+    IRMRKTypedMultiResource,
+    RMRKNestingMultiResource
+{
+    mapping(uint64 => string) private _resourceTypes;
+
+    constructor(string memory name, string memory symbol)
+        RMRKNestingMultiResource(name, symbol)
+    {}
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, RMRKNestingMultiResource)
+        returns (bool)
+    {
+        return
+            RMRKNestingMultiResource.supportsInterface(interfaceId) ||
+            interfaceId == type(IRMRKTypedMultiResource).interfaceId;
+    }
+
+    function _addTypedResourceEntry(
+        uint64 resourceId,
+        string memory metadataURI,
+        string memory type_
+    ) internal {
+        _addResourceEntry(resourceId, metadataURI);
+        _resourceTypes[resourceId] = type_;
+    }
+
+    function getResourceType(uint64 resourceId)
+        public
+        view
+        returns (string memory)
+    {
+        return _resourceTypes[resourceId];
+    }
+}

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedEquippable.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedEquippable.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../equippable/RMRKEquippable.sol";
+import "./IRMRKTypedMultiResource.sol";
+
+contract RMRKTypedEquippable is IRMRKTypedMultiResource, RMRKEquippable {
+    mapping(uint64 => string) private _resourceTypes;
+
+    constructor(string memory name, string memory symbol)
+        RMRKEquippable(name, symbol)
+    {}
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, RMRKEquippable)
+        returns (bool)
+    {
+        return
+            RMRKEquippable.supportsInterface(interfaceId) ||
+            interfaceId == type(IRMRKTypedMultiResource).interfaceId;
+    }
+
+    function _addTypedResourceEntry(
+        ExtendedResource memory resource,
+        uint64[] calldata fixedPartIds,
+        uint64[] calldata slotPartIds,
+        string memory type_
+    ) internal {
+        _addResourceEntry(resource, fixedPartIds, slotPartIds);
+        _resourceTypes[resource.id] = type_;
+    }
+
+    function getResourceType(uint64 resourceId)
+        public
+        view
+        returns (string memory)
+    {
+        return _resourceTypes[resourceId];
+    }
+}

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedEquippable.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedEquippable.sol
@@ -3,11 +3,9 @@
 pragma solidity ^0.8.15;
 
 import "../../equippable/RMRKEquippable.sol";
-import "./IRMRKTypedMultiResource.sol";
+import "./RMRKTypedMultiResourceAbstract.sol";
 
-contract RMRKTypedEquippable is IRMRKTypedMultiResource, RMRKEquippable {
-    mapping(uint64 => string) private _resourceTypes;
-
+contract RMRKTypedEquippable is RMRKTypedMultiResourceAbstract, RMRKEquippable {
     constructor(string memory name, string memory symbol)
         RMRKEquippable(name, symbol)
     {}
@@ -25,23 +23,5 @@ contract RMRKTypedEquippable is IRMRKTypedMultiResource, RMRKEquippable {
         return
             RMRKEquippable.supportsInterface(interfaceId) ||
             interfaceId == type(IRMRKTypedMultiResource).interfaceId;
-    }
-
-    function _addTypedResourceEntry(
-        ExtendedResource memory resource,
-        uint64[] calldata fixedPartIds,
-        uint64[] calldata slotPartIds,
-        string memory type_
-    ) internal {
-        _addResourceEntry(resource, fixedPartIds, slotPartIds);
-        _resourceTypes[resource.id] = type_;
-    }
-
-    function getResourceType(uint64 resourceId)
-        public
-        view
-        returns (string memory)
-    {
-        return _resourceTypes[resourceId];
     }
 }

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedExternalEquippable.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedExternalEquippable.sol
@@ -3,14 +3,13 @@
 pragma solidity ^0.8.15;
 
 import "../../equippable/RMRKExternalEquip.sol";
-import "./IRMRKTypedMultiResource.sol";
+import "./RMRKTypedMultiResourceAbstract.sol";
 
-contract RMRKTypedExternalEquippable is IRMRKTypedMultiResource, RMRKExternalEquip {
-    mapping(uint64 => string) private _resourceTypes;
-
-    constructor(address nestingAddress)
-        RMRKExternalEquip(nestingAddress)
-    {}
+contract RMRKTypedExternalEquippable is
+    RMRKTypedMultiResourceAbstract,
+    RMRKExternalEquip
+{
+    constructor(address nestingAddress) RMRKExternalEquip(nestingAddress) {}
 
     /**
      * @dev See {IERC165-supportsInterface}.
@@ -25,23 +24,5 @@ contract RMRKTypedExternalEquippable is IRMRKTypedMultiResource, RMRKExternalEqu
         return
             RMRKExternalEquip.supportsInterface(interfaceId) ||
             interfaceId == type(IRMRKTypedMultiResource).interfaceId;
-    }
-
-    function _addTypedResourceEntry(
-        ExtendedResource memory resource,
-        uint64[] calldata fixedPartIds,
-        uint64[] calldata slotPartIds,
-        string memory type_
-    ) internal {
-        _addResourceEntry(resource, fixedPartIds, slotPartIds);
-        _resourceTypes[resource.id] = type_;
-    }
-
-    function getResourceType(uint64 resourceId)
-        public
-        view
-        returns (string memory)
-    {
-        return _resourceTypes[resourceId];
     }
 }

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedExternalEquippable.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedExternalEquippable.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../equippable/RMRKExternalEquip.sol";
+import "./IRMRKTypedMultiResource.sol";
+
+contract RMRKTypedExternalEquippable is IRMRKTypedMultiResource, RMRKExternalEquip {
+    mapping(uint64 => string) private _resourceTypes;
+
+    constructor(address nestingAddress)
+        RMRKExternalEquip(nestingAddress)
+    {}
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, RMRKExternalEquip)
+        returns (bool)
+    {
+        return
+            RMRKExternalEquip.supportsInterface(interfaceId) ||
+            interfaceId == type(IRMRKTypedMultiResource).interfaceId;
+    }
+
+    function _addTypedResourceEntry(
+        ExtendedResource memory resource,
+        uint64[] calldata fixedPartIds,
+        uint64[] calldata slotPartIds,
+        string memory type_
+    ) internal {
+        _addResourceEntry(resource, fixedPartIds, slotPartIds);
+        _resourceTypes[resource.id] = type_;
+    }
+
+    function getResourceType(uint64 resourceId)
+        public
+        view
+        returns (string memory)
+    {
+        return _resourceTypes[resourceId];
+    }
+}

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../multiresource/RMRKMultiResource.sol";
+import "./IRMRKTypedMultiResource.sol";
+
+contract RMRKTypedMultiResource is IRMRKTypedMultiResource, RMRKMultiResource {
+    mapping(uint64 => string) private _resourceTypes;
+
+    constructor(string memory name, string memory symbol)
+        RMRKMultiResource(name, symbol)
+    {}
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, RMRKMultiResource)
+        returns (bool)
+    {
+        return
+            RMRKMultiResource.supportsInterface(interfaceId) ||
+            interfaceId == type(IRMRKTypedMultiResource).interfaceId;
+    }
+
+    function _addTypedResourceEntry(
+        uint64 resourceId,
+        string memory metadataURI,
+        string memory type_
+    ) internal {
+        _addResourceEntry(resourceId, metadataURI);
+        _resourceTypes[resourceId] = type_;
+    }
+
+    function getResourceType(uint64 resourceId)
+        public
+        view
+        returns (string memory)
+    {
+        return _resourceTypes[resourceId];
+    }
+}

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol
@@ -3,11 +3,12 @@
 pragma solidity ^0.8.15;
 
 import "../../multiresource/RMRKMultiResource.sol";
-import "./IRMRKTypedMultiResource.sol";
+import "./RMRKTypedMultiResourceAbstract.sol";
 
-contract RMRKTypedMultiResource is IRMRKTypedMultiResource, RMRKMultiResource {
-    mapping(uint64 => string) private _resourceTypes;
-
+contract RMRKTypedMultiResource is
+    RMRKTypedMultiResourceAbstract,
+    RMRKMultiResource
+{
     constructor(string memory name, string memory symbol)
         RMRKMultiResource(name, symbol)
     {}
@@ -25,22 +26,5 @@ contract RMRKTypedMultiResource is IRMRKTypedMultiResource, RMRKMultiResource {
         return
             RMRKMultiResource.supportsInterface(interfaceId) ||
             interfaceId == type(IRMRKTypedMultiResource).interfaceId;
-    }
-
-    function _addTypedResourceEntry(
-        uint64 resourceId,
-        string memory metadataURI,
-        string memory type_
-    ) internal {
-        _addResourceEntry(resourceId, metadataURI);
-        _resourceTypes[resourceId] = type_;
-    }
-
-    function getResourceType(uint64 resourceId)
-        public
-        view
-        returns (string memory)
-    {
-        return _resourceTypes[resourceId];
     }
 }

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResourceAbstract.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResourceAbstract.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "./IRMRKTypedMultiResource.sol";
+
+abstract contract RMRKTypedMultiResourceAbstract is IRMRKTypedMultiResource {
+    mapping(uint64 => string) private _resourceTypes;
+
+    function getResourceType(uint64 resourceId)
+        public
+        view
+        returns (string memory)
+    {
+        return _resourceTypes[resourceId];
+    }
+
+    function _setResourceType(uint64 resourceId, string memory type_) internal {
+        _resourceTypes[resourceId] = type_;
+    }
+}

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -261,7 +261,8 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
         (address immediateOwner, , ) = rmrkOwnerOf(tokenId);
         if (immediateOwner != from) revert ERC721TransferFromIncorrectOwner();
         if (to == address(0)) revert ERC721TransferToTheZeroAddress();
-        if (to == address(this) && tokenId == destinationId) revert RMRKNestingTransferToSelf();
+        if (to == address(this) && tokenId == destinationId)
+            revert RMRKNestingTransferToSelf();
 
         // Destination contract checks:
         // It seems redundant, but otherwise it would revert with no error

--- a/contracts/mocks/extensions/RMRKNestingTypedMultiResourceMock.sol
+++ b/contracts/mocks/extensions/RMRKNestingTypedMultiResourceMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../RMRK/extension/typedMultiResource/RMRKNestingTypedMultiResource.sol";
+import "hardhat/console.sol";
+
+error RMRKTokenHasNoResourcesWithType();
+
+contract RMRKNestingTypedMultiResourceMock is RMRKNestingTypedMultiResource {
+    constructor(string memory name, string memory symbol)
+        RMRKNestingTypedMultiResource(name, symbol)
+    {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function addResourceToToken(
+        uint256 tokenId,
+        uint64 resourceId,
+        uint64 overwrites
+    ) external {
+        _requireMinted(tokenId);
+        _addResourceToToken(tokenId, resourceId, overwrites);
+    }
+
+    function addTypedResourceEntry(
+        uint64 id,
+        string memory metadataURI,
+        string memory type_
+    ) external {
+        _addTypedResourceEntry(id, metadataURI, type_);
+    }
+}

--- a/contracts/mocks/extensions/RMRKNestingTypedMultiResourceMock.sol
+++ b/contracts/mocks/extensions/RMRKNestingTypedMultiResourceMock.sol
@@ -26,10 +26,11 @@ contract RMRKNestingTypedMultiResourceMock is RMRKNestingTypedMultiResource {
     }
 
     function addTypedResourceEntry(
-        uint64 id,
+        uint64 resourceId,
         string memory metadataURI,
         string memory type_
     ) external {
-        _addTypedResourceEntry(id, metadataURI, type_);
+        _addResourceEntry(resourceId, metadataURI);
+        _setResourceType(resourceId, type_);
     }
 }

--- a/contracts/mocks/extensions/RMRKTypedEquippableMock.sol
+++ b/contracts/mocks/extensions/RMRKTypedEquippableMock.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../RMRK/extension/typedMultiResource/RMRKTypedEquippable.sol";
+import "hardhat/console.sol";
+
+error RMRKTokenHasNoResourcesWithType();
+
+contract RMRKTypedEquippableMock is RMRKTypedEquippable {
+    constructor(string memory name, string memory symbol)
+        RMRKTypedEquippable(name, symbol)
+    {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function addResourceToToken(
+        uint256 tokenId,
+        uint64 resourceId,
+        uint64 overwrites
+    ) external {
+        _requireMinted(tokenId);
+        _addResourceToToken(tokenId, resourceId, overwrites);
+    }
+
+    function addTypedResourceEntry(
+        ExtendedResource memory resource,
+        uint64[] calldata fixedPartIds,
+        uint64[] calldata slotPartIds,
+        string memory type_
+    ) external {
+        _addTypedResourceEntry(resource, fixedPartIds, slotPartIds, type_);
+    }
+}

--- a/contracts/mocks/extensions/RMRKTypedEquippableMock.sol
+++ b/contracts/mocks/extensions/RMRKTypedEquippableMock.sol
@@ -31,6 +31,7 @@ contract RMRKTypedEquippableMock is RMRKTypedEquippable {
         uint64[] calldata slotPartIds,
         string memory type_
     ) external {
-        _addTypedResourceEntry(resource, fixedPartIds, slotPartIds, type_);
+        _addResourceEntry(resource, fixedPartIds, slotPartIds);
+        _setResourceType(resource.id, type_);
     }
 }

--- a/contracts/mocks/extensions/RMRKTypedExternalEquippableMock.sol
+++ b/contracts/mocks/extensions/RMRKTypedExternalEquippableMock.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../RMRK/extension/typedMultiResource/RMRKTypedExternalEquippable.sol";
+
+error RMRKTokenHasNoResourcesWithType();
+
+contract RMRKTypedExternalEquippableMock is RMRKTypedExternalEquippable {
+    constructor(address nestingAddress)
+        RMRKTypedExternalEquippable(nestingAddress)
+    {}
+
+    function addResourceToToken(
+        uint256 tokenId,
+        uint64 resourceId,
+        uint64 overwrites
+    ) external {
+        _requireMinted(tokenId);
+        _addResourceToToken(tokenId, resourceId, overwrites);
+    }
+
+    function addTypedResourceEntry(
+        ExtendedResource memory resource,
+        uint64[] calldata fixedPartIds,
+        uint64[] calldata slotPartIds,
+        string memory type_
+    ) external {
+        _addTypedResourceEntry(resource, fixedPartIds, slotPartIds, type_);
+    }
+}

--- a/contracts/mocks/extensions/RMRKTypedExternalEquippableMock.sol
+++ b/contracts/mocks/extensions/RMRKTypedExternalEquippableMock.sol
@@ -26,6 +26,7 @@ contract RMRKTypedExternalEquippableMock is RMRKTypedExternalEquippable {
         uint64[] calldata slotPartIds,
         string memory type_
     ) external {
-        _addTypedResourceEntry(resource, fixedPartIds, slotPartIds, type_);
+        _addResourceEntry(resource, fixedPartIds, slotPartIds);
+        _setResourceType(resource.id, type_);
     }
 }

--- a/contracts/mocks/extensions/RMRKTypedMultiResourceMock.sol
+++ b/contracts/mocks/extensions/RMRKTypedMultiResourceMock.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.15;
 
 import "../../RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol";
-import "hardhat/console.sol";
 
 error RMRKTokenHasNoResourcesWithType();
 
@@ -55,7 +54,6 @@ contract RMRKTypedMultiResourceMock is RMRKTypedMultiResource {
                 resourceTypeEncoded == targetTypeEncoded &&
                 currentPrio < maxPriority
             ) {
-                console.log("Found at i: ", i);
                 maxPriority = currentPrio;
                 maxPriorityIndex = i;
             }

--- a/contracts/mocks/extensions/RMRKTypedMultiResourceMock.sol
+++ b/contracts/mocks/extensions/RMRKTypedMultiResourceMock.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol";
+import "hardhat/console.sol";
+
+error RMRKTokenHasNoResourcesWithType();
+
+contract RMRKTypedMultiResourceMock is RMRKTypedMultiResource {
+    uint16 private constant _LOWEST_POSSIBLE_PRIORITY = 2**16 - 1;
+
+    constructor(string memory name, string memory symbol)
+        RMRKTypedMultiResource(name, symbol)
+    {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function addResourceToToken(
+        uint256 tokenId,
+        uint64 resourceId,
+        uint64 overwrites
+    ) external {
+        _requireMinted(tokenId);
+        _addResourceToToken(tokenId, resourceId, overwrites);
+    }
+
+    function addTypedResourceEntry(
+        uint64 id,
+        string memory metadataURI,
+        string memory type_
+    ) external {
+        _addTypedResourceEntry(id, metadataURI, type_);
+    }
+
+    function getTopResourceMetaForTokenWithType(
+        uint256 tokenId,
+        string memory type_
+    ) external view returns (string memory) {
+        uint16[] memory priorities = getActiveResourcePriorities(tokenId);
+        uint64[] memory resources = getActiveResources(tokenId);
+        uint256 len = priorities.length;
+
+        uint16 maxPriority = _LOWEST_POSSIBLE_PRIORITY;
+        uint64 maxPriorityIndex = 0;
+        bytes32 targetTypeEncoded = keccak256(bytes(type_));
+        for (uint64 i; i < len; ) {
+            uint16 currentPrio = priorities[i];
+            bytes32 resourceTypeEncoded = keccak256(
+                bytes(getResourceType(resources[i]))
+            );
+            if (
+                resourceTypeEncoded == targetTypeEncoded &&
+                currentPrio < maxPriority
+            ) {
+                console.log("Found at i: ", i);
+                maxPriority = currentPrio;
+                maxPriorityIndex = i;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (maxPriority == _LOWEST_POSSIBLE_PRIORITY)
+            revert RMRKTokenHasNoResourcesWithType();
+        return getResourceMetaForToken(tokenId, maxPriorityIndex);
+    }
+}

--- a/contracts/mocks/extensions/RMRKTypedMultiResourceMock.sol
+++ b/contracts/mocks/extensions/RMRKTypedMultiResourceMock.sol
@@ -27,11 +27,12 @@ contract RMRKTypedMultiResourceMock is RMRKTypedMultiResource {
     }
 
     function addTypedResourceEntry(
-        uint64 id,
+        uint64 resourceId,
         string memory metadataURI,
         string memory type_
     ) external {
-        _addTypedResourceEntry(id, metadataURI, type_);
+        _addResourceEntry(resourceId, metadataURI);
+        _setResourceType(resourceId, type_);
     }
 
     function getTopResourceMetaForTokenWithType(

--- a/test/extensions/typedMultiResource.ts
+++ b/test/extensions/typedMultiResource.ts
@@ -134,6 +134,10 @@ describe('RMRKNestingTypedMultiResourceMock', async function () {
     expect(await typedNestingMultiResource.supportsInterface('0xc65a6425')).to.equal(true);
   });
 
+  it('can support INesting', async function () {
+    expect(await typedNestingMultiResource.supportsInterface('0xf790390a')).to.equal(true);
+  });
+
   it('can support IRMRKTypedMultiResource', async function () {
     expect(await typedNestingMultiResource.supportsInterface('0xb6a3032e')).to.equal(true);
   });
@@ -177,6 +181,14 @@ describe('RMRKTypedEquippableMock', async function () {
 
   it('can support IMultiResource', async function () {
     expect(await typedEquippable.supportsInterface('0xc65a6425')).to.equal(true);
+  });
+
+  it('can support INesting', async function () {
+    expect(await typedEquippable.supportsInterface('0xf790390a')).to.equal(true);
+  });
+
+  it('can support IEquippable', async function () {
+    expect(await typedEquippable.supportsInterface('0xd3a28ca0')).to.equal(true);
   });
 
   it('can support IRMRKTypedMultiResource', async function () {
@@ -242,6 +254,14 @@ describe('RMRKTypedExternalEquippableMock', async function () {
 
   it('can support IMultiResource', async function () {
     expect(await typedExternalEquippable.supportsInterface('0xc65a6425')).to.equal(true);
+  });
+
+  it('can support IEquippable', async function () {
+    expect(await typedExternalEquippable.supportsInterface('0xd3a28ca0')).to.equal(true);
+  });
+
+  it('can support IExternalEquip', async function () {
+    expect(await typedExternalEquippable.supportsInterface('0xe5383e6c')).to.equal(true);
   });
 
   it('can support IRMRKTypedMultiResource', async function () {

--- a/test/extensions/typedMultiResource.ts
+++ b/test/extensions/typedMultiResource.ts
@@ -1,0 +1,84 @@
+import { Contract } from 'ethers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { bn, mintFromMock } from '../utils';
+
+// --------------- FIXTURES -----------------------
+
+async function fixture() {
+  const factory = await ethers.getContractFactory('RMRKTypedMultiResourceMock');
+  const typedMultiResource = await factory.deploy('Chunky', 'CHNK');
+  await typedMultiResource.deployed();
+
+  return { typedMultiResource };
+}
+
+describe('RMRKTypedMultiResourceMock', async function () {
+  let owner: SignerWithAddress;
+  let typedMultiResource: Contract;
+  let tokenId: number;
+
+  const resId = bn(1);
+  const resId2 = bn(2);
+  const resId3 = bn(3);
+
+  beforeEach(async function () {
+    ({ typedMultiResource } = await loadFixture(fixture));
+
+    const signers = await ethers.getSigners();
+    owner = signers[0];
+
+    tokenId = await mintFromMock(typedMultiResource, owner.address);
+  });
+
+  it('can support IERC165', async function () {
+    expect(await typedMultiResource.supportsInterface('0x01ffc9a7')).to.equal(true);
+  });
+
+  it('can support IMultiResource', async function () {
+    expect(await typedMultiResource.supportsInterface('0xc65a6425')).to.equal(true);
+  });
+
+  it('can support IRMRKTypedMultiResource', async function () {
+    expect(await typedMultiResource.supportsInterface('0xb6a3032e')).to.equal(true);
+  });
+
+  it('does not support other interfaces', async function () {
+    expect(await typedMultiResource.supportsInterface('0xffffffff')).to.equal(false);
+  });
+
+  it('can add typed resources', async function () {
+    await typedMultiResource.addTypedResourceEntry(resId, 'ipfs://res1.jpg', 'image/jpeg');
+    expect(await typedMultiResource.getResourceType(resId)).to.eql('image/jpeg');
+  });
+
+  it('can get top resource by priority and type', async function () {
+    await typedMultiResource.addTypedResourceEntry(resId, 'ipfs://res1.jpg', 'image/jpeg');
+    await typedMultiResource.addTypedResourceEntry(resId2, 'ipfs://res2.pdf', 'application/pdf');
+    await typedMultiResource.addTypedResourceEntry(resId3, 'ipfs://res3.jpg', 'image/jpeg');
+    await typedMultiResource.addResourceToToken(tokenId, resId, 0);
+    await typedMultiResource.acceptResource(tokenId, 0);
+    await typedMultiResource.addResourceToToken(tokenId, resId2, 0);
+    await typedMultiResource.acceptResource(tokenId, 0);
+    await typedMultiResource.addResourceToToken(tokenId, resId3, 0);
+    await typedMultiResource.acceptResource(tokenId, 0);
+    console.log(await typedMultiResource.getActiveResources(tokenId));
+    await typedMultiResource.setPriority(tokenId, [1, 0, 2]); // Pdf has higher priority but it's the wanted type
+
+    expect(
+      await typedMultiResource.getTopResourceMetaForTokenWithType(tokenId, 'image/jpeg'),
+    ).to.eql('ipfs://res1.jpg');
+  });
+
+  it('cannot get top resource for if token has no resources with this type', async function () {
+    await typedMultiResource.addTypedResourceEntry(resId, 'ipfs://res1.jpg', 'image/jpeg');
+    await typedMultiResource.addResourceToToken(tokenId, resId, 0);
+    await typedMultiResource.acceptResource(tokenId, 0);
+
+    await expect(
+      typedMultiResource.getTopResourceMetaForTokenWithType(tokenId, 'application/pdf'),
+    ).to.be.revertedWithCustomError(typedMultiResource, 'RMRKTokenHasNoResourcesWithType');
+  });
+});

--- a/test/nestingExternalEquip.ts
+++ b/test/nestingExternalEquip.ts
@@ -73,10 +73,10 @@ describe('NestingWithEquippableMock ERC721 Behavior', function () {
   });
 
   describe('Interface support', function () {
-    it('supports NestingExternalEquip', async function () {
+    it('can support INestingExternalEquip', async function () {
       expect(await this.token.supportsInterface('0x8b7f3e99')).to.equal(true);
     });
-    it('supports IExternalNesting', async function () {
+    it('can support IExternalEquip', async function () {
       expect(await this.equip.supportsInterface('0xe5383e6c')).to.equal(true);
     });
 


### PR DESCRIPTION
This interface forces the user to implement a `getResourceType` method.
There are 4 core implementations available for each of the combinations that inherits from IMultiresource. Also 4 corresponding mocks to test the basics.

On the `RMRKTypedMultiResourceMock` there's additionally a utility function implemented to show how this could be used to get the highest priority resource for a given token, filtering by type: `getTopResourceMetaForTokenWithType`.