### PR TITLE
Code review

### DIFF
--- a/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
@@ -15,7 +15,7 @@ error RMRKMustUnequipFirst();
 /**
  * @dev RMRKNesting contract with external equippable contract for space saving purposes. Expected to be deployed along
  * an instance of RMRKExternalEquip.sol. To make use of the equippable module with this contract, expose the _setEquippableAddress
- * function and set it to the corresponding equipment contraft after deployment. Consider using RMRKOwnableLock to lock the equippable
+ * function and set it to the corresponding equipment contract after deployment. Consider using RMRKOwnableLock to lock the equippable
  * address after deployment.
  */
 contract RMRKNestingExternalEquip is IRMRKNestingExternalEquip, RMRKNesting {
@@ -37,7 +37,7 @@ contract RMRKNestingExternalEquip is IRMRKNestingExternalEquip, RMRKNesting {
             super.supportsInterface(interfaceId);
     }
 
-    // It's overriden to make check the child is not equipped when trying to unnest
+    // It's overridden to make check the child is not equipped when trying to unnest
     function unnestChild(
         uint256 tokenId,
         uint256 index,

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -42,7 +42,7 @@ error RMRKInvalidChildReclaim();
 error RMRKChildAlreadyExists();
 
 /**
- * @dev RMRK nesting implementation. This contract is heirarchy agnostic, and can
+ * @dev RMRK nesting implementation. This contract is hierarchy agnostic, and can
  * support an arbitrary number of nested levels up and down, as long as gas limits
  * allow
  *
@@ -54,9 +54,6 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
     using Strings for uint256;
 
     uint256 private constant _MAX_LEVELS_TO_CHECK_FOR_INHERITANCE_LOOP = 100;
-
-    // Mapping from token ID to owner address
-    mapping(uint256 => address) private _owners;
 
     // Mapping owner address to token count
     mapping(address => uint256) private _balances;
@@ -729,7 +726,7 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
         });
 
         // This check is not done since there's no guarantee of mapping being
-        // up to date, see defintion for details. A similar protection does
+        // up to date, see definition for details. A similar protection does
         // exist when accepting a child:
         // if (_childIsInPending[child.contractAddress][child.tokenId] != 0)
         //     revert RMRKChildAlreadyExists();

--- a/contracts/implementations/RMRKNestingExternalEquipImpl.sol
+++ b/contracts/implementations/RMRKNestingExternalEquipImpl.sol
@@ -93,6 +93,7 @@ contract RMRKNestingExternalEquipImpl is
         external
         onlyOwnerOrContributor
     {
+        //TODO: should we add a check if passed address supports IRMRKNestingExternalEquip
         _setEquippableAddress(equippable);
     }
 


### PR DESCRIPTION
I did a security pass of the contracts and I didn't find anything major.
I noticed an unused mapping `_owners` in the RMRKNesting contract which I removed.
I also have a suggestion for the split equippable to check for the support of the required interface in the `setEquippableAddress` function.