### PR TITLE
Standardize pragma version

### DIFF
--- a/contracts/RMRK/access/OwnableLock.sol
+++ b/contracts/RMRK/access/OwnableLock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/utils/Context.sol";
 

--- a/contracts/RMRK/base/IRMRKBaseStorage.sol
+++ b/contracts/RMRK/base/IRMRKBaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/RMRK/base/RMRKBaseStorage.sol
+++ b/contracts/RMRK/base/RMRKBaseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "./IRMRKBaseStorage.sol";
 import "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/RMRK/core/IRMRKCore.sol
+++ b/contracts/RMRK/core/IRMRKCore.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 interface IRMRKCore {
     /**

--- a/contracts/RMRK/core/RMRKCore.sol
+++ b/contracts/RMRK/core/RMRKCore.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "./IRMRKCore.sol";
 

--- a/contracts/RMRK/equippable/IRMRKEquippable.sol
+++ b/contracts/RMRK/equippable/IRMRKEquippable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "../multiresource/IRMRKMultiResource.sol";
 

--- a/contracts/RMRK/equippable/IRMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/IRMRKExternalEquip.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "./IRMRKEquippable.sol";
 

--- a/contracts/RMRK/equippable/IRMRKNestingExternalEquip.sol
+++ b/contracts/RMRK/equippable/IRMRKNestingExternalEquip.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -2,7 +2,7 @@
 
 //Generally all interactions should propagate downstream
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../base/IRMRKBaseStorage.sol";
 import "../library/RMRKLib.sol";

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -6,7 +6,7 @@
  * RMRK Equippables accessory contract, responsible for state storage and management of equippable items.
  */
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../base/IRMRKBaseStorage.sol";
 import "../multiresource/AbstractMultiResource.sol";

--- a/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKNestingExternalEquip.sol
@@ -2,7 +2,7 @@
 
 //Generally all interactions should propagate downstream
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../RMRK/equippable/IRMRKEquippable.sol";
 import "../../RMRK/equippable/IRMRKExternalEquip.sol";

--- a/contracts/RMRK/extension/RMRKCollectionProperties.sol
+++ b/contracts/RMRK/extension/RMRKCollectionProperties.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 contract RMRKCollectionProperties {}

--- a/contracts/RMRK/extension/RMRKCustomData.sol
+++ b/contracts/RMRK/extension/RMRKCustomData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 contract RMRKCustomData {}

--- a/contracts/RMRK/extension/RMRKResourceWhitelist.sol
+++ b/contracts/RMRK/extension/RMRKResourceWhitelist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 contract RMRKResourceWhitelist {}

--- a/contracts/RMRK/extension/RMRKRoyalties.sol
+++ b/contracts/RMRK/extension/RMRKRoyalties.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
 

--- a/contracts/RMRK/extension/RMRKThemes.sol
+++ b/contracts/RMRK/extension/RMRKThemes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 contract RMRKThemes {}

--- a/contracts/RMRK/extension/RMRKTokenProperties.sol
+++ b/contracts/RMRK/extension/RMRKTokenProperties.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 contract RMRKTokenProperties {}

--- a/contracts/RMRK/extension/reclaimableChild/IRMRKReclaimableChild.sol
+++ b/contracts/RMRK/extension/reclaimableChild/IRMRKReclaimableChild.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
+++ b/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../nesting/RMRKNesting.sol";
 import "./IRMRKReclaimableChild.sol";

--- a/contracts/RMRK/extension/soulbound/IRMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/IRMRKSoulbound.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../core/RMRKCore.sol";
 import "./IRMRKSoulbound.sol";

--- a/contracts/RMRK/extension/typedMultiResource/IRMRKTypedMultiResource.sol
+++ b/contracts/RMRK/extension/typedMultiResource/IRMRKTypedMultiResource.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 // import "../../multiresource/IRMRKMultiResource.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol
+++ b/contracts/RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "./IRMRKTypedMultiResource.sol";
 

--- a/contracts/RMRK/library/RMRKLib.sol
+++ b/contracts/RMRK/library/RMRKLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 library RMRKLib {
     function removeItemByValue(uint64[] storage array, uint64 value) internal {

--- a/contracts/RMRK/multiresource/AbstractMultiResource.sol
+++ b/contracts/RMRK/multiresource/AbstractMultiResource.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "./IRMRKMultiResource.sol";
 import "../library/RMRKLib.sol";

--- a/contracts/RMRK/multiresource/IRMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/IRMRKMultiResource.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/RMRK/multiresource/RMRKMultiResource.sol
+++ b/contracts/RMRK/multiresource/RMRKMultiResource.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.7.0) (token/ERC721/ERC721.sol)
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/contracts/RMRK/nesting/IRMRKNesting.sol
+++ b/contracts/RMRK/nesting/IRMRKNesting.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/RMRK/nesting/RMRKNesting.sol
+++ b/contracts/RMRK/nesting/RMRKNesting.sol
@@ -2,7 +2,7 @@
 
 //Generally all interactions should propagate downstream
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "./IRMRKNesting.sol";
 import "../core/RMRKCore.sol";

--- a/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
+++ b/contracts/RMRK/nesting/RMRKNestingMultiResource.sol
@@ -2,7 +2,7 @@
 
 //Generally all interactions should propagate downstream
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../multiresource/AbstractMultiResource.sol";
 import "./IRMRKNesting.sol";

--- a/contracts/RMRK/security/ReentrancyGuard.sol
+++ b/contracts/RMRK/security/ReentrancyGuard.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts v4.4.1 (security/ReentrancyGuard.sol)
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 error RentrantCall();
 

--- a/contracts/RMRK/utils/IRMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/IRMRKEquipRenderUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "../equippable/IRMRKEquippable.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "contracts/RMRK/multiresource/IRMRKMultiResource.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/contracts/RMRK/utils/RMRKCollectionMetadata.sol
+++ b/contracts/RMRK/utils/RMRKCollectionMetadata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 contract RMRKCollectionMetadata {
     string private _collectionMetadata;

--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -6,7 +6,7 @@ import "../library/RMRKLib.sol";
 import "./IRMRKEquipRenderUtils.sol";
 // import "hardhat/console.sol";
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 error RMRKTokenDoesNotHaveActiveResource();
 error RMRKNotComposableResource();

--- a/contracts/RMRK/utils/RMRKMintingUtils.sol
+++ b/contracts/RMRK/utils/RMRKMintingUtils.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import "../access/OwnableLock.sol";
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 error RMRKMintOverMax();
 

--- a/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiResourceRenderUtils.sol
@@ -3,7 +3,7 @@
 import "contracts/RMRK/multiresource/IRMRKMultiResource.sol";
 import "contracts/RMRK/utils/IRMRKMultiResourceRenderUtils.sol";
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 /**
  * @dev Extra utility functions for composing RMRK resources.

--- a/contracts/implementations/RMRKBaseStorageImpl.sol
+++ b/contracts/implementations/RMRKBaseStorageImpl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/access/OwnableLock.sol";
 import "../RMRK/base/RMRKBaseStorage.sol";

--- a/contracts/implementations/RMRKExternalEquipImpl.sol
+++ b/contracts/implementations/RMRKExternalEquipImpl.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/equippable/RMRKExternalEquip.sol";
 import "../RMRK/access/OwnableLock.sol";

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.16;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 

--- a/contracts/mocks/MintingUtilsMock.sol
+++ b/contracts/mocks/MintingUtilsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/utils/RMRKMintingUtils.sol";
 

--- a/contracts/mocks/OwnableLockMock.sol
+++ b/contracts/mocks/OwnableLockMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/access/OwnableLock.sol";
 

--- a/contracts/mocks/RMRKBaseStorageMock.sol
+++ b/contracts/mocks/RMRKBaseStorageMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/base/RMRKBaseStorage.sol";
 

--- a/contracts/mocks/RMRKEquippableMock.sol
+++ b/contracts/mocks/RMRKEquippableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/equippable/RMRKEquippable.sol";
 

--- a/contracts/mocks/RMRKExternalEquipMock.sol
+++ b/contracts/mocks/RMRKExternalEquipMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/equippable/RMRKExternalEquip.sol";
 

--- a/contracts/mocks/RMRKMultiResourceMock.sol
+++ b/contracts/mocks/RMRKMultiResourceMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/multiresource/RMRKMultiResource.sol";
 

--- a/contracts/mocks/RMRKNestingExternalEquipMock.sol
+++ b/contracts/mocks/RMRKNestingExternalEquipMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/equippable/RMRKNestingExternalEquip.sol";
 

--- a/contracts/mocks/RMRKNestingMock.sol
+++ b/contracts/mocks/RMRKNestingMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/nesting/RMRKNesting.sol";
 

--- a/contracts/mocks/RMRKNestingMultiResourceMock.sol
+++ b/contracts/mocks/RMRKNestingMultiResourceMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../RMRK/nesting/RMRKNestingMultiResource.sol";
 

--- a/contracts/mocks/extensions/claimableChild/RMRKNestingClaimableChildMock.sol
+++ b/contracts/mocks/extensions/claimableChild/RMRKNestingClaimableChildMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol";
 import "../../RMRKNestingMock.sol";

--- a/contracts/mocks/extensions/soulbound/RMRKSemiSoulboundNestingMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSemiSoulboundNestingMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKNestingMock.sol";

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 // import "../../../RMRK/equippable/RMRKEquippable.sol";

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiResourceMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiResourceMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKMultiResourceMock.sol";

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingExternalEquippableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingExternalEquippableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKNestingExternalEquipMock.sol";

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKNestingMock.sol";

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMultiResourceMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestingMultiResourceMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 import "../../RMRKNestingMultiResourceMock.sol";

--- a/contracts/mocks/extensions/typedMultiResource/RMRKNestingTypedMultiResourceMock.sol
+++ b/contracts/mocks/extensions/typedMultiResource/RMRKNestingTypedMultiResourceMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol";
 import "../../RMRKNestingMultiResourceMock.sol";

--- a/contracts/mocks/extensions/typedMultiResource/RMRKTypedEquippableMock.sol
+++ b/contracts/mocks/extensions/typedMultiResource/RMRKTypedEquippableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol";
 import "../../RMRKEquippableMock.sol";

--- a/contracts/mocks/extensions/typedMultiResource/RMRKTypedExternalEquippableMock.sol
+++ b/contracts/mocks/extensions/typedMultiResource/RMRKTypedExternalEquippableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol";
 import "../../RMRKExternalEquipMock.sol";

--- a/contracts/mocks/extensions/typedMultiResource/RMRKTypedMultiResourceMock.sol
+++ b/contracts/mocks/extensions/typedMultiResource/RMRKTypedMultiResourceMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.16;
 
 import "../../../RMRK/extension/typedMultiResource/RMRKTypedMultiResource.sol";
 import "../../RMRKMultiResourceMock.sol";


### PR DESCRIPTION
Standardizes all the contracts solidity pragma version to ^0.8.16 which is the latest version of the solidity compiler that Hardhat supports.
