### PR TITLE
Checks for inheritance loop, up to 100 levels of nesting.

### DIFF
--- a/test/behavior/nesting.ts
+++ b/test/behavior/nesting.ts
@@ -808,6 +808,21 @@ async function shouldBehaveLikeNesting(
       ).to.be.revertedWithCustomError(child, 'RMRKNestingTransferToSelf');
     });
 
+    it('cannot nest tranfer a descendant same NFT', async function () {
+      // We can no longer nest transfer it, even if we are the root owner:
+      await nestTransfer(child, firstOwner, parent.address, childId, parentId);
+      const grandChildId = await nestMint(child, child.address, childId);
+      // Ownership is now parent->child->granChild
+      // Cannot send parent to grandChild
+      await expect(
+        nestTransfer(parent, firstOwner, child.address, parentId, grandChildId),
+      ).to.be.revertedWithCustomError(child, 'RMRKNestingTransferToDescendant');
+      // Cannot send parent to child
+      await expect(
+        nestTransfer(parent, firstOwner, child.address, parentId, childId),
+      ).to.be.revertedWithCustomError(child, 'RMRKNestingTransferToDescendant');
+    });
+
     it('cannot nest tranfer if not owner', async function () {
       const notOwner = addrs[3];
       await expect(

--- a/test/behavior/nesting.ts
+++ b/test/behavior/nesting.ts
@@ -823,6 +823,19 @@ async function shouldBehaveLikeNesting(
       ).to.be.revertedWithCustomError(child, 'RMRKNestingTransferToDescendant');
     });
 
+    it('cannot nest tranfer if ancestors tree is too deep', async function () {
+      let lastId = childId;
+      for (let i = 0; i < 100; i++) {
+        const newChildId = await nestMint(child, child.address, lastId);
+        lastId = newChildId;
+      }
+      // Ownership is now parent->child->child->child->child...->lastChild
+      // Cannot send parent to lastChild
+      await expect(
+        nestTransfer(parent, firstOwner, child.address, parentId, lastId),
+      ).to.be.revertedWithCustomError(child, 'RMRKNestingTooDeep');
+    });
+
     it('cannot nest tranfer if not owner', async function () {
       const notOwner = addrs[3];
       await expect(


### PR DESCRIPTION
If you create an inheritance loop, ownership checks will always run out of gas due to an infinite loop. 
We avoid this at least up to 10 levels. 