### PR TITLE
Reclaim child extension

### DIFF
--- a/contracts/RMRK/extension/reclaimableChild/IRMRKReclaimableChild.sol
+++ b/contracts/RMRK/extension/reclaimableChild/IRMRKReclaimableChild.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IRMRKReclaimableChild is IERC165 {
+    /**
+     * @dev Function called to reclaim an abandoned child created by unnesting with `to` as the zero
+     * address or by rejecting children. This function will set the child's owner to the rootOwner
+     * of the caller, allowing the rootOwner management permissions for the child.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist
+     *
+     */
+    function reclaimChild(
+        uint256 tokenId,
+        address childAddress,
+        uint256 childTokenId
+    ) external;
+}

--- a/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
+++ b/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../nesting/RMRKNesting.sol";
+import "./IRMRKReclaimableChild.sol";
+
+error RMRKInvalidChildReclaim();
+
+abstract contract RMRKReclaimableChild is IRMRKReclaimableChild, RMRKNesting {
+    // WARNING: This mapping is not updated on burn or reject all, to save gas.
+    // This is only used to cheaply forbid reclaiming a child which is pending
+    mapping(address => mapping(uint256 => uint256)) private _childIsInPending;
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, RMRKNesting)
+        returns (bool)
+    {
+        return
+            RMRKNesting.supportsInterface(interfaceId) ||
+            interfaceId == type(IRMRKReclaimableChild).interfaceId;
+    }
+
+    function reclaimChild(
+        uint256 tokenId,
+        address childAddress,
+        uint256 childTokenId
+    ) public virtual override onlyApprovedOrOwner(tokenId) {
+        if (childIsInActive(childAddress, childTokenId))
+            revert RMRKInvalidChildReclaim();
+        if (_childIsInPending[childAddress][childTokenId] != 0)
+            revert RMRKInvalidChildReclaim();
+
+        (address owner, uint256 ownerTokenId, bool isNft) = IRMRKNesting(
+            childAddress
+        ).rmrkOwnerOf(childTokenId);
+        if (owner != address(this) || ownerTokenId != tokenId || !isNft)
+            revert RMRKInvalidChildReclaim();
+        IERC721(childAddress).safeTransferFrom(
+            address(this),
+            _msgSender(),
+            childTokenId
+        );
+    }
+
+    function _beforeAddChild(uint256 tokenId, Child memory child)
+        internal
+        virtual
+        override
+    {
+        super._beforeAddChild(tokenId, child);
+        _childIsInPending[child.contractAddress][child.tokenId] = 1; // We use 1 as true
+    }
+
+    function _beforeAcceptChild(
+        uint256 tokenId,
+        uint256 index,
+        Child memory child
+    ) internal virtual override {
+        super._beforeAcceptChild(tokenId, index, child);
+        delete _childIsInPending[child.contractAddress][child.tokenId];
+    }
+
+    function _beforeUnnestChild(
+        uint256 tokenId,
+        uint256 index,
+        Child memory child,
+        bool isPending
+    ) internal virtual override {
+        super._beforeUnnestChild(tokenId, index, child, isPending);
+        if (isPending)
+            delete _childIsInPending[child.contractAddress][child.tokenId];
+    }
+}

--- a/contracts/RMRK/nesting/IRMRKNesting.sol
+++ b/contracts/RMRK/nesting/IRMRKNesting.sol
@@ -131,22 +131,6 @@ interface IRMRKNesting is IERC165 {
     ) external;
 
     /**
-     * @dev Function called to reclaim an abandoned child created by unnesting with `to` as the zero
-     * address. This function will set the child's owner to the rootOwner of the caller, allowing
-     * the rootOwner management permissions for the child.
-     *
-     * Requirements:
-     *
-     * - `tokenId` must exist
-     *
-     */
-    function reclaimChild(
-        uint256 tokenId,
-        address childAddress,
-        uint256 childTokenId
-    ) external;
-
-    /**
      * @dev Returns array of child objects existing for `parentTokenId`.
      *
      */

--- a/contracts/mocks/RMRKNestingMock.sol
+++ b/contracts/mocks/RMRKNestingMock.sol
@@ -59,7 +59,7 @@ contract RMRKNestingMock is RMRKNesting {
         uint256 fromTokenId,
         uint256 toTokenId,
         uint256 tokenId
-    ) internal override {
+    ) internal virtual override {
         super._beforeNestedTokenTransfer(
             from,
             to,
@@ -76,7 +76,7 @@ contract RMRKNestingMock is RMRKNesting {
         uint256 fromTokenId,
         uint256 toTokenId,
         uint256 tokenId
-    ) internal override {
+    ) internal virtual override {
         super._afterNestedTokenTransfer(
             from,
             to,

--- a/contracts/mocks/extensions/claimableChild/RMRKNestingClaimableChildMock.sol
+++ b/contracts/mocks/extensions/claimableChild/RMRKNestingClaimableChildMock.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+import "../../../RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol";
+import "../../RMRKNestingMock.sol";
+
+error RMRKTokenHasNoResourcesWithType();
+
+contract RMRKNestingClaimableChildMock is
+    RMRKNestingMock,
+    RMRKReclaimableChild
+{
+    constructor(string memory name, string memory symbol)
+        RMRKNestingMock(name, symbol)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(RMRKNesting, RMRKReclaimableChild)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _beforeAddChild(uint256 tokenId, Child memory child)
+        internal
+        virtual
+        override(RMRKNesting, RMRKReclaimableChild)
+    {
+        super._beforeAddChild(tokenId, child);
+    }
+
+    function _beforeAcceptChild(
+        uint256 tokenId,
+        uint256 index,
+        Child memory child
+    ) internal virtual override(RMRKNesting, RMRKReclaimableChild) {
+        super._beforeAcceptChild(tokenId, index, child);
+    }
+
+    function _beforeUnnestChild(
+        uint256 tokenId,
+        uint256 index,
+        Child memory child,
+        bool isPending
+    ) internal virtual override(RMRKNesting, RMRKReclaimableChild) {
+        super._beforeUnnestChild(tokenId, index, child, isPending);
+    }
+
+    function _beforeNestedTokenTransfer(
+        address from,
+        address to,
+        uint256 fromTokenId,
+        uint256 toTokenId,
+        uint256 tokenId
+    ) internal override(RMRKNestingMock, RMRKNesting) {
+        super._beforeNestedTokenTransfer(
+            from,
+            to,
+            fromTokenId,
+            toTokenId,
+            tokenId
+        );
+    }
+
+    function _afterNestedTokenTransfer(
+        address from,
+        address to,
+        uint256 fromTokenId,
+        uint256 toTokenId,
+        uint256 tokenId
+    ) internal override(RMRKNestingMock, RMRKNesting) {
+        super._afterNestedTokenTransfer(
+            from,
+            to,
+            fromTokenId,
+            toTokenId,
+            tokenId
+        );
+    }
+}

--- a/test/extensions/reclaimableChild.ts
+++ b/test/extensions/reclaimableChild.ts
@@ -1,0 +1,147 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ADDRESS_ZERO, bn, mintFromMock, nestMintFromMock } from '../utils';
+import { IERC165, IOtherInterface, IRMRKNesting, IRMRKReclaimableChild } from '../interfaces';
+
+// --------------- FIXTURES -----------------------
+
+async function reclaimableChildNestingFixture() {
+  const factory = await ethers.getContractFactory('RMRKNestingClaimableChildMock');
+  const child = await factory.deploy('Chunky', 'CHNK');
+  const parent = await factory.deploy('Chunky', 'CHNK');
+  await parent.deployed();
+  await child.deployed();
+
+  return { parent, child };
+}
+
+describe('RMRKNestingClaimableChildMock', async function () {
+  beforeEach(async function () {
+    const { parent, child } = await loadFixture(reclaimableChildNestingFixture);
+    this.parent = parent;
+    this.child = child;
+  });
+
+  shouldBehaveLikeReclaimableChild();
+});
+
+async function shouldBehaveLikeReclaimableChild() {
+  let addrs: SignerWithAddress[];
+  let tokenOwner: SignerWithAddress;
+  let parentId: number;
+  let childId: number;
+
+  beforeEach(async function () {
+    addrs = await ethers.getSigners();
+    tokenOwner = addrs[1];
+
+    parentId = await mintFromMock(this.parent, tokenOwner.address);
+    childId = await nestMintFromMock(this.child, this.parent.address, parentId);
+  });
+
+  it('can support IERC165', async function () {
+    expect(await this.parent.supportsInterface(IERC165)).to.equal(true);
+  });
+
+  it('can support IRMRKReclaimableChild', async function () {
+    expect(await this.parent.supportsInterface(IRMRKReclaimableChild)).to.equal(true);
+  });
+
+  it('can support IRMRKNesting', async function () {
+    expect(await this.parent.supportsInterface(IRMRKNesting)).to.equal(true);
+  });
+
+  it('does not support other interfaces', async function () {
+    expect(await this.parent.supportsInterface(IOtherInterface)).to.equal(false);
+  });
+
+  describe('With active child', async function () {
+    beforeEach(async function () {
+      await this.parent.connect(tokenOwner).acceptChild(parentId, 0);
+    });
+
+    it('can reclaim unnested child if unnested to address zero', async function () {
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, ADDRESS_ZERO, false);
+
+      await this.parent.connect(tokenOwner).reclaimChild(parentId, this.child.address, childId);
+      expect(await this.child.ownerOf(childId)).to.eql(tokenOwner.address);
+      expect(await this.child.rmrkOwnerOf(childId)).to.eql([tokenOwner.address, bn(0), false]);
+    });
+
+    it('cannot reclaim active child', async function () {
+      await expect(
+        this.parent.connect(tokenOwner).reclaimChild(parentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'RMRKInvalidChildReclaim');
+    });
+
+    it('cannot reclaim unnested child if unnested to a non zero address', async function () {
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, addrs[2].address, false);
+
+      await expect(
+        this.parent.connect(tokenOwner).reclaimChild(parentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'RMRKInvalidChildReclaim');
+    });
+
+    it('cannot reclaim unnested child from different parent token', async function () {
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, ADDRESS_ZERO, false);
+      const otherParentId = await mintFromMock(this.parent, tokenOwner.address);
+
+      await expect(
+        this.parent.connect(tokenOwner).reclaimChild(otherParentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'RMRKInvalidChildReclaim');
+    });
+
+    it('cannot reclaim unnested child from a non owned parent token', async function () {
+      const notParent = addrs[2];
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, ADDRESS_ZERO, false);
+
+      await expect(
+        this.parent.connect(notParent).reclaimChild(parentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'ERC721NotApprovedOrOwner');
+    });
+  });
+
+  describe('With pending child', async function () {
+    it('can reclaim unnested child if unnested to address zero', async function () {
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, ADDRESS_ZERO, true);
+
+      await this.parent.connect(tokenOwner).reclaimChild(parentId, this.child.address, childId);
+      expect(await this.child.ownerOf(childId)).to.eql(tokenOwner.address);
+      expect(await this.child.rmrkOwnerOf(childId)).to.eql([tokenOwner.address, bn(0), false]);
+    });
+
+    it('cannot reclaim pending child', async function () {
+      await expect(
+        this.parent.connect(tokenOwner).reclaimChild(parentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'RMRKInvalidChildReclaim');
+    });
+
+    it('cannot reclaim unnested child if unnested to a non zero address', async function () {
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, addrs[2].address, true);
+
+      await expect(
+        this.parent.connect(tokenOwner).reclaimChild(parentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'RMRKInvalidChildReclaim');
+    });
+
+    it('cannot reclaim unnested child from different parent token', async function () {
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, ADDRESS_ZERO, true);
+      const otherParentId = await mintFromMock(this.parent, tokenOwner.address);
+
+      await expect(
+        this.parent.connect(tokenOwner).reclaimChild(otherParentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'RMRKInvalidChildReclaim');
+    });
+
+    it('cannot reclaim unnested child from a non owned parent token', async function () {
+      const notParent = addrs[2];
+      await this.parent.connect(tokenOwner).unnestChild(parentId, 0, ADDRESS_ZERO, true);
+
+      await expect(
+        this.parent.connect(notParent).reclaimChild(parentId, this.child.address, childId),
+      ).to.be.revertedWithCustomError(this.parent, 'ERC721NotApprovedOrOwner');
+    });
+  });
+}

--- a/test/extensions/typedMultiResource.ts
+++ b/test/extensions/typedMultiResource.ts
@@ -4,6 +4,14 @@ import { expect } from 'chai';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { bn, mintFromMock } from '../utils';
+import {
+  IERC165,
+  IRMRKEquippable,
+  IRMRKMultiResource,
+  IRMRKNesting,
+  IRMRKTypedMultiResource,
+  IOtherInterface,
+} from '../interfaces';
 
 // --------------- FIXTURES -----------------------
 
@@ -127,23 +135,25 @@ describe('RMRKNestingTypedMultiResourceMock', async function () {
   });
 
   it('can support IERC165', async function () {
-    expect(await typedNestingMultiResource.supportsInterface('0x01ffc9a7')).to.equal(true);
+    expect(await typedNestingMultiResource.supportsInterface(IERC165)).to.equal(true);
   });
 
   it('can support IMultiResource', async function () {
-    expect(await typedNestingMultiResource.supportsInterface('0xc65a6425')).to.equal(true);
+    expect(await typedNestingMultiResource.supportsInterface(IRMRKMultiResource)).to.equal(true);
   });
 
   it('can support INesting', async function () {
-    expect(await typedNestingMultiResource.supportsInterface('0xc71287ad')).to.equal(true);
+    expect(await typedNestingMultiResource.supportsInterface(IRMRKNesting)).to.equal(true);
   });
 
   it('can support IRMRKTypedMultiResource', async function () {
-    expect(await typedNestingMultiResource.supportsInterface('0xb6a3032e')).to.equal(true);
+    expect(await typedNestingMultiResource.supportsInterface(IRMRKTypedMultiResource)).to.equal(
+      true,
+    );
   });
 
   it('does not support other interfaces', async function () {
-    expect(await typedNestingMultiResource.supportsInterface('0xffffffff')).to.equal(false);
+    expect(await typedNestingMultiResource.supportsInterface(IOtherInterface)).to.equal(false);
   });
 
   it('can add typed resources', async function () {
@@ -176,27 +186,27 @@ describe('RMRKTypedEquippableMock', async function () {
   });
 
   it('can support IERC165', async function () {
-    expect(await typedEquippable.supportsInterface('0x01ffc9a7')).to.equal(true);
+    expect(await typedEquippable.supportsInterface(IERC165)).to.equal(true);
   });
 
   it('can support IMultiResource', async function () {
-    expect(await typedEquippable.supportsInterface('0xc65a6425')).to.equal(true);
+    expect(await typedEquippable.supportsInterface(IRMRKMultiResource)).to.equal(true);
   });
 
   it('can support INesting', async function () {
-    expect(await typedEquippable.supportsInterface('0xc71287ad')).to.equal(true);
+    expect(await typedEquippable.supportsInterface(IRMRKNesting)).to.equal(true);
   });
 
   it('can support IEquippable', async function () {
-    expect(await typedEquippable.supportsInterface('0xd3a28ca0')).to.equal(true);
+    expect(await typedEquippable.supportsInterface(IRMRKEquippable)).to.equal(true);
   });
 
   it('can support IRMRKTypedMultiResource', async function () {
-    expect(await typedEquippable.supportsInterface('0xb6a3032e')).to.equal(true);
+    expect(await typedEquippable.supportsInterface(IRMRKTypedMultiResource)).to.equal(true);
   });
 
   it('does not support other interfaces', async function () {
-    expect(await typedEquippable.supportsInterface('0xffffffff')).to.equal(false);
+    expect(await typedEquippable.supportsInterface(IOtherInterface)).to.equal(false);
   });
 
   it('can add typed resources', async function () {

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -1,0 +1,31 @@
+const IERC165 = '0x01ffc9a7';
+const IERC721 = '0x80ac58cd';
+const IOtherInterface = '0xffffffff';
+const IRMRKBaseStorage = '0xd912401f';
+const IRMRKEquippable = '0xd3a28ca0';
+const IRMRKExternalEquip = '0xe5383e6c';
+const IRMRKMultiResource = '0xc65a6425';
+const IRMRKNesting = '0xe8a71d62';
+const IRMRKNestingExternalEquip = '0x8b7f3e99';
+const IRMRKReclaimableChild = '0x2fb59acf';
+const IRMRKRenderUtils = '0x93668f28';
+const IRMRKRenderUtilsEquip = '0x65307461';
+const IRMRKSoulboundMultiResource = '0x911ec470';
+const IRMRKTypedMultiResource = '0xb6a3032e';
+
+export {
+  IERC165,
+  IERC721,
+  IOtherInterface,
+  IRMRKBaseStorage,
+  IRMRKEquippable,
+  IRMRKExternalEquip,
+  IRMRKMultiResource,
+  IRMRKNesting,
+  IRMRKNestingExternalEquip,
+  IRMRKReclaimableChild,
+  IRMRKRenderUtils,
+  IRMRKRenderUtilsEquip,
+  IRMRKSoulboundMultiResource,
+  IRMRKTypedMultiResource,
+};


### PR DESCRIPTION
Adds hooks on all children management operations.
Removes reclaimChild from IRMRKNesting.
Implements a new IRMRKReclaimableChild extension.