### PR TITLE
Extract errors to a library

### DIFF
--- a/contracts/RMRK/access/OwnableLock.sol
+++ b/contracts/RMRK/access/OwnableLock.sol
@@ -3,16 +3,11 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/Context.sol";
+import "../library/RMRKErrors.sol";
 
 /*
 Minimal ownable lock, based on "openzeppelin's access/Ownable.sol";
 */
-error RMRKLocked();
-error RMRKNotOwner();
-error RMRKNotOwnerOrContributor();
-error RMRKNewOwnerIsZeroAddress();
-error RMRKNewContributorIsZeroAddress();
-
 contract OwnableLock is Context {
     bool private _lock;
     address private _owner;

--- a/contracts/RMRK/base/RMRKBaseStorage.sol
+++ b/contracts/RMRK/base/RMRKBaseStorage.sol
@@ -4,14 +4,8 @@ pragma solidity ^0.8.15;
 
 import "./IRMRKBaseStorage.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
+import "../library/RMRKErrors.sol";
 // import "hardhat/console.sol";
-
-error RMRKBadConfig();
-error RMRKIdZeroForbidden();
-error RMRKPartAlreadyExists();
-error RMRKPartDoesNotExist();
-error RMRKPartIsNotSlot();
-error RMRKZeroLengthIdsPassed();
 
 /**
  * @dev Base storage contract for RMRK equippable module.

--- a/contracts/RMRK/base/RMRKBaseStorage.sol
+++ b/contracts/RMRK/base/RMRKBaseStorage.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.15;
 import "./IRMRKBaseStorage.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "../library/RMRKErrors.sol";
+
 // import "hardhat/console.sol";
 
 /**

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -10,6 +10,7 @@ import "../multiresource/AbstractMultiResource.sol";
 import "../nesting/RMRKNesting.sol";
 import "../security/ReentrancyGuard.sol";
 import "./IRMRKEquippable.sol";
+
 // import "hardhat/console.sol";
 
 contract RMRKEquippable is

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -12,19 +12,6 @@ import "../security/ReentrancyGuard.sol";
 import "./IRMRKEquippable.sol";
 // import "hardhat/console.sol";
 
-// MultiResource
-error RMRKNotApprovedForResourcesOrOwner();
-error RMRKApprovalForResourcesToCurrentOwner();
-error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
-// Equippable
-error RMRKBaseRequiredForParts();
-error RMRKEquippableEquipNotAllowedByBase();
-error RMRKMustUnequipFirst();
-error RMRKNotEquipped();
-error RMRKSlotAlreadyUsed();
-error RMRKTargetResourceCannotReceiveSlot();
-error RMRKTokenCannotBeEquippedWithResourceIntoSlot();
-
 contract RMRKEquippable is
     ReentrancyGuard,
     RMRKNesting,

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -16,6 +16,7 @@ import "../security/ReentrancyGuard.sol";
 import "./IRMRKNestingExternalEquip.sol";
 import "./IRMRKExternalEquip.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 // import "hardhat/console.sol";
 
 /**

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -18,20 +18,6 @@ import "./IRMRKExternalEquip.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 // import "hardhat/console.sol";
 
-// MultiResource
-error RMRKNotApprovedForResourcesOrOwner();
-error RMRKApprovalForResourcesToCurrentOwner();
-error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
-// Equippable
-error ERC721InvalidTokenId();
-error ERC721NotApprovedOrOwner();
-error RMRKBaseRequiredForParts();
-error RMRKEquippableEquipNotAllowedByBase();
-error RMRKNotEquipped();
-error RMRKSlotAlreadyUsed();
-error RMRKTargetResourceCannotReceiveSlot();
-error RMRKTokenCannotBeEquippedWithResourceIntoSlot();
-
 /**
  * @dev RMRKEquippable external contract, expected to be paired with an instance of RMRKNestingExternalEquip.sol. This
  * contract takes over

--- a/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
@@ -8,6 +8,7 @@ import "../../RMRK/equippable/IRMRKEquippable.sol";
 import "../../RMRK/equippable/IRMRKExternalEquip.sol";
 import "../../RMRK/equippable/IRMRKNestingExternalEquip.sol";
 import "../../RMRK/nesting/RMRKNesting.sol";
+
 // import "hardhat/console.sol";
 
 /**

--- a/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
@@ -10,8 +10,6 @@ import "../../RMRK/equippable/IRMRKNestingExternalEquip.sol";
 import "../../RMRK/nesting/RMRKNesting.sol";
 // import "hardhat/console.sol";
 
-error RMRKMustUnequipFirst();
-
 /**
  * @dev RMRKNesting contract with external equippable contract for space saving purposes. Expected to be deployed along
  * an instance of RMRKExternalEquip.sol. To make use of the equippable module with this contract, expose the _setEquippableAddress

--- a/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
+++ b/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
@@ -5,8 +5,6 @@ pragma solidity ^0.8.15;
 import "../../nesting/RMRKNesting.sol";
 import "./IRMRKReclaimableChild.sol";
 
-error RMRKInvalidChildReclaim();
-
 abstract contract RMRKReclaimableChild is IRMRKReclaimableChild, RMRKNesting {
     // WARNING: This mapping is not updated on burn or reject all, to save gas.
     // This is only used to cheaply forbid reclaiming a child which is pending

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -4,8 +4,7 @@ pragma solidity ^0.8.15;
 
 import "../../core/RMRKCore.sol";
 import "./IRMRKSoulbound.sol";
-
-error RMRKCannotTransferSoulbound();
+import "../../library/RMRKErrors.sol";
 
 abstract contract RMRKSoulbound is IRMRKSoulbound, RMRKCore {
     function _beforeTokenTransfer(

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -20,15 +20,15 @@ error ERC721ApprovedQueryForNonexistentToken();
 error ERC721ApproveToCaller();
 /// Attempting to use an invalid token ID
 error ERC721InvalidTokenId();
-/// Attempting to mint to 0x0 addressß
+/// Attempting to mint to 0x0 address
 error ERC721MintToTheZeroAddress();
 /// Attempting to manage a token without being its owner or approved by the owner
 error ERC721NotApprovedOrOwner();
 /// Attempting to mint an already minted token
 error ERC721TokenAlreadyMinted();
-/// Attempting to transfer the token form and address that is not the owner
+/// Attempting to transfer the token from an address that is not the owner
 error ERC721TransferFromIncorrectOwner();
-/// Attempting to transfer to an address that is unable to receive the token
+/// Attempting to safe transfer to an address that is unable to receive the token
 error ERC721TransferToNonReceiverImplementer();
 /// Attempting to transfer the token to a 0x0 address
 error ERC721TransferToTheZeroAddress();
@@ -36,11 +36,9 @@ error ERC721TransferToTheZeroAddress();
 error RMRKApprovalForResourcesToCurrentOwner();
 /// Attempting to grant approval of resources without being the caller or approved for all
 error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
-/// Attempting to grant resource approval to self
-error RMRKApproveForResourcesToCaller();
 /// Attempting to incorrectly configue a Base item
 error RMRKBadConfig();
-/// Attempting to set the priorities with an array of length that doesn't match the resource length
+/// Attempting to set the priorities with an array of length that doesn't match the length of active resources array
 error RMRKBadPriorityListLength();
 /// Attempting to add a resource entry without a `Part`
 error RMRKBaseRequiredForParts();
@@ -50,7 +48,7 @@ error RMRKCannotTransferSoulbound();
 error RMRKChildAlreadyExists();
 /// Attempting to interact with a child, using index that is higher than the number of children
 error RMRKChildIndexOutOfRange();
-/// Attempting to equip a `Part` that does not allow equipping to the desired address
+/// Attempting to equip a `Part` with a child not approved by the base
 error RMRKEquippableEquipNotAllowedByBase();
 /// Attempting to use ID 0, which is not supported
 /// @dev The ID 0 in RMRK suite is reserved for empty values. Guarding against its use ensures the expected operation
@@ -59,9 +57,9 @@ error RMRKIdZeroForbidden();
 error RMRKIndexOutOfRange();
 /// Attempting to reclaim a child that can't be reclaimed
 error RMRKInvalidChildReclaim();
-/// Attempting to interact with an end-user accoutn when the contract account is expected
+/// Attempting to interact with an end-user account when the contract account is expected
 error RMRKIsNotContract();
-/// Attempting to interact with a contract that had its operation paused
+/// Attempting to interact with a contract that had its operation locked
 error RMRKLocked();
 /// Attempting to add a pending child after the number of pending children has reached the limit (default limit is 128)
 error RMRKMaxPendingChildrenReached();
@@ -86,14 +84,16 @@ error RMRKNestingTransferToSelf();
 error RMRKNoResourceMatchingId();
 /// Attempting to manage a resource without owning it or having been granted permission by the owner to do so
 error RMRKNotApprovedForResourcesOrOwner();
-/// Attempting to interact with a token or resource without being its owner or having been granted permission by the
+/// Attempting to interact with a token without being its owner or having been granted permission by the
 ///  owner to do so
+/// @dev When a token is nested, only the direct owner (NFT parent) can mange it. In that case, approved addresses are
+///  not allowed to manage it, in order to ensure the expected behaviour
 error RMRKNotApprovedOrDirectOwner();
-/// Attempting to compose a resource wihtout an address
+/// Attempting to compose a resource wihtout having an associated Base
 error RMRKNotComposableResource();
 /// Attempting to unequip an item that isn't equipped
 error RMRKNotEquipped();
-/// Attempting to interact with a token or resource without being its owner
+/// Attempting to interact with a management function without being the smart contract's owner
 error RMRKNotOwner();
 /// Attempting to interact with a function without being the owner or contributor of the collection
 error RMRKNotOwnerOrContributor();
@@ -111,15 +111,15 @@ error RMRKPartIsNotSlot();
 error RMRKPendingChildIndexOutOfRange();
 /// Attempting to add a resource using an ID that has already been used
 error RMRKResourceAlreadyExists();
-/// Attempting to equip an item into a slot that already has an item euipped
+/// Attempting to equip an item into a slot that already has an item equipped
 error RMRKSlotAlreadyUsed();
-/// Attempting to equip an item into a resource that is not a `Slot`
+/// Attempting to equip an item into a `Slot` that the target resource does not implement
 error RMRKTargetResourceCannotReceiveSlot();
-/// Attempting to equip a child into a slot that doesn't support the tokens from child's collection
+/// Attempting to equip a child into a `Slot` and parent that the child's collection doesn't support
 error RMRKTokenCannotBeEquippedWithResourceIntoSlot();
 /// Attempting to compose a NFT of a token without active resources
 error RMRKTokenDoesNotHaveActiveResource();
-/// Attempting to determine a priority of tokens resources wihtout them being defined
+/// Attempting to determine the resource with the top priority on a token without resources
 error RMRKTokenHasNoResources();
-/// Attempting not to pass an empth array of equippable addresses when adding or setting the equippable addresses
+/// Attempting not to pass an empty array of equippable addresses when adding or setting the equippable addresses
 error RMRKZeroLengthIdsPassed();

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.15;
+
+error ERC721AddressZeroIsNotaValidOwner();
+error ERC721ApprovalToCurrentOwner();
+error ERC721ApproveCallerIsNotOwnerNorApprovedForAll();
+error ERC721ApprovedQueryForNonexistentToken();
+error ERC721ApproveToCaller();
+error ERC721InvalidTokenId();
+error ERC721MintToTheZeroAddress();
+error ERC721NotApprovedOrOwner();
+error ERC721TokenAlreadyMinted();
+error ERC721TransferFromIncorrectOwner();
+error ERC721TransferToNonReceiverImplementer();
+error ERC721TransferToTheZeroAddress();
+error RMRKApprovalForResourcesToCurrentOwner();
+error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
+error RMRKApproveForResourcesToCaller();
+error RMRKBadConfig();
+error RMRKBadPriorityListLength();
+error RMRKBaseRequiredForParts();
+error RMRKCannotTransferSoulbound();
+error RMRKChildAlreadyExists();
+error RMRKChildIndexOutOfRange();
+error RMRKEquippableEquipNotAllowedByBase();
+error RMRKIdZeroForbidden();
+error RMRKIndexOutOfRange();
+error RMRKInvalidChildReclaim();
+error RMRKIsNotContract();
+error RMRKLocked();
+error RMRKMaxPendingChildrenReached();
+error RMRKMaxPendingResourcesReached();
+error RMRKMintOverMax();
+error RMRKMintToNonRMRKImplementer();
+error RMRKMustUnequipFirst();
+error RMRKNestingTooDeep();
+error RMRKNestingTransferToDescendant();
+error RMRKNestingTransferToNonRMRKNestingImplementer();
+error RMRKNestingTransferToSelf();
+error RMRKNoResourceMatchingId();
+error RMRKNotApprovedForResourcesOrOwner();
+error RMRKNotApprovedOrDirectOwner();
+error RMRKNotComposableResource();
+error RMRKNotEquipped();
+error RMRKNotOwner();
+error RMRKNotOwnerOrContributor();
+error RMRKNewOwnerIsZeroAddress();
+error RMRKNewContributorIsZeroAddress();
+error RMRKPartAlreadyExists();
+error RMRKPartDoesNotExist();
+error RMRKPartIsNotSlot();
+error RMRKPendingChildIndexOutOfRange();
+error RMRKResourceAlreadyExists();
+error RMRKSlotAlreadyUsed();
+error RMRKTargetResourceCannotReceiveSlot();
+error RMRKTokenCannotBeEquippedWithResourceIntoSlot();
+error RMRKTokenDoesNotHaveActiveResource();
+error RMRKTokenHasNoResources();
+error RMRKZeroLengthIdsPassed();
+
+contract RMRKErrors {
+
+}

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -58,7 +58,3 @@ error RMRKTokenCannotBeEquippedWithResourceIntoSlot();
 error RMRKTokenDoesNotHaveActiveResource();
 error RMRKTokenHasNoResources();
 error RMRKZeroLengthIdsPassed();
-
-contract RMRKErrors {
-
-}

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -40,7 +40,7 @@ error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
 error RMRKBadConfig();
 /// Attempting to set the priorities with an array of length that doesn't match the length of active resources array
 error RMRKBadPriorityListLength();
-/// Attempting to add a resource entry without a `Part`
+/// Attempting to add a resource entry with `Part`s, without setting the `Base` address
 error RMRKBaseRequiredForParts();
 /// Attempting to transfer a soulbound (non-transferrable) token
 error RMRKCannotTransferSoulbound();

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -2,59 +2,124 @@
 
 pragma solidity ^0.8.15;
 
+/// @title RMRKErrors
+/// @author RMRK team
+/// @notice A collection of errors used in the RMRK suite
+/// @dev Errors are kept in a centralised file in order to provide a central point of reference and to avoid error
+///  naming collisions due to inheritance
+
+/// Attempting to grant the token to 0x0 address
 error ERC721AddressZeroIsNotaValidOwner();
+/// Attempting to grant approval to the current owner of the token
 error ERC721ApprovalToCurrentOwner();
+/// Attempting to grant approval when not being owner or approved for all should not be permitted
 error ERC721ApproveCallerIsNotOwnerNorApprovedForAll();
+/// Attempting to get approvals for a token owned by 0x0 (considered non-existent)
 error ERC721ApprovedQueryForNonexistentToken();
+/// Attempting to grant approval to self
 error ERC721ApproveToCaller();
+/// Attempting to use an invalid token ID
 error ERC721InvalidTokenId();
+/// Attempting to mint to 0x0 addressß
 error ERC721MintToTheZeroAddress();
+/// Attempting to manage a token without being its owner or approved by the owner
 error ERC721NotApprovedOrOwner();
+/// Attempting to mint an already minted token
 error ERC721TokenAlreadyMinted();
+/// Attempting to transfer the token form and address that is not the owner
 error ERC721TransferFromIncorrectOwner();
+/// Attempting to transfer to an address that is unable to receive the token
 error ERC721TransferToNonReceiverImplementer();
+/// Attempting to transfer the token to a 0x0 address
 error ERC721TransferToTheZeroAddress();
+/// Attempting to grant approval of resources to their current owner
 error RMRKApprovalForResourcesToCurrentOwner();
+/// Attempting to grant approval of resources without being the caller or approved for all
 error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
+/// Attempting to grant resource approval to self
 error RMRKApproveForResourcesToCaller();
+/// Attempting to incorrectly configue a Base item
 error RMRKBadConfig();
+/// Attempting to set the priorities with an array of length that doesn't match the resource length
 error RMRKBadPriorityListLength();
+/// Attempting to add a resource entry without a `Part`
 error RMRKBaseRequiredForParts();
+/// Attempting to transfer a soulbound (non-transferrable) token
 error RMRKCannotTransferSoulbound();
+/// Attempting to accept a child that has already been accepted
 error RMRKChildAlreadyExists();
+/// Attempting to interact with a child, using index that is higher than the number of children
 error RMRKChildIndexOutOfRange();
+/// Attempting to equip a `Part` that does not allow equipping to the desired address
 error RMRKEquippableEquipNotAllowedByBase();
+/// Attempting to use ID 0, which is not supported
+/// @dev The ID 0 in RMRK suite is reserved for empty values. Guarding against its use ensures the expected operation
 error RMRKIdZeroForbidden();
+/// Attempting to interact with a resource, using index greater than number of resources
 error RMRKIndexOutOfRange();
+/// Attempting to reclaim a child that can't be reclaimed
 error RMRKInvalidChildReclaim();
+/// Attempting to interact with an end-user accoutn when the contract account is expected
 error RMRKIsNotContract();
+/// Attempting to interact with a contract that had its operation paused
 error RMRKLocked();
+/// Attempting to add a pending child after the number of pending children has reached the limit (default limit is 128)
 error RMRKMaxPendingChildrenReached();
+/// Attempting to add a pending resource after the number of pending resources has reached the limit (default limit is
+///  128)
 error RMRKMaxPendingResourcesReached();
+/// Attempting to mint a number of tokens that would cause the total supply to be greater than maximum supply
 error RMRKMintOverMax();
+/// Attempting to mint a nested token to a smart contract that doesn't support nesting
 error RMRKMintToNonRMRKImplementer();
+/// Attempting to unnest a child before it is unequipped
 error RMRKMustUnequipFirst();
+/// Attempting to nest a child over the nesting limit (current limit is 100 levels of nesting)
 error RMRKNestingTooDeep();
+/// Attempting to nest the token to own descendant, which would create a loop and leave the looped tokens in limbo
 error RMRKNestingTransferToDescendant();
+/// Attempting to nest the token to a smart contract that doesn't support nesting
 error RMRKNestingTransferToNonRMRKNestingImplementer();
+/// Attempting to nest the token into itself
 error RMRKNestingTransferToSelf();
+/// Attempting to interact with a resource that can not be found
 error RMRKNoResourceMatchingId();
+/// Attempting to manage a resource without owning it or having been granted permission by the owner to do so
 error RMRKNotApprovedForResourcesOrOwner();
+/// Attempting to interact with a token or resource without being its owner or having been granted permission by the
+///  owner to do so
 error RMRKNotApprovedOrDirectOwner();
+/// Attempting to compose a resource wihtout an address
 error RMRKNotComposableResource();
+/// Attempting to unequip an item that isn't equipped
 error RMRKNotEquipped();
+/// Attempting to interact with a token or resource without being its owner
 error RMRKNotOwner();
+/// Attempting to interact with a function without being the owner or contributor of the collection
 error RMRKNotOwnerOrContributor();
+/// Attempting to transfer the ownership to the 0x0 address
 error RMRKNewOwnerIsZeroAddress();
+/// Attempting to assign a 0x0 address as a contributor
 error RMRKNewContributorIsZeroAddress();
+/// Attempting to add a `Part` with an ID that is already used
 error RMRKPartAlreadyExists();
+/// Attempting to use a `Part` that doesn't exist
 error RMRKPartDoesNotExist();
+/// Attempting to use a `Part` that is `Fixed` when `Slot` kind of `Part` should be used
 error RMRKPartIsNotSlot();
+/// Attempting to interact with a pending child using an index greater than the size of pending array
 error RMRKPendingChildIndexOutOfRange();
+/// Attempting to add a resource using an ID that has already been used
 error RMRKResourceAlreadyExists();
+/// Attempting to equip an item into a slot that already has an item euipped
 error RMRKSlotAlreadyUsed();
+/// Attempting to equip an item into a resource that is not a `Slot`
 error RMRKTargetResourceCannotReceiveSlot();
+/// Attempting to equip a child into a slot that doesn't support the tokens from child's collection
 error RMRKTokenCannotBeEquippedWithResourceIntoSlot();
+/// Attempting to compose a NFT of a token without active resources
 error RMRKTokenDoesNotHaveActiveResource();
+/// Attempting to determine a priority of tokens resources wihtout them being defined
 error RMRKTokenHasNoResources();
+/// Attempting not to pass an empth array of equippable addresses when adding or setting the equippable addresses
 error RMRKZeroLengthIdsPassed();

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -160,7 +160,7 @@ abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
         virtual
     {
         address owner = _msgSender();
-        if (owner == operator) revert RMRKApproveForResourcesToCaller();
+        if (owner == operator) revert RMRKApprovalForResourcesToCurrentOwner();
 
         _operatorApprovalsForResources[owner][operator] = approved;
         emit ApprovalForAllForResources(owner, operator, approved);

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -5,14 +5,7 @@ pragma solidity ^0.8.15;
 import "./IRMRKMultiResource.sol";
 import "../library/RMRKLib.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
-
-error RMRKApproveForResourcesToCaller();
-error RMRKBadPriorityListLength();
-error RMRKIndexOutOfRange();
-error RMRKMaxPendingResourcesReached();
-error RMRKNoResourceMatchingId();
-error RMRKResourceAlreadyExists();
-error RMRKIdZeroForbidden();
+import "../library/RMRKErrors.sol";
 
 abstract contract AbstractMultiResource is Context, IRMRKMultiResource {
     using RMRKLib for uint64[];

--- a/contracts/RMRK/multiresource/RMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/RMRKMultiResource.sol
@@ -11,8 +11,8 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "./AbstractMultiResource.sol";
 import "../core/RMRKCore.sol";
 import "../library/RMRKErrors.sol";
-// import "hardhat/console.sol";
 
+// import "hardhat/console.sol";
 
 /**
  * @dev Implementation of RMRK Multiresource contract, on top of ERC721.

--- a/contracts/RMRK/multiresource/RMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/RMRKMultiResource.sol
@@ -424,7 +424,7 @@ contract RMRKMultiResource is
         address to,
         uint256 tokenId,
         bytes memory data
-    ) internal returns (bool) {
+    ) private returns (bool) {
         if (to.isContract()) {
             try
                 IERC721Receiver(to).onERC721Received(

--- a/contracts/RMRK/multiresource/RMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/RMRKMultiResource.sol
@@ -10,23 +10,9 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "./AbstractMultiResource.sol";
 import "../core/RMRKCore.sol";
+import "../library/RMRKErrors.sol";
 // import "hardhat/console.sol";
 
-error ERC721AddressZeroIsNotaValidOwner();
-error ERC721ApprovalToCurrentOwner();
-error ERC721ApproveCallerIsNotOwnerNorApprovedForAll();
-error ERC721ApproveToCaller();
-error ERC721InvalidTokenId();
-error ERC721MintToTheZeroAddress();
-error ERC721NotApprovedOrOwner();
-error ERC721TokenAlreadyMinted();
-error ERC721TransferFromIncorrectOwner();
-error ERC721TransferToNonReceiverImplementer();
-error ERC721TransferToTheZeroAddress();
-error RMRKApprovalForResourcesToCurrentOwner();
-error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
-error RMRKNotApprovedForResourcesOrOwner();
-error RMRKTokenIdZeroForbidden();
 
 /**
  * @dev Implementation of RMRK Multiresource contract, on top of ERC721.
@@ -318,7 +304,7 @@ contract RMRKMultiResource is
     function _mint(address to, uint256 tokenId) internal virtual {
         if (to == address(0)) revert ERC721MintToTheZeroAddress();
         if (_exists(tokenId)) revert ERC721TokenAlreadyMinted();
-        if (tokenId == 0) revert RMRKTokenIdZeroForbidden();
+        if (tokenId == 0) revert RMRKIdZeroForbidden();
 
         _beforeTokenTransfer(address(0), to, tokenId);
 

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -15,6 +15,7 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "../library/RMRKErrors.sol";
+
 // import "hardhat/console.sol";
 
 /**

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -679,7 +679,7 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
         address to,
         uint256 tokenId,
         bytes memory data
-    ) internal returns (bool) {
+    ) private returns (bool) {
         if (to.isContract()) {
             try
                 IERC721Receiver(to).onERC721Received(

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -14,32 +14,8 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
+import "../library/RMRKErrors.sol";
 // import "hardhat/console.sol";
-
-error ERC721AddressZeroIsNotaValidOwner();
-error ERC721ApprovalToCurrentOwner();
-error ERC721ApproveCallerIsNotOwnerNorApprovedForAll();
-error ERC721ApprovedQueryForNonexistentToken();
-error ERC721ApproveToCaller();
-error ERC721InvalidTokenId();
-error ERC721MintToTheZeroAddress();
-error ERC721NotApprovedOrOwner();
-error ERC721TokenAlreadyMinted();
-error ERC721TransferFromIncorrectOwner();
-error ERC721TransferToNonReceiverImplementer();
-error ERC721TransferToTheZeroAddress();
-error RMRKChildAlreadyExists();
-error RMRKChildIndexOutOfRange();
-error RMRKIsNotContract();
-error RMRKMaxPendingChildrenReached();
-error RMRKMintToNonRMRKImplementer();
-error RMRKNestingTooDeep();
-error RMRKNestingTransferToDescendant();
-error RMRKNestingTransferToNonRMRKNestingImplementer();
-error RMRKNestingTransferToSelf();
-error RMRKNotApprovedOrDirectOwner();
-error RMRKPendingChildIndexOutOfRange();
-error RMRKTokenIdZeroForbidden();
 
 /**
  * @dev RMRK nesting implementation. This contract is hierarchy agnostic, and can
@@ -406,7 +382,7 @@ contract RMRKNesting is Context, IERC165, IERC721, IRMRKNesting, RMRKCore {
     ) private {
         if (to == address(0)) revert ERC721MintToTheZeroAddress();
         if (_exists(tokenId)) revert ERC721TokenAlreadyMinted();
-        if (tokenId == 0) revert RMRKTokenIdZeroForbidden();
+        if (tokenId == 0) revert RMRKIdZeroForbidden();
 
         _beforeTokenTransfer(address(0), to, tokenId);
         _beforeNestedTokenTransfer(address(0), to, 0, destinationId, tokenId);

--- a/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 // import "hardhat/console.sol";
 
 /**

--- a/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
@@ -13,11 +13,6 @@ import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 // import "hardhat/console.sol";
 
-// MultiResource
-error RMRKNotApprovedForResourcesOrOwner();
-error RMRKApprovalForResourcesToCurrentOwner();
-error RMRKApproveForResourcesCallerIsNotOwnerNorApprovedForAll();
-
 /**
  * @dev Mid-level contract implementing multiresource on top of nesting.
  *

--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -3,13 +3,11 @@
 import "../base/IRMRKBaseStorage.sol";
 import "../equippable/IRMRKEquippable.sol";
 import "../library/RMRKLib.sol";
+import "../library/RMRKErrors.sol";
 import "./IRMRKEquipRenderUtils.sol";
 // import "hardhat/console.sol";
 
 pragma solidity ^0.8.15;
-
-error RMRKTokenDoesNotHaveActiveResource();
-error RMRKNotComposableResource();
 
 /**
  * @dev Extra utility functions for composing RMRK extended resources.

--- a/contracts/RMRK/utils/RMRKMintingUtils.sol
+++ b/contracts/RMRK/utils/RMRKMintingUtils.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import "../access/OwnableLock.sol";
+import "../library/RMRKErrors.sol";
 
 pragma solidity ^0.8.15;
-
-error RMRKMintOverMax();
 
 /**
  * @dev Top-level utilities for managing minting. Implements OwnableLock by default.

--- a/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
@@ -2,14 +2,13 @@
 
 import "contracts/RMRK/multiresource/IRMRKMultiResource.sol";
 import "contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol";
+import "../library/RMRKErrors.sol";
 
 pragma solidity ^0.8.15;
 
 /**
  * @dev Extra utility functions for composing RMRK resources.
  */
-
-error RMRKTokenHasNoResources();
 
 contract RMRKMultiResourceRenderUtils is IRMRKMultiResourceRenderUtils {
     uint16 private constant _LOWEST_POSSIBLE_PRIORITY = 2**16 - 1;

--- a/contracts/implementations/RMRKEquippableImpl.sol
+++ b/contracts/implementations/RMRKEquippableImpl.sol
@@ -90,8 +90,6 @@ contract RMRKEquippableImpl is
         uint64 resourceId,
         uint64 overwrites
     ) external onlyOwnerOrContributor {
-        // This reverts if token does not exist:
-        ownerOf(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/implementations/RMRKExternalEquipImpl.sol
+++ b/contracts/implementations/RMRKExternalEquipImpl.sol
@@ -17,8 +17,6 @@ contract RMRKExternalEquipImpl is OwnableLock, RMRKExternalEquip {
         uint64 resourceId,
         uint64 overwrites
     ) public onlyOwnerOrContributor {
-        // This reverts if token does not exist:
-        ownerOf(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/implementations/RMRKMultiResourceImpl.sol
+++ b/contracts/implementations/RMRKMultiResourceImpl.sol
@@ -72,7 +72,6 @@ contract RMRKMultiResourceImpl is
         uint64 resourceId,
         uint64 overwrites
     ) external onlyOwnerOrContributor {
-        _requireMinted(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/implementations/RMRKNestingMultiResourceImpl.sol
+++ b/contracts/implementations/RMRKNestingMultiResourceImpl.sol
@@ -91,7 +91,6 @@ contract RMRKNestingMultiResourceImpl is
         uint64 resourceId,
         uint64 overwrites
     ) external onlyOwnerOrContributor {
-        _requireMinted(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/mocks/RMRKEquippableMock.sol
+++ b/contracts/mocks/RMRKEquippableMock.sol
@@ -43,8 +43,6 @@ contract RMRKEquippableMock is RMRKEquippable {
         uint64 resourceId,
         uint64 overwrites
     ) external {
-        // This reverts if token does not exist:
-        ownerOf(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/mocks/RMRKExternalEquipMock.sol
+++ b/contracts/mocks/RMRKExternalEquipMock.sol
@@ -19,8 +19,6 @@ contract RMRKExternalEquipMock is RMRKExternalEquip {
         uint64 resourceId,
         uint64 overwrites
     ) external {
-        // This reverts if token does not exist:
-        ownerOf(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/mocks/RMRKMultiResourceMock.sol
+++ b/contracts/mocks/RMRKMultiResourceMock.sol
@@ -38,7 +38,6 @@ contract RMRKMultiResourceMock is RMRKMultiResource {
         uint64 resourceId,
         uint64 overwrites
     ) external {
-        _requireMinted(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/contracts/mocks/RMRKNestingMultiResourceMock.sol
+++ b/contracts/mocks/RMRKNestingMultiResourceMock.sol
@@ -41,7 +41,6 @@ contract RMRKNestingMultiResourceMock is RMRKNestingMultiResource {
         uint64 resourceId,
         uint64 overwrites
     ) external {
-        _requireMinted(tokenId);
         _addResourceToToken(tokenId, resourceId, overwrites);
     }
 

--- a/test/behavior/equippableResources.ts
+++ b/test/behavior/equippableResources.ts
@@ -213,15 +213,16 @@ async function shouldBehaveLikeEquippableResources(
       );
     });
 
-    it('cannot add resource to non existing token', async function () {
+    it('can add resource to non existing token and it is pending when minted', async function () {
       const resId = bn(1);
-      const tokenId = 1;
+      const lastTokenId = await mint(chunky, owner.address);
+      const nextTokenId = lastTokenId + 1; // not existing yet
 
       await addResources([resId]);
-      await expect(chunkyEquip.addResourceToToken(tokenId, resId, 0)).to.be.revertedWithCustomError(
-        chunky,
-        'ERC721InvalidTokenId',
-      );
+      await chunkyEquip.addResourceToToken(nextTokenId, resId, 0);
+      await mint(chunky, owner.address);
+
+      expect(await chunkyEquip.getPendingResources(nextTokenId)).to.eql([resId]);
     });
 
     it('cannot add resource twice to the same token', async function () {

--- a/test/behavior/multiresource.ts
+++ b/test/behavior/multiresource.ts
@@ -91,7 +91,7 @@ async function shouldBehaveLikeMultiResource(
       it('cannot approve owner for all resources', async function () {
         await expect(
           this.token.connect(tokenOwner).setApprovalForAllForResources(tokenOwner.address, true),
-        ).to.be.revertedWithCustomError(this.token, 'RMRKApproveForResourcesToCaller');
+        ).to.be.revertedWithCustomError(this.token, 'RMRKApprovalForResourcesToCurrentOwner');
       });
 
       it('cannot approve owner if not owner', async function () {

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -146,14 +146,14 @@ describe('MultiResourceMock Other Behavior', async function () {
       );
     });
 
-    it('cannot add resource to non existing token', async function () {
+    it('can add resource to non existing token and it is pending when minted', async function () {
       const resId = await addResourceEntryFromMock(token);
-      const tokenId = 9999;
+      const lastTokenId = await mintFromMock(token, tokenOwner.address);
+      const nextTokenId = lastTokenId + 1; // not existing yet
 
-      await expect(token.addResourceToToken(tokenId, resId, 0)).to.be.revertedWithCustomError(
-        token,
-        'ERC721InvalidTokenId',
-      );
+      await token.addResourceToToken(nextTokenId, resId, 0);
+      await mintFromMock(token, tokenOwner.address);
+      expect(await token.getPendingResources(nextTokenId)).to.eql([resId]);
     });
 
     it('cannot add resource twice to the same token', async function () {

--- a/test/multiresource.ts
+++ b/test/multiresource.ts
@@ -54,7 +54,7 @@ describe('MultiResourceMock Other Behavior', async function () {
     it('cannot mint id 0', async function () {
       await expect(
         token['mint(address,uint256)'](addrs[0].address, 0),
-      ).to.be.revertedWithCustomError(token, 'RMRKTokenIdZeroForbidden');
+      ).to.be.revertedWithCustomError(token, 'RMRKIdZeroForbidden');
     });
   });
 

--- a/test/nesting.ts
+++ b/test/nesting.ts
@@ -65,7 +65,7 @@ describe('NestingMock', function () {
       const tokenId = 0;
       await expect(
         child['mint(address,uint256)'](owner.address, tokenId),
-      ).to.be.revertedWithCustomError(child, 'RMRKTokenIdZeroForbidden');
+      ).to.be.revertedWithCustomError(child, 'RMRKIdZeroForbidden');
     });
 
     it('cannot nest mint id 0', async function () {
@@ -73,7 +73,7 @@ describe('NestingMock', function () {
       const childId = 0;
       await expect(
         child['nestMint(address,uint256,uint256)'](parent.address, childId, parentId),
-      ).to.be.revertedWithCustomError(child, 'RMRKTokenIdZeroForbidden');
+      ).to.be.revertedWithCustomError(child, 'RMRKIdZeroForbidden');
     });
 
     it('cannot mint already minted token', async function () {


### PR DESCRIPTION
Errors were extractred to a library smart contract. The contract option was picked over the library simply because deployment in such manner should conserve gas. The errors library smart contracts was then imported in the smart contracts and the inheritance tree respected, so that each instance only gets it inherited once.