### PR TITLE
Implements Soulbound extension

### DIFF
--- a/contracts/RMRK/core/RMRKCore.sol
+++ b/contracts/RMRK/core/RMRKCore.sol
@@ -43,4 +43,41 @@ contract RMRKCore is IRMRKCore {
     {
         return "";
     }
+
+    /**
+     * @dev Hook that is called before any token transfer. This includes minting
+     * and burning.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, ``from``'s `tokenId` will be
+     * transferred to `to`.
+     * - When `from` is zero, `tokenId` will be minted for `to`.
+     * - When `to` is zero, ``from``'s `tokenId` will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual {}
 }

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -217,7 +217,7 @@ contract RMRKEquippable is RMRKNesting, AbstractMultiResource, IRMRKEquippable {
         Child memory child = childOf(tokenId, index);
         if (isChildEquipped(tokenId, child.contractAddress, child.tokenId))
             revert RMRKMustUnequipFirst();
-        super.unnestChild(tokenId, index, to);
+        _unnestChild(tokenId, index, to);
     }
 
     function equip(IntakeEquip memory data)

--- a/contracts/RMRK/extension/soulbound/IRMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/IRMRKSoulbound.sol
@@ -8,8 +8,5 @@ interface IRMRKSoulbound is IERC165 {
     /**
      * @notice Returns whether or not the token is soulbound
      */
-    function isSoulbound(uint256 tokenId)
-        external
-        view
-        returns (bool);
+    function isSoulbound(uint256 tokenId) external view returns (bool);
 }

--- a/contracts/RMRK/extension/soulbound/IRMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/IRMRKSoulbound.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IRMRKSoulbound is IERC165 {
+    /**
+     * @notice Returns whether or not the token is soulbound
+     */
+    function isSoulbound(uint256 tokenId)
+        external
+        view
+        returns (bool);
+}

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../core/RMRKCore.sol";
+import "./IRMRKSoulbound.sol";
+
+error RMRKCannotTransferSoulbound();
+
+abstract contract RMRKSoulbound is IRMRKSoulbound, RMRKCore {
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        if (
+            from != address(0) && // Exclude minting
+            to != address(0) && // Exclude Burning
+            isSoulbound(tokenId)
+        ) revert RMRKCannotTransferSoulbound();
+
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    function isSoulbound(uint256) public virtual view returns (bool) {
+        return true;
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        returns (bool)
+    {
+        return interfaceId == type(IRMRKSoulbound).interfaceId;
+    }
+}

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -22,7 +22,7 @@ abstract contract RMRKSoulbound is IRMRKSoulbound, RMRKCore {
         super._beforeTokenTransfer(from, to, tokenId);
     }
 
-    function isSoulbound(uint256) public virtual view returns (bool) {
+    function isSoulbound(uint256) public view virtual returns (bool) {
         return true;
     }
 

--- a/contracts/RMRK/multiresource/RMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/RMRKMultiResource.sol
@@ -462,43 +462,6 @@ contract RMRKMultiResource is
         }
     }
 
-    /**
-     * @dev Hook that is called before any token transfer. This includes minting
-     * and burning.
-     *
-     * Calling conditions:
-     *
-     * - When `from` and `to` are both non-zero, ``from``'s `tokenId` will be
-     * transferred to `to`.
-     * - When `from` is zero, `tokenId` will be minted for `to`.
-     * - When `to` is zero, ``from``'s `tokenId` will be burned.
-     * - `from` and `to` are never both zero.
-     *
-     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
-     */
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual {}
-
-    /**
-     * @dev Hook that is called after any transfer of tokens. This includes
-     * minting and burning.
-     *
-     * Calling conditions:
-     *
-     * - when `from` and `to` are both non-zero.
-     * - `from` and `to` are never both zero.
-     *
-     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
-     */
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual {}
-
     // ------------------------------- RESOURCES ------------------------------
 
     function acceptResource(uint256 tokenId, uint256 index)

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -666,43 +666,6 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
         }
     }
 
-    /**
-     * @dev Hook that is called before any token transfer. This includes minting
-     * and burning.
-     *
-     * Calling conditions:
-     *
-     * - When `from` and `to` are both non-zero, ``from``'s `tokenId` will be
-     * transferred to `to`.
-     * - When `from` is zero, `tokenId` will be minted for `to`.
-     * - When `to` is zero, ``from``'s `tokenId` will be burned.
-     * - `from` and `to` are never both zero.
-     *
-     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
-     */
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual {}
-
-    /**
-     * @dev Hook that is called after any transfer of tokens. This includes
-     * minting and burning.
-     *
-     * Calling conditions:
-     *
-     * - when `from` and `to` are both non-zero.
-     * - `from` and `to` are never both zero.
-     *
-     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
-     */
-    function _afterTokenTransfer(
-        address from,
-        address to,
-        uint256 tokenId
-    ) internal virtual {}
-
     ////////////////////////////////////////
     //      CHILD MANAGEMENT PUBLIC
     ////////////////////////////////////////
@@ -838,6 +801,14 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
         uint256 index,
         address to
     ) public virtual onlyApprovedOrOwner(tokenId) {
+        _unnestChild(tokenId, index, to);
+    }
+
+    function _unnestChild(
+        uint256 tokenId,
+        uint256 index,
+        address to
+    ) internal virtual {
         if (_children[tokenId].length <= index)
             revert RMRKChildIndexOutOfRange();
 

--- a/contracts/mocks/extensions/soulbound/RMRKSemiSoulboundNestingMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSemiSoulboundNestingMock.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import "../../RMRKNestingMock.sol";
+
+contract RMRKSemiSoulboundNestingMock is RMRKSoulbound, RMRKNestingMock {
+
+    mapping(uint256=>bool) soulboundExempt;
+
+    constructor(string memory name, string memory symbol)
+        RMRKNestingMock(name, symbol)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(RMRKSoulbound, RMRKNesting)
+        returns (bool)
+    {
+        return RMRKSoulbound.supportsInterface(interfaceId) ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(RMRKCore, RMRKSoulbound) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    // This shows how the method can be overwritten for custom soulbound logic
+    function isSoulbound(uint256 tokenId) public view override returns(bool) {
+        return !soulboundExempt[tokenId];
+    }
+
+    function setSoulboundExempt(uint256 tokenId) public {
+        soulboundExempt[tokenId] = true;
+    }
+}

--- a/contracts/mocks/extensions/soulbound/RMRKSemiSoulboundNestingMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSemiSoulboundNestingMock.sol
@@ -6,8 +6,7 @@ import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKNestingMock.sol";
 
 contract RMRKSemiSoulboundNestingMock is RMRKSoulbound, RMRKNestingMock {
-
-    mapping(uint256=>bool) soulboundExempt;
+    mapping(uint256 => bool) soulboundExempt;
 
     constructor(string memory name, string memory symbol)
         RMRKNestingMock(name, symbol)
@@ -20,7 +19,8 @@ contract RMRKSemiSoulboundNestingMock is RMRKSoulbound, RMRKNestingMock {
         override(RMRKSoulbound, RMRKNesting)
         returns (bool)
     {
-        return RMRKSoulbound.supportsInterface(interfaceId) ||
+        return
+            RMRKSoulbound.supportsInterface(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 
@@ -33,7 +33,7 @@ contract RMRKSemiSoulboundNestingMock is RMRKSoulbound, RMRKNestingMock {
     }
 
     // This shows how the method can be overwritten for custom soulbound logic
-    function isSoulbound(uint256 tokenId) public view override returns(bool) {
+    function isSoulbound(uint256 tokenId) public view override returns (bool) {
         return !soulboundExempt[tokenId];
     }
 

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
@@ -18,7 +18,8 @@ contract RMRKSoulboundEquippableMock is RMRKSoulbound, RMRKEquippableMock {
         override(RMRKSoulbound, RMRKEquippable)
         returns (bool)
     {
-        return RMRKSoulbound.supportsInterface(interfaceId) ||
+        return
+            RMRKSoulbound.supportsInterface(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+// import "../../../RMRK/equippable/RMRKEquippable.sol";
+import "../../RMRKEquippableMock.sol";
+
+contract RMRKSoulboundEquippableMock is RMRKSoulbound, RMRKEquippableMock {
+    constructor(string memory name, string memory symbol)
+        RMRKEquippableMock(name, symbol)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(RMRKSoulbound, RMRKEquippable)
+        returns (bool)
+    {
+        return RMRKSoulbound.supportsInterface(interfaceId) ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(RMRKCore, RMRKSoulbound) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+}

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiResourceMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiResourceMock.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.15;
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKMultiResourceMock.sol";
 
-
 contract RMRKSoulboundMultiResourceMock is
     RMRKSoulbound,
     RMRKMultiResourceMock
@@ -21,7 +20,8 @@ contract RMRKSoulboundMultiResourceMock is
         override(RMRKSoulbound, RMRKMultiResource)
         returns (bool)
     {
-        return RMRKSoulbound.supportsInterface(interfaceId) ||
+        return
+            RMRKSoulbound.supportsInterface(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiResourceMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiResourceMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import "../../RMRKMultiResourceMock.sol";
+
+
+contract RMRKSoulboundMultiResourceMock is
+    RMRKSoulbound,
+    RMRKMultiResourceMock
+{
+    constructor(string memory name, string memory symbol)
+        RMRKMultiResourceMock(name, symbol)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(RMRKSoulbound, RMRKMultiResource)
+        returns (bool)
+    {
+        return RMRKSoulbound.supportsInterface(interfaceId) ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(RMRKCore, RMRKSoulbound) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+}

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingExternalEquippableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingExternalEquippableMock.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import "../../RMRKNestingExternalEquipMock.sol";
+
+contract RMRKSoulboundNestingExternalEquippableMock is RMRKSoulbound, RMRKNestingExternalEquipMock {
+    constructor(string memory name, string memory symbol)
+        RMRKNestingExternalEquipMock(name, symbol)
+    {}
+    
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(RMRKSoulbound, RMRKNestingExternalEquip)
+        returns (bool)
+    {
+        return RMRKSoulbound.supportsInterface(interfaceId) ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(RMRKCore, RMRKSoulbound) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+}

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingExternalEquippableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingExternalEquippableMock.sol
@@ -5,11 +5,14 @@ pragma solidity ^0.8.15;
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKNestingExternalEquipMock.sol";
 
-contract RMRKSoulboundNestingExternalEquippableMock is RMRKSoulbound, RMRKNestingExternalEquipMock {
+contract RMRKSoulboundNestingExternalEquippableMock is
+    RMRKSoulbound,
+    RMRKNestingExternalEquipMock
+{
     constructor(string memory name, string memory symbol)
         RMRKNestingExternalEquipMock(name, symbol)
     {}
-    
+
     function supportsInterface(bytes4 interfaceId)
         public
         view
@@ -17,7 +20,8 @@ contract RMRKSoulboundNestingExternalEquippableMock is RMRKSoulbound, RMRKNestin
         override(RMRKSoulbound, RMRKNestingExternalEquip)
         returns (bool)
     {
-        return RMRKSoulbound.supportsInterface(interfaceId) ||
+        return
+            RMRKSoulbound.supportsInterface(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMock.sol
@@ -17,7 +17,8 @@ contract RMRKSoulboundNestingMock is RMRKSoulbound, RMRKNestingMock {
         override(RMRKSoulbound, RMRKNesting)
         returns (bool)
     {
-        return RMRKSoulbound.supportsInterface(interfaceId) ||
+        return
+            RMRKSoulbound.supportsInterface(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMock.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import "../../RMRKNestingMock.sol";
+
+contract RMRKSoulboundNestingMock is RMRKSoulbound, RMRKNestingMock {
+    constructor(string memory name, string memory symbol)
+        RMRKNestingMock(name, symbol)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(RMRKSoulbound, RMRKNesting)
+        returns (bool)
+    {
+        return RMRKSoulbound.supportsInterface(interfaceId) ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(RMRKCore, RMRKSoulbound) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+}

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMultiResourceMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMultiResourceMock.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import "../../RMRKNestingMultiResourceMock.sol";
+
+contract RMRKSoulboundNestingMultiResourceMock is
+    RMRKSoulbound,
+    RMRKNestingMultiResourceMock
+{
+    constructor(string memory name, string memory symbol)
+        RMRKNestingMultiResourceMock(name, symbol)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(RMRKSoulbound, RMRKNestingMultiResource)
+        returns (bool)
+    {
+        return RMRKSoulbound.supportsInterface(interfaceId) ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override(RMRKCore, RMRKSoulbound) {
+        super._beforeTokenTransfer(from, to, tokenId);
+    }
+}

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMultiResourceMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMultiResourceMock.sol
@@ -20,7 +20,8 @@ contract RMRKSoulboundNestingMultiResourceMock is
         override(RMRKSoulbound, RMRKNestingMultiResource)
         returns (bool)
     {
-        return RMRKSoulbound.supportsInterface(interfaceId) ||
+        return
+            RMRKSoulbound.supportsInterface(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/test/extensions/soulbound.ts
+++ b/test/extensions/soulbound.ts
@@ -1,0 +1,364 @@
+import { Contract } from 'ethers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { mintFromMock, nestMintFromMock } from '../utils';
+
+// --------------- FIXTURES -----------------------
+
+async function soulboundMultiResourceFixture() {
+  const factory = await ethers.getContractFactory('RMRKSoulboundMultiResourceMock');
+  const token = await factory.deploy('Chunky', 'CHNK');
+  await token.deployed();
+
+  return { token };
+}
+
+async function soulboundNestingFixture() {
+  const factory = await ethers.getContractFactory('RMRKSoulboundNestingMock');
+  const token = await factory.deploy('Chunky', 'CHNK');
+  await token.deployed();
+
+  return { token };
+}
+
+async function soulboundNestingMultiResourceFixture() {
+  const factory = await ethers.getContractFactory('RMRKSoulboundNestingMultiResourceMock');
+  const token = await factory.deploy('Chunky', 'CHNK');
+  await token.deployed();
+
+  return { token };
+}
+
+async function soulboundEquippableFixture() {
+  const factory = await ethers.getContractFactory('RMRKSoulboundEquippableMock');
+  const token = await factory.deploy('Chunky', 'CHNK');
+  await token.deployed();
+
+  return { token };
+}
+
+async function soulboundNestingExternalEquippableFixture() {
+  const nestingFactory = await ethers.getContractFactory(
+    'RMRKSoulboundNestingExternalEquippableMock',
+  );
+  const nesting = await nestingFactory.deploy('Chunky', 'CHNK');
+  await nesting.deployed();
+
+  const equipFactory = await ethers.getContractFactory('RMRKExternalEquipMock');
+  const equip = await equipFactory.deploy(nesting.address);
+  await equip.deployed();
+
+  await nesting.setEquippableAddress(equip.address);
+
+  return { nesting, equip };
+}
+
+describe('RMRKSoulboundMultiResourceMock', async function () {
+  beforeEach(async function () {
+    const { token } = await loadFixture(soulboundMultiResourceFixture);
+    this.token = token;
+  });
+
+  shouldBehaveLikeSoulboundBasic();
+});
+
+describe('RMRKSoulboundNestingMock', async function () {
+  beforeEach(async function () {
+    const { token } = await loadFixture(soulboundNestingFixture);
+    this.token = token;
+  });
+
+  shouldBehaveLikeSoulboundBasic();
+  shouldBehaveLikeSoulboundNesting();
+});
+
+describe('RMRKSoulboundNestingMultiResourceMock', async function () {
+  beforeEach(async function () {
+    const { token } = await loadFixture(soulboundNestingMultiResourceFixture);
+    this.token = token;
+  });
+
+  shouldBehaveLikeSoulboundBasic();
+  shouldBehaveLikeSoulboundNesting();
+});
+
+describe('RMRKSoulboundEquippableMock', async function () {
+  beforeEach(async function () {
+    const { token } = await loadFixture(soulboundEquippableFixture);
+    this.token = token;
+  });
+
+  shouldBehaveLikeSoulboundBasic();
+  shouldBehaveLikeSoulboundNesting();
+});
+
+describe('RMRKSoulboundNestingExternalEquippableMock', async function () {
+  beforeEach(async function () {
+    const { nesting } = await loadFixture(soulboundNestingExternalEquippableFixture);
+    this.token = nesting;
+  });
+
+  shouldBehaveLikeSoulboundBasic();
+  shouldBehaveLikeSoulboundNesting();
+});
+
+// describe('RMRKNestingSoulboundMultiResourceMock', async function () {
+//   let soulboundNestingMultiResource: Contract;
+//   let owner: SignerWithAddress;
+//   let tokenId: number;
+
+//   beforeEach(async function () {
+//     ({ soulboundNestingMultiResource } = await loadFixture(nestingSoulboundMultiResourceFixture));
+
+//     const signers = await ethers.getSigners();
+//     owner = signers[0];
+
+//     tokenId = await mintFromMock(soulboundNestingMultiResource, owner.address);
+//   });
+
+//   it('can support IERC165', async function () {
+//     expect(await soulboundNestingMultiResource.supportsInterface('0x01ffc9a7')).to.equal(true);
+//   });
+
+//   it('can support IMultiResource', async function () {
+//     expect(await soulboundNestingMultiResource.supportsInterface('0xc65a6425')).to.equal(true);
+//   });
+
+//   it('can support INesting', async function () {
+//     expect(await soulboundNestingMultiResource.supportsInterface('0xf790390a')).to.equal(true);
+//   });
+
+//   it('can support IRMRKSoulboundMultiResource', async function () {
+//     expect(await soulboundNestingMultiResource.supportsInterface('0xb6a3032e')).to.equal(true);
+//   });
+
+//   it('does not support other interfaces', async function () {
+//     expect(await soulboundNestingMultiResource.supportsInterface('0xffffffff')).to.equal(false);
+//   });
+
+//   it('can add soulbound resources', async function () {
+//     const resId = bn(1);
+//     await soulboundNestingMultiResource.addSoulboundResourceEntry(resId, 'ipfs://res1.jpg', 'image/jpeg');
+//     expect(await soulboundNestingMultiResource.getResourceType(resId)).to.eql('image/jpeg');
+//   });
+
+//   it('can add soulbound resources to tokens', async function () {
+//     const resId = bn(1);
+//     await soulboundNestingMultiResource.addSoulboundResourceEntry(resId, 'ipfs://res1.jpg', 'image/jpeg');
+//     await soulboundNestingMultiResource.addResourceToToken(tokenId, resId, 0);
+
+//     expect(await soulboundNestingMultiResource.getPendingResources(tokenId)).to.eql([resId]);
+//   });
+// });
+
+// describe('RMRKSoulboundEquippableMock', async function () {
+//   let soulboundEquippable: Contract;
+//   let owner: SignerWithAddress;
+//   let tokenId: number;
+
+//   beforeEach(async function () {
+//     ({ soulboundEquippable } = await loadFixture(soulboundEquippableFixture));
+
+//     const signers = await ethers.getSigners();
+//     owner = signers[0];
+
+//     tokenId = await mintFromMock(soulboundEquippable, owner.address);
+//   });
+
+//   it('can support IERC165', async function () {
+//     expect(await soulboundEquippable.supportsInterface('0x01ffc9a7')).to.equal(true);
+//   });
+
+//   it('can support IMultiResource', async function () {
+//     expect(await soulboundEquippable.supportsInterface('0xc65a6425')).to.equal(true);
+//   });
+
+//   it('can support INesting', async function () {
+//     expect(await soulboundEquippable.supportsInterface('0xf790390a')).to.equal(true);
+//   });
+
+//   it('can support IEquippable', async function () {
+//     expect(await soulboundEquippable.supportsInterface('0xd3a28ca0')).to.equal(true);
+//   });
+
+//   it('can support IRMRKSoulboundMultiResource', async function () {
+//     expect(await soulboundEquippable.supportsInterface('0xb6a3032e')).to.equal(true);
+//   });
+
+//   it('does not support other interfaces', async function () {
+//     expect(await soulboundEquippable.supportsInterface('0xffffffff')).to.equal(false);
+//   });
+
+//   it('can add soulbound resources', async function () {
+//     const resId = bn(1);
+//     await soulboundEquippable.addSoulboundResourceEntry(
+//       {
+//         id: resId,
+//         equippableRefId: 0,
+//         metadataURI: 'fallback.json',
+//         baseAddress: ethers.constants.AddressZero,
+//       },
+//       [],
+//       [],
+//       'image/jpeg',
+//     );
+//     expect(await soulboundEquippable.getResourceType(resId)).to.eql('image/jpeg');
+//   });
+
+//   it('can add soulbound resources to tokens', async function () {
+//     const resId = bn(1);
+//     await soulboundEquippable.addSoulboundResourceEntry(
+//       {
+//         id: resId,
+//         equippableRefId: 0,
+//         metadataURI: 'fallback.json',
+//         baseAddress: ethers.constants.AddressZero,
+//       },
+//       [],
+//       [],
+//       'image/jpeg',
+//     );
+//     await soulboundEquippable.addResourceToToken(tokenId, resId, 0);
+//     expect(await soulboundEquippable.getPendingResources(tokenId)).to.eql([resId]);
+//   });
+// });
+
+// describe('RMRKSoulboundExternalEquippableMock', async function () {
+//   let soulboundExternalEquippable: Contract;
+//   let nesting: Contract;
+//   let owner: SignerWithAddress;
+//   let tokenId: number;
+
+//   beforeEach(async function () {
+//     ({ nesting, soulboundExternalEquippable } = await loadFixture(soulboundExternalEquippableFixture));
+
+//     const signers = await ethers.getSigners();
+//     owner = signers[0];
+
+//     tokenId = await mintFromMock(nesting, owner.address);
+//   });
+
+//   it('can support IERC165', async function () {
+//     expect(await soulboundExternalEquippable.supportsInterface('0x01ffc9a7')).to.equal(true);
+//   });
+
+//   it('can support IMultiResource', async function () {
+//     expect(await soulboundExternalEquippable.supportsInterface('0xc65a6425')).to.equal(true);
+//   });
+
+//   it('can support IEquippable', async function () {
+//     expect(await soulboundExternalEquippable.supportsInterface('0xd3a28ca0')).to.equal(true);
+//   });
+
+//   it('can support IExternalEquip', async function () {
+//     expect(await soulboundExternalEquippable.supportsInterface('0xe5383e6c')).to.equal(true);
+//   });
+
+//   it('can support IRMRKSoulboundMultiResource', async function () {
+//     expect(await soulboundExternalEquippable.supportsInterface('0xb6a3032e')).to.equal(true);
+//   });
+
+//   it('does not support other interfaces', async function () {
+//     expect(await soulboundExternalEquippable.supportsInterface('0xffffffff')).to.equal(false);
+//   });
+
+//   it('can add soulbound resources', async function () {
+//     const resId = bn(1);
+//     await soulboundExternalEquippable.addSoulboundResourceEntry(
+//       {
+//         id: resId,
+//         equippableRefId: 0,
+//         metadataURI: 'fallback.json',
+//         baseAddress: ethers.constants.AddressZero,
+//       },
+//       [],
+//       [],
+//       'image/jpeg',
+//     );
+//     expect(await soulboundExternalEquippable.getResourceType(resId)).to.eql('image/jpeg');
+//   });
+
+//   it('can add soulbound resources to tokens', async function () {
+//     const resId = bn(1);
+//     await soulboundExternalEquippable.addSoulboundResourceEntry(
+//       {
+//         id: resId,
+//         equippableRefId: 0,
+//         metadataURI: 'fallback.json',
+//         baseAddress: ethers.constants.AddressZero,
+//       },
+//       [],
+//       [],
+//       'image/jpeg',
+//     );
+//     await soulboundExternalEquippable.addResourceToToken(tokenId, resId, 0);
+//     expect(await soulboundExternalEquippable.getPendingResources(tokenId)).to.eql([resId]);
+//   });
+// });
+
+async function shouldBehaveLikeSoulboundBasic() {
+  let soulbound: Contract;
+  let owner: SignerWithAddress;
+  let otherOwner: SignerWithAddress;
+  let tokenId: number;
+
+  beforeEach(async function () {
+    const signers = await ethers.getSigners();
+    owner = signers[0];
+    otherOwner = signers[1];
+    soulbound = this.token;
+
+    tokenId = await mintFromMock(soulbound, owner.address);
+  });
+
+  it('can support IERC165', async function () {
+    expect(await soulbound.supportsInterface('0x01ffc9a7')).to.equal(true);
+  });
+
+  it('can support IRMRKSoulboundMultiResource', async function () {
+    expect(await soulbound.supportsInterface('0x911ec470')).to.equal(true);
+  });
+
+  it('does not support other interfaces', async function () {
+    expect(await soulbound.supportsInterface('0xffffffff')).to.equal(false);
+  });
+
+  it('cannot transfer', async function () {
+    expect(
+      soulbound.connect(owner).transfer(otherOwner.address, tokenId),
+    ).to.be.revertedWithCustomError(soulbound, 'RMRKCannotTransferSoulbound');
+  });
+}
+
+async function shouldBehaveLikeSoulboundNesting() {
+  let soulbound: Contract;
+  let owner: SignerWithAddress;
+  let otherOwner: SignerWithAddress;
+  let tokenId: number;
+
+  beforeEach(async function () {
+    const signers = await ethers.getSigners();
+    owner = signers[0];
+    otherOwner = signers[1];
+    soulbound = this.token;
+
+    tokenId = await mintFromMock(soulbound, owner.address);
+  });
+
+  it('cannot nest transfer', async function () {
+    const otherTokenId = await mintFromMock(soulbound, owner.address);
+    expect(
+      soulbound.connect(owner).nestTransfer(otherOwner.address, tokenId, otherTokenId),
+    ).to.be.revertedWithCustomError(soulbound, 'RMRKCannotTransferSoulbound');
+  });
+
+  it('cannot unnest transfer', async function () {
+    await nestMintFromMock(soulbound, soulbound.address, tokenId);
+    await soulbound.connect(owner).acceptChild(tokenId, 0);
+    expect(
+      soulbound.connect(owner).unnestChild(tokenId, 0, owner.address)
+    ).to.be.revertedWithCustomError(soulbound, 'RMRKCannotTransferSoulbound');
+  });
+}

--- a/test/extensions/soulbound.ts
+++ b/test/extensions/soulbound.ts
@@ -104,200 +104,6 @@ describe('RMRKSoulboundNestingExternalEquippableMock', async function () {
   shouldBehaveLikeSoulboundNesting();
 });
 
-// describe('RMRKNestingSoulboundMultiResourceMock', async function () {
-//   let soulboundNestingMultiResource: Contract;
-//   let owner: SignerWithAddress;
-//   let tokenId: number;
-
-//   beforeEach(async function () {
-//     ({ soulboundNestingMultiResource } = await loadFixture(nestingSoulboundMultiResourceFixture));
-
-//     const signers = await ethers.getSigners();
-//     owner = signers[0];
-
-//     tokenId = await mintFromMock(soulboundNestingMultiResource, owner.address);
-//   });
-
-//   it('can support IERC165', async function () {
-//     expect(await soulboundNestingMultiResource.supportsInterface('0x01ffc9a7')).to.equal(true);
-//   });
-
-//   it('can support IMultiResource', async function () {
-//     expect(await soulboundNestingMultiResource.supportsInterface('0xc65a6425')).to.equal(true);
-//   });
-
-//   it('can support INesting', async function () {
-//     expect(await soulboundNestingMultiResource.supportsInterface('0xf790390a')).to.equal(true);
-//   });
-
-//   it('can support IRMRKSoulboundMultiResource', async function () {
-//     expect(await soulboundNestingMultiResource.supportsInterface('0xb6a3032e')).to.equal(true);
-//   });
-
-//   it('does not support other interfaces', async function () {
-//     expect(await soulboundNestingMultiResource.supportsInterface('0xffffffff')).to.equal(false);
-//   });
-
-//   it('can add soulbound resources', async function () {
-//     const resId = bn(1);
-//     await soulboundNestingMultiResource.addSoulboundResourceEntry(resId, 'ipfs://res1.jpg', 'image/jpeg');
-//     expect(await soulboundNestingMultiResource.getResourceType(resId)).to.eql('image/jpeg');
-//   });
-
-//   it('can add soulbound resources to tokens', async function () {
-//     const resId = bn(1);
-//     await soulboundNestingMultiResource.addSoulboundResourceEntry(resId, 'ipfs://res1.jpg', 'image/jpeg');
-//     await soulboundNestingMultiResource.addResourceToToken(tokenId, resId, 0);
-
-//     expect(await soulboundNestingMultiResource.getPendingResources(tokenId)).to.eql([resId]);
-//   });
-// });
-
-// describe('RMRKSoulboundEquippableMock', async function () {
-//   let soulboundEquippable: Contract;
-//   let owner: SignerWithAddress;
-//   let tokenId: number;
-
-//   beforeEach(async function () {
-//     ({ soulboundEquippable } = await loadFixture(soulboundEquippableFixture));
-
-//     const signers = await ethers.getSigners();
-//     owner = signers[0];
-
-//     tokenId = await mintFromMock(soulboundEquippable, owner.address);
-//   });
-
-//   it('can support IERC165', async function () {
-//     expect(await soulboundEquippable.supportsInterface('0x01ffc9a7')).to.equal(true);
-//   });
-
-//   it('can support IMultiResource', async function () {
-//     expect(await soulboundEquippable.supportsInterface('0xc65a6425')).to.equal(true);
-//   });
-
-//   it('can support INesting', async function () {
-//     expect(await soulboundEquippable.supportsInterface('0xf790390a')).to.equal(true);
-//   });
-
-//   it('can support IEquippable', async function () {
-//     expect(await soulboundEquippable.supportsInterface('0xd3a28ca0')).to.equal(true);
-//   });
-
-//   it('can support IRMRKSoulboundMultiResource', async function () {
-//     expect(await soulboundEquippable.supportsInterface('0xb6a3032e')).to.equal(true);
-//   });
-
-//   it('does not support other interfaces', async function () {
-//     expect(await soulboundEquippable.supportsInterface('0xffffffff')).to.equal(false);
-//   });
-
-//   it('can add soulbound resources', async function () {
-//     const resId = bn(1);
-//     await soulboundEquippable.addSoulboundResourceEntry(
-//       {
-//         id: resId,
-//         equippableRefId: 0,
-//         metadataURI: 'fallback.json',
-//         baseAddress: ethers.constants.AddressZero,
-//       },
-//       [],
-//       [],
-//       'image/jpeg',
-//     );
-//     expect(await soulboundEquippable.getResourceType(resId)).to.eql('image/jpeg');
-//   });
-
-//   it('can add soulbound resources to tokens', async function () {
-//     const resId = bn(1);
-//     await soulboundEquippable.addSoulboundResourceEntry(
-//       {
-//         id: resId,
-//         equippableRefId: 0,
-//         metadataURI: 'fallback.json',
-//         baseAddress: ethers.constants.AddressZero,
-//       },
-//       [],
-//       [],
-//       'image/jpeg',
-//     );
-//     await soulboundEquippable.addResourceToToken(tokenId, resId, 0);
-//     expect(await soulboundEquippable.getPendingResources(tokenId)).to.eql([resId]);
-//   });
-// });
-
-// describe('RMRKSoulboundExternalEquippableMock', async function () {
-//   let soulboundExternalEquippable: Contract;
-//   let nesting: Contract;
-//   let owner: SignerWithAddress;
-//   let tokenId: number;
-
-//   beforeEach(async function () {
-//     ({ nesting, soulboundExternalEquippable } = await loadFixture(soulboundExternalEquippableFixture));
-
-//     const signers = await ethers.getSigners();
-//     owner = signers[0];
-
-//     tokenId = await mintFromMock(nesting, owner.address);
-//   });
-
-//   it('can support IERC165', async function () {
-//     expect(await soulboundExternalEquippable.supportsInterface('0x01ffc9a7')).to.equal(true);
-//   });
-
-//   it('can support IMultiResource', async function () {
-//     expect(await soulboundExternalEquippable.supportsInterface('0xc65a6425')).to.equal(true);
-//   });
-
-//   it('can support IEquippable', async function () {
-//     expect(await soulboundExternalEquippable.supportsInterface('0xd3a28ca0')).to.equal(true);
-//   });
-
-//   it('can support IExternalEquip', async function () {
-//     expect(await soulboundExternalEquippable.supportsInterface('0xe5383e6c')).to.equal(true);
-//   });
-
-//   it('can support IRMRKSoulboundMultiResource', async function () {
-//     expect(await soulboundExternalEquippable.supportsInterface('0xb6a3032e')).to.equal(true);
-//   });
-
-//   it('does not support other interfaces', async function () {
-//     expect(await soulboundExternalEquippable.supportsInterface('0xffffffff')).to.equal(false);
-//   });
-
-//   it('can add soulbound resources', async function () {
-//     const resId = bn(1);
-//     await soulboundExternalEquippable.addSoulboundResourceEntry(
-//       {
-//         id: resId,
-//         equippableRefId: 0,
-//         metadataURI: 'fallback.json',
-//         baseAddress: ethers.constants.AddressZero,
-//       },
-//       [],
-//       [],
-//       'image/jpeg',
-//     );
-//     expect(await soulboundExternalEquippable.getResourceType(resId)).to.eql('image/jpeg');
-//   });
-
-//   it('can add soulbound resources to tokens', async function () {
-//     const resId = bn(1);
-//     await soulboundExternalEquippable.addSoulboundResourceEntry(
-//       {
-//         id: resId,
-//         equippableRefId: 0,
-//         metadataURI: 'fallback.json',
-//         baseAddress: ethers.constants.AddressZero,
-//       },
-//       [],
-//       [],
-//       'image/jpeg',
-//     );
-//     await soulboundExternalEquippable.addResourceToToken(tokenId, resId, 0);
-//     expect(await soulboundExternalEquippable.getPendingResources(tokenId)).to.eql([resId]);
-//   });
-// });
-
 async function shouldBehaveLikeSoulboundBasic() {
   let soulbound: Contract;
   let owner: SignerWithAddress;
@@ -330,6 +136,14 @@ async function shouldBehaveLikeSoulboundBasic() {
       soulbound.connect(owner).transfer(otherOwner.address, tokenId),
     ).to.be.revertedWithCustomError(soulbound, 'RMRKCannotTransferSoulbound');
   });
+
+  it('can burn', async function () {
+    await soulbound.connect(owner).burn(tokenId);
+    await expect(soulbound.ownerOf(tokenId)).to.be.revertedWithCustomError(
+      soulbound,
+      'ERC721InvalidTokenId',
+    );
+  });
 }
 
 async function shouldBehaveLikeSoulboundNesting() {
@@ -358,7 +172,7 @@ async function shouldBehaveLikeSoulboundNesting() {
     await nestMintFromMock(soulbound, soulbound.address, tokenId);
     await soulbound.connect(owner).acceptChild(tokenId, 0);
     expect(
-      soulbound.connect(owner).unnestChild(tokenId, 0, owner.address)
+      soulbound.connect(owner).unnestChild(tokenId, 0, owner.address),
     ).to.be.revertedWithCustomError(soulbound, 'RMRKCannotTransferSoulbound');
   });
 }


### PR DESCRIPTION
A single interface and abstract class.
Implementers can override the `isSoulbound` method for custom cases.
Adds mocks and tests for every lego combination.
