### PR TITLE
Improvements on token properties

### DIFF
--- a/contracts/RMRK/extension/tokenProperties/IRMRKTokenProperties.sol
+++ b/contracts/RMRK/extension/tokenProperties/IRMRKTokenProperties.sol
@@ -10,14 +10,16 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  * @notice Interface smart contract of the RMRK token properties extension.
  */
 interface IRMRKTokenProperties is IERC165 {
-
     /**
      * @notice Used to retrieve the string type token properties.
      * @param tokenId The token ID
      * @param key The key of the property
      * @return string The value of the string property
      */
-    function getStringTokenProperty(uint256 tokenId, string memory key) external view returns (string memory);
+    function getStringTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (string memory);
 
     /**
      * @notice Used to retrieve the uint type token properties.
@@ -25,7 +27,10 @@ interface IRMRKTokenProperties is IERC165 {
      * @param key The key of the property
      * @return uint256 The value of the uint property
      */
-    function getUintTokenProperty(uint256 tokenId, string memory key) external view returns (uint256);
+    function getUintTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (uint256);
 
     /**
      * @notice Used to retrieve the bool type token properties.
@@ -33,7 +38,10 @@ interface IRMRKTokenProperties is IERC165 {
      * @param key The key of the property
      * @return bool The value of the bool property
      */
-    function getBoolTokenProperty(uint256 tokenId, string memory key) external view returns (bool);
+    function getBoolTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (bool);
 
     /**
      * @notice Used to retrieve the address type token properties.
@@ -41,7 +49,10 @@ interface IRMRKTokenProperties is IERC165 {
      * @param key The key of the property
      * @return address The value of the address property
      */
-    function getAddressTokenProperty(uint256 tokenId, string memory key) external view returns (address);
+    function getAddressTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (address);
 
     /**
      * @notice Used to retrieve the bytes type token properties.
@@ -49,7 +60,10 @@ interface IRMRKTokenProperties is IERC165 {
      * @param key The key of the property
      * @return bytes The value of the bytes property
      */
-    function getBytesTokenProperty(uint256 tokenId, string memory key) external view returns (bytes memory);
+    function getBytesTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (bytes memory);
 
     /**
      * @notice Used to set a number property.
@@ -57,15 +71,23 @@ interface IRMRKTokenProperties is IERC165 {
      * @param key The property key
      * @param value The property value
      */
-    function setUintProperty(uint256 tokenId, string memory key, uint256 value) external;
+    function setUintProperty(
+        uint256 tokenId,
+        string memory key,
+        uint256 value
+    ) external;
 
     /**
-    * @notice Used to set a string property.
-    * @param tokenId The token ID
-    * @param key The property key
-    * @param value The property value
-    */
-    function setStringProperty(uint256 tokenId, string memory key, string memory value) external;
+     * @notice Used to set a string property.
+     * @param tokenId The token ID
+     * @param key The property key
+     * @param value The property value
+     */
+    function setStringProperty(
+        uint256 tokenId,
+        string memory key,
+        string memory value
+    ) external;
 
     /**
      * @notice Used to set a boolean property.
@@ -73,7 +95,11 @@ interface IRMRKTokenProperties is IERC165 {
      * @param key The property key
      * @param value The property value
      */
-    function setBoolProperty(uint256 tokenId, string memory key, bool value) external;
+    function setBoolProperty(
+        uint256 tokenId,
+        string memory key,
+        bool value
+    ) external;
 
     /**
      * @notice Used to set an bytes property.
@@ -81,14 +107,21 @@ interface IRMRKTokenProperties is IERC165 {
      * @param key The property key
      * @param value The property value
      */
-    function setBytesProperty(uint256 tokenId, string memory key, bytes memory value) external;
+    function setBytesProperty(
+        uint256 tokenId,
+        string memory key,
+        bytes memory value
+    ) external;
 
     /**
-    * @notice Used to set an address property.
+     * @notice Used to set an address property.
      * @param tokenId The token ID
      * @param key The property key
      * @param value The property value
      */
-    function setAddressProperty(uint256 tokenId, string memory key, address value) external;
-
+    function setAddressProperty(
+        uint256 tokenId,
+        string memory key,
+        address value
+    ) external;
 }

--- a/contracts/RMRK/extension/tokenProperties/RMRKTokenProperties.sol
+++ b/contracts/RMRK/extension/tokenProperties/RMRKTokenProperties.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.16;
+
+import "./IRMRKTokenProperties.sol";
+
+/**
+ * @title RMRKTokenProperties
+ * @author RMRK team
+ * @notice Smart contract of the RMRK Token properties module.
+ */
+abstract contract RMRKTokenProperties is IRMRKTokenProperties {
+    // For keys, we use a mapping from strings to Ids.
+    // The purpose is to store unique string keys only once, since they are more expensive,
+    mapping(string => uint256) private _keysToIds;
+    uint256 private _totalProperties;
+
+    // For strings, we also use a mapping from strings to Ids, together with a reverse mapping
+    // The purpose is to store unique string values only once, since they are more expensive,
+    // and storing only ids.
+    uint256 private _totalStringValues;
+    mapping(string => uint256) private _stringValueToId;
+    mapping(uint256 => string) private _stringIdToValue;
+    mapping(uint256 => mapping(uint256 => uint256)) private _stringValueIds;
+
+    mapping(uint256 => mapping(uint256 => address)) private _addressValues;
+    mapping(uint256 => mapping(uint256 => bytes)) private _bytesValues;
+    mapping(uint256 => mapping(uint256 => uint256)) private _uintValues;
+    mapping(uint256 => mapping(uint256 => bool)) private _boolValues;
+
+    /**
+     * @inheritdoc IRMRKTokenProperties
+     */
+    function getStringTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (string memory) {
+        uint256 idForValue = _stringValueIds[tokenId][_keysToIds[key]];
+        return _stringIdToValue[idForValue];
+    }
+
+    /**
+     * @inheritdoc IRMRKTokenProperties
+     */
+    function getUintTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (uint256) {
+        return _uintValues[tokenId][_keysToIds[key]];
+    }
+
+    /**
+     * @inheritdoc IRMRKTokenProperties
+     */
+    function getBoolTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (bool) {
+        return _boolValues[tokenId][_keysToIds[key]];
+    }
+
+    /**
+     * @inheritdoc IRMRKTokenProperties
+     */
+    function getAddressTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (address) {
+        return _addressValues[tokenId][_keysToIds[key]];
+    }
+
+    /**
+     * @inheritdoc IRMRKTokenProperties
+     */
+    function getBytesTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (bytes memory) {
+        return _bytesValues[tokenId][_keysToIds[key]];
+    }
+
+    /**
+     * @notice Used to set a number property.
+     * @param tokenId The token ID
+     * @param key The property key
+     * @param value The property value
+     */
+    function _setUintProperty(
+        uint256 tokenId,
+        string memory key,
+        uint256 value
+    ) internal {
+        _uintValues[tokenId][_getIdForKey(key)] = value;
+    }
+
+    /**
+     * @notice Used to set a string property.
+     * @param tokenId The token ID
+     * @param key The property key
+     * @param value The property value
+     */
+    function _setStringProperty(
+        uint256 tokenId,
+        string memory key,
+        string memory value
+    ) internal {
+        _stringValueIds[tokenId][_getIdForKey(key)] = _getStringIdForValue(
+            value
+        );
+    }
+
+    /**
+     * @notice Used to set a boolean property.
+     * @param tokenId The token ID
+     * @param key The property key
+     * @param value The property value
+     */
+    function _setBoolProperty(
+        uint256 tokenId,
+        string memory key,
+        bool value
+    ) internal {
+        _boolValues[tokenId][_getIdForKey(key)] = value;
+    }
+
+    /**
+     * @notice Used to set an bytes property.
+     * @param tokenId The token ID
+     * @param key The property key
+     * @param value The property value
+     */
+    function _setBytesProperty(
+        uint256 tokenId,
+        string memory key,
+        bytes memory value
+    ) internal {
+        _bytesValues[tokenId][_getIdForKey(key)] = value;
+    }
+
+    /**
+     * @notice Used to set an address property.
+     * @param tokenId The token ID
+     * @param key The property key
+     * @param value The property value
+     */
+    function _setAddressProperty(
+        uint256 tokenId,
+        string memory key,
+        address value
+    ) internal {
+        _addressValues[tokenId][_getIdForKey(key)] = value;
+    }
+
+    /**
+     * @notice Used to get the Id for a key. If the key does not exist, a new Id is created.
+     *  Ids are shared among all tokens and types
+     * @param key The property key
+     * @return uint256 The id for the key
+     */
+    function _getIdForKey(string memory key) internal returns (uint256) {
+        if (_keysToIds[key] == 0) {
+            _totalProperties++;
+            _keysToIds[key] = _totalProperties;
+            return _totalProperties;
+        } else {
+            return _keysToIds[key];
+        }
+    }
+
+    /**
+     * @notice Used to get the Id for a string value. If the value does not exist, a new Id is created.
+     *  Ids are shared among all tokens and used only for strings.
+     * @param value The property value
+     * @return uint256 The id for the value
+     */
+    function _getStringIdForValue(
+        string memory value
+    ) internal returns (uint256) {
+        if (_stringValueToId[value] == 0) {
+            _totalStringValues++;
+            _stringValueToId[value] = _totalStringValues;
+            _stringIdToValue[_totalStringValues] = value;
+            return _totalStringValues;
+        } else {
+            return _stringValueToId[value];
+        }
+    }
+
+    /**
+     * @inheritdoc IERC165
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual returns (bool) {
+        return
+            interfaceId == type(IRMRKTokenProperties).interfaceId ||
+            interfaceId == type(IERC165).interfaceId;
+    }
+}

--- a/contracts/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.sol
+++ b/contracts/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.sol
@@ -10,12 +10,16 @@ import "../../../RMRK/extension/tokenProperties/IRMRKTokenProperties.sol";
  * @notice Smart contract of the RMRK Token properties module.
  */
 contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
-
     mapping(string => uint256) private _keysToIds;
-    uint256 private _totalProperties = 0;
+    uint256 private _totalProperties;
 
-    mapping(string => uint256) private _stringValuesToIds;
-    mapping(uint256 => mapping(uint256 => string)) private _stringValues;
+    // For strings, we also use a mapping from strings to Ids, together with a reverse mapping
+    // The purpose is to store unique string values only once since they are more expensive,
+    // and storing only ids.
+    uint256 private _totalStringValues;
+    mapping(string => uint256) private _stringValueToId;
+    mapping(uint256 => string) private _stringIdToValue;
+    mapping(uint256 => mapping(uint256 => uint256)) private _stringValueIds;
 
     mapping(uint256 => mapping(uint256 => address)) private _addressValues;
     mapping(uint256 => mapping(uint256 => bytes)) private _bytesValues;
@@ -23,13 +27,17 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
     mapping(uint256 => mapping(uint256 => bool)) private _boolValues;
 
     /**
-    * @notice Used to retrieve the string type token properties.
+     * @notice Used to retrieve the string type token properties.
      * @param tokenId The token ID
      * @param key The key of the property
      * @return string The value of the string property
      */
-    function getStringTokenProperty(uint256 tokenId, string memory key) external view returns (string memory) {
-        return _stringValues[tokenId][_keysToIds[key]];
+    function getStringTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (string memory) {
+        uint256 idForValue = _stringValueIds[tokenId][_keysToIds[key]];
+        return _stringIdToValue[idForValue];
     }
 
     /**
@@ -38,7 +46,10 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
      * @param key The key of the property
      * @return uint256 The value of the uint property
      */
-    function getUintTokenProperty(uint256 tokenId, string memory key) external view returns (uint256) {
+    function getUintTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (uint256) {
         return _uintValues[tokenId][_keysToIds[key]];
     }
 
@@ -48,7 +59,10 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
      * @param key The key of the property
      * @return bool The value of the bool property
      */
-    function getBoolTokenProperty(uint256 tokenId, string memory key) external view returns (bool) {
+    function getBoolTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (bool) {
         return _boolValues[tokenId][_keysToIds[key]];
     }
 
@@ -58,7 +72,10 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
      * @param key The key of the property
      * @return address The value of the address property
      */
-    function getAddressTokenProperty(uint256 tokenId, string memory key) external view returns (address) {
+    function getAddressTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (address) {
         return _addressValues[tokenId][_keysToIds[key]];
     }
 
@@ -68,7 +85,10 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
      * @param key The key of the property
      * @return bytes The value of the bytes property
      */
-    function getBytesTokenProperty(uint256 tokenId, string memory key) external view returns (bytes memory) {
+    function getBytesTokenProperty(
+        uint256 tokenId,
+        string memory key
+    ) external view returns (bytes memory) {
         return _bytesValues[tokenId][_keysToIds[key]];
     }
 
@@ -78,33 +98,28 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
      * @param key The property key
      * @param value The property value
      */
-    function setUintProperty(uint256 tokenId, string memory key, uint256 value) external {
+    function setUintProperty(
+        uint256 tokenId,
+        string memory key,
+        uint256 value
+    ) external {
         _uintValues[tokenId][_getIdForKey(key)] = value;
     }
 
     /**
-    * @notice Used to set a string property.
-    * @param tokenId The token ID
-    * @param key The property key
-    * @param value The property value
-    */
-    function setStringProperty(uint256 tokenId, string memory key, string memory value) external {
-
-        if (_stringValuesToIds[value] == 0 && _keysToIds[key] == 0) {
-            _keysToIds[key] = _totalProperties;
-            _stringValues[tokenId][_keysToIds[key]] = value;
-            _stringValuesToIds[value] = _totalProperties;
-            _totalProperties++;
-        }
-        else {
-            //prevents storing duplicate string values and keys
-            if (_stringValuesToIds[value] > 0 && _keysToIds[key] == 0) {
-                _keysToIds[key] = _stringValuesToIds[value];
-            }
-            else {
-                _stringValuesToIds[value] = _keysToIds[key];
-            }
-        }
+     * @notice Used to set a string property.
+     * @param tokenId The token ID
+     * @param key The property key
+     * @param value The property value
+     */
+    function setStringProperty(
+        uint256 tokenId,
+        string memory key,
+        string memory value
+    ) external {
+        _stringValueIds[tokenId][_getIdForKey(key)] = _getStringIdForValue(
+            value
+        );
     }
 
     /**
@@ -113,7 +128,11 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
      * @param key The property key
      * @param value The property value
      */
-    function setBoolProperty(uint256 tokenId, string memory key, bool value) external {
+    function setBoolProperty(
+        uint256 tokenId,
+        string memory key,
+        bool value
+    ) external {
         _boolValues[tokenId][_getIdForKey(key)] = value;
     }
 
@@ -123,38 +142,71 @@ contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
      * @param key The property key
      * @param value The property value
      */
-    function setBytesProperty(uint256 tokenId, string memory key, bytes memory value) external {
+    function setBytesProperty(
+        uint256 tokenId,
+        string memory key,
+        bytes memory value
+    ) external {
         _bytesValues[tokenId][_getIdForKey(key)] = value;
     }
 
     /**
-    * @notice Used to set an address property.
+     * @notice Used to set an address property.
      * @param tokenId The token ID
      * @param key The property key
      * @param value The property value
      */
-    function setAddressProperty(uint256 tokenId, string memory key, address value) external {
+    function setAddressProperty(
+        uint256 tokenId,
+        string memory key,
+        address value
+    ) external {
         _addressValues[tokenId][_getIdForKey(key)] = value;
     }
 
+    /**
+     * @notice Used to get the Id for a key. If the key does not exist, a new Id is created.
+     *  Ids are shared among all tokens and types
+     * @param key The property key
+     * @return uint256 The id for the key
+     */
     function _getIdForKey(string memory key) internal returns (uint256) {
         if (_keysToIds[key] == 0) {
             _totalProperties++;
             _keysToIds[key] = _totalProperties;
             return _totalProperties;
-        }
-        else {
+        } else {
             return _keysToIds[key];
         }
     }
 
     /**
-    * @inheritdoc IERC165
+     * @notice Used to get the Id for a string value. If the value does not exist, a new Id is created.
+     *  Ids are shared among all tokens and used only for strings.
+     * @param value The property value
+     * @return uint256 The id for the value
+     */
+    function _getStringIdForValue(
+        string memory value
+    ) internal returns (uint256) {
+        if (_stringValueToId[value] == 0) {
+            _totalStringValues++;
+            _stringValueToId[value] = _totalStringValues;
+            _stringIdToValue[_totalStringValues] = value;
+            return _totalStringValues;
+        } else {
+            return _stringValueToId[value];
+        }
+    }
+
+    /**
+     * @inheritdoc IERC165
      */
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual returns (bool) {
-        return interfaceId == type(IRMRKTokenProperties).interfaceId || interfaceId == type(IERC165).interfaceId;
+        return
+            interfaceId == type(IRMRKTokenProperties).interfaceId ||
+            interfaceId == type(IERC165).interfaceId;
     }
-
 }

--- a/contracts/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.sol
+++ b/contracts/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.sol
@@ -2,211 +2,66 @@
 
 pragma solidity ^0.8.16;
 
-import "../../../RMRK/extension/tokenProperties/IRMRKTokenProperties.sol";
+import "../../../RMRK/extension/tokenProperties/RMRKTokenProperties.sol";
 
 /**
- * @title RMRKTokenProperties
+ * @title RMRKTokenPropertiesMock
  * @author RMRK team
  * @notice Smart contract of the RMRK Token properties module.
  */
-contract RMRKTokenPropertiesMock is IRMRKTokenProperties {
-    mapping(string => uint256) private _keysToIds;
-    uint256 private _totalProperties;
-
-    // For strings, we also use a mapping from strings to Ids, together with a reverse mapping
-    // The purpose is to store unique string values only once since they are more expensive,
-    // and storing only ids.
-    uint256 private _totalStringValues;
-    mapping(string => uint256) private _stringValueToId;
-    mapping(uint256 => string) private _stringIdToValue;
-    mapping(uint256 => mapping(uint256 => uint256)) private _stringValueIds;
-
-    mapping(uint256 => mapping(uint256 => address)) private _addressValues;
-    mapping(uint256 => mapping(uint256 => bytes)) private _bytesValues;
-    mapping(uint256 => mapping(uint256 => uint256)) private _uintValues;
-    mapping(uint256 => mapping(uint256 => bool)) private _boolValues;
-
+contract RMRKTokenPropertiesMock is RMRKTokenProperties {
     /**
-     * @notice Used to retrieve the string type token properties.
-     * @param tokenId The token ID
-     * @param key The key of the property
-     * @return string The value of the string property
-     */
-    function getStringTokenProperty(
-        uint256 tokenId,
-        string memory key
-    ) external view returns (string memory) {
-        uint256 idForValue = _stringValueIds[tokenId][_keysToIds[key]];
-        return _stringIdToValue[idForValue];
-    }
-
-    /**
-     * @notice Used to retrieve the uint type token properties.
-     * @param tokenId The token ID
-     * @param key The key of the property
-     * @return uint256 The value of the uint property
-     */
-    function getUintTokenProperty(
-        uint256 tokenId,
-        string memory key
-    ) external view returns (uint256) {
-        return _uintValues[tokenId][_keysToIds[key]];
-    }
-
-    /**
-     * @notice Used to retrieve the bool type token properties.
-     * @param tokenId The token ID
-     * @param key The key of the property
-     * @return bool The value of the bool property
-     */
-    function getBoolTokenProperty(
-        uint256 tokenId,
-        string memory key
-    ) external view returns (bool) {
-        return _boolValues[tokenId][_keysToIds[key]];
-    }
-
-    /**
-     * @notice Used to retrieve the address type token properties.
-     * @param tokenId The token ID
-     * @param key The key of the property
-     * @return address The value of the address property
-     */
-    function getAddressTokenProperty(
-        uint256 tokenId,
-        string memory key
-    ) external view returns (address) {
-        return _addressValues[tokenId][_keysToIds[key]];
-    }
-
-    /**
-     * @notice Used to retrieve the bytes type token properties.
-     * @param tokenId The token ID
-     * @param key The key of the property
-     * @return bytes The value of the bytes property
-     */
-    function getBytesTokenProperty(
-        uint256 tokenId,
-        string memory key
-    ) external view returns (bytes memory) {
-        return _bytesValues[tokenId][_keysToIds[key]];
-    }
-
-    /**
-     * @notice Used to set a number property.
-     * @param tokenId The token ID
-     * @param key The property key
-     * @param value The property value
+     * @inheritdoc IRMRKTokenProperties
      */
     function setUintProperty(
         uint256 tokenId,
         string memory key,
         uint256 value
     ) external {
-        _uintValues[tokenId][_getIdForKey(key)] = value;
+        _setUintProperty(tokenId, key, value);
     }
 
     /**
-     * @notice Used to set a string property.
-     * @param tokenId The token ID
-     * @param key The property key
-     * @param value The property value
+     * @inheritdoc IRMRKTokenProperties
      */
     function setStringProperty(
         uint256 tokenId,
         string memory key,
         string memory value
     ) external {
-        _stringValueIds[tokenId][_getIdForKey(key)] = _getStringIdForValue(
-            value
-        );
+        _setStringProperty(tokenId, key, value);
     }
 
     /**
-     * @notice Used to set a boolean property.
-     * @param tokenId The token ID
-     * @param key The property key
-     * @param value The property value
+     * @inheritdoc IRMRKTokenProperties
      */
     function setBoolProperty(
         uint256 tokenId,
         string memory key,
         bool value
     ) external {
-        _boolValues[tokenId][_getIdForKey(key)] = value;
+        _setBoolProperty(tokenId, key, value);
     }
 
     /**
-     * @notice Used to set an bytes property.
-     * @param tokenId The token ID
-     * @param key The property key
-     * @param value The property value
+     * @inheritdoc IRMRKTokenProperties
      */
     function setBytesProperty(
         uint256 tokenId,
         string memory key,
         bytes memory value
     ) external {
-        _bytesValues[tokenId][_getIdForKey(key)] = value;
+        _setBytesProperty(tokenId, key, value);
     }
 
     /**
-     * @notice Used to set an address property.
-     * @param tokenId The token ID
-     * @param key The property key
-     * @param value The property value
+     * @inheritdoc IRMRKTokenProperties
      */
     function setAddressProperty(
         uint256 tokenId,
         string memory key,
         address value
     ) external {
-        _addressValues[tokenId][_getIdForKey(key)] = value;
-    }
-
-    /**
-     * @notice Used to get the Id for a key. If the key does not exist, a new Id is created.
-     *  Ids are shared among all tokens and types
-     * @param key The property key
-     * @return uint256 The id for the key
-     */
-    function _getIdForKey(string memory key) internal returns (uint256) {
-        if (_keysToIds[key] == 0) {
-            _totalProperties++;
-            _keysToIds[key] = _totalProperties;
-            return _totalProperties;
-        } else {
-            return _keysToIds[key];
-        }
-    }
-
-    /**
-     * @notice Used to get the Id for a string value. If the value does not exist, a new Id is created.
-     *  Ids are shared among all tokens and used only for strings.
-     * @param value The property value
-     * @return uint256 The id for the value
-     */
-    function _getStringIdForValue(
-        string memory value
-    ) internal returns (uint256) {
-        if (_stringValueToId[value] == 0) {
-            _totalStringValues++;
-            _stringValueToId[value] = _totalStringValues;
-            _stringIdToValue[_totalStringValues] = value;
-            return _totalStringValues;
-        } else {
-            return _stringValueToId[value];
-        }
-    }
-
-    /**
-     * @inheritdoc IERC165
-     */
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual returns (bool) {
-        return
-            interfaceId == type(IRMRKTokenProperties).interfaceId ||
-            interfaceId == type(IERC165).interfaceId;
+        _setAddressProperty(tokenId, key, value);
     }
 }

--- a/docs/RMRK/extension/tokenProperties/RMRKTokenProperties.md
+++ b/docs/RMRK/extension/tokenProperties/RMRKTokenProperties.md
@@ -1,0 +1,242 @@
+# RMRKTokenProperties
+
+*RMRK team*
+
+> RMRKTokenProperties
+
+Smart contract of the RMRK Token properties module.
+
+
+
+## Methods
+
+### getAddressTokenProperty
+
+```solidity
+function getAddressTokenProperty(uint256 tokenId, string key) external view returns (address)
+```
+
+Used to retrieve the address type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | address The value of the address property |
+
+### getBoolTokenProperty
+
+```solidity
+function getBoolTokenProperty(uint256 tokenId, string key) external view returns (bool)
+```
+
+Used to retrieve the bool type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | bool The value of the bool property |
+
+### getBytesTokenProperty
+
+```solidity
+function getBytesTokenProperty(uint256 tokenId, string key) external view returns (bytes)
+```
+
+Used to retrieve the bytes type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes | bytes The value of the bytes property |
+
+### getStringTokenProperty
+
+```solidity
+function getStringTokenProperty(uint256 tokenId, string key) external view returns (string)
+```
+
+Used to retrieve the string type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | string The value of the string property |
+
+### getUintTokenProperty
+
+```solidity
+function getUintTokenProperty(uint256 tokenId, string key) external view returns (uint256)
+```
+
+Used to retrieve the uint type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | uint256 The value of the uint property |
+
+### setAddressProperty
+
+```solidity
+function setAddressProperty(uint256 tokenId, string key, address value) external nonpayable
+```
+
+Used to set an address property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | address | The property value |
+
+### setBoolProperty
+
+```solidity
+function setBoolProperty(uint256 tokenId, string key, bool value) external nonpayable
+```
+
+Used to set a boolean property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | bool | The property value |
+
+### setBytesProperty
+
+```solidity
+function setBytesProperty(uint256 tokenId, string key, bytes value) external nonpayable
+```
+
+Used to set an bytes property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | bytes | The property value |
+
+### setStringProperty
+
+```solidity
+function setStringProperty(uint256 tokenId, string key, string value) external nonpayable
+```
+
+Used to set a string property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | string | The property value |
+
+### setUintProperty
+
+```solidity
+function setUintProperty(uint256 tokenId, string key, uint256 value) external nonpayable
+```
+
+Used to set a number property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | uint256 | The property value |
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+*Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section] to learn more about how these ids are created. This function call must use less than 30 000 gas.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+
+
+

--- a/docs/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.md
+++ b/docs/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.md
@@ -1,0 +1,242 @@
+# RMRKTokenPropertiesMock
+
+*RMRK team*
+
+> RMRKTokenPropertiesMock
+
+Smart contract of the RMRK Token properties module.
+
+
+
+## Methods
+
+### getAddressTokenProperty
+
+```solidity
+function getAddressTokenProperty(uint256 tokenId, string key) external view returns (address)
+```
+
+Used to retrieve the address type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | address The value of the address property |
+
+### getBoolTokenProperty
+
+```solidity
+function getBoolTokenProperty(uint256 tokenId, string key) external view returns (bool)
+```
+
+Used to retrieve the bool type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | bool The value of the bool property |
+
+### getBytesTokenProperty
+
+```solidity
+function getBytesTokenProperty(uint256 tokenId, string key) external view returns (bytes)
+```
+
+Used to retrieve the bytes type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes | bytes The value of the bytes property |
+
+### getStringTokenProperty
+
+```solidity
+function getStringTokenProperty(uint256 tokenId, string key) external view returns (string)
+```
+
+Used to retrieve the string type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | string The value of the string property |
+
+### getUintTokenProperty
+
+```solidity
+function getUintTokenProperty(uint256 tokenId, string key) external view returns (uint256)
+```
+
+Used to retrieve the uint type token properties.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The key of the property |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | uint256 The value of the uint property |
+
+### setAddressProperty
+
+```solidity
+function setAddressProperty(uint256 tokenId, string key, address value) external nonpayable
+```
+
+Used to set an address property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | address | The property value |
+
+### setBoolProperty
+
+```solidity
+function setBoolProperty(uint256 tokenId, string key, bool value) external nonpayable
+```
+
+Used to set a boolean property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | bool | The property value |
+
+### setBytesProperty
+
+```solidity
+function setBytesProperty(uint256 tokenId, string key, bytes value) external nonpayable
+```
+
+Used to set an bytes property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | bytes | The property value |
+
+### setStringProperty
+
+```solidity
+function setStringProperty(uint256 tokenId, string key, string value) external nonpayable
+```
+
+Used to set a string property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | string | The property value |
+
+### setUintProperty
+
+```solidity
+function setUintProperty(uint256 tokenId, string key, uint256 value) external nonpayable
+```
+
+Used to set a number property.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | The token ID |
+| key | string | The property key |
+| value | uint256 | The property value |
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+*Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section] to learn more about how these ids are created. This function call must use less than 30 000 gas.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+
+
+

--- a/test/extensions/tokenProperties.ts
+++ b/test/extensions/tokenProperties.ts
@@ -18,7 +18,7 @@ async function tokenPropertiesFixture() {
 
 // --------------- TESTS -----------------------
 
-describe.only('RMRKTokenPropertiesMock', async function () {
+describe('RMRKTokenPropertiesMock', async function () {
   let tokenProperties: RMRKTokenPropertiesMock;
 
   beforeEach(async function () {

--- a/test/extensions/tokenProperties.ts
+++ b/test/extensions/tokenProperties.ts
@@ -34,6 +34,7 @@ describe.only("RMRKTokenPropertiesMock", async function() {
   describe("RMRKTokenProperties", async function() {
     let owner: SignerWithAddress;
     const tokenId = 1;
+    const tokenId2 = 2;
 
     beforeEach(async function() {
       ({ tokenProperties } = await loadFixture(tokenPropertiesFixture));
@@ -53,8 +54,6 @@ describe.only("RMRKTokenPropertiesMock", async function() {
       await tokenProperties.setUintProperty(tokenId, "health", bn(80));
       await tokenProperties.setBytesProperty(tokenId, "data", "0x1234");
 
-      console.log(await tokenProperties.getUintTokenProperty(tokenId,"health"));
-
       expect(await tokenProperties.getStringTokenProperty(tokenId, "description")).to.eql("test description");
       expect(await tokenProperties.getStringTokenProperty(tokenId, "description1")).to.eql("test description");
       expect(await tokenProperties.getBoolTokenProperty(tokenId, "rare")).to.eql(true);
@@ -67,6 +66,35 @@ describe.only("RMRKTokenPropertiesMock", async function() {
       expect(await tokenProperties.getStringTokenProperty(tokenId, "description")).to.eql("test description update");
     });
 
+    it("can reuse keys and values are fine", async function() {
+      await tokenProperties.setStringProperty(tokenId, "X", "X1");
+      await tokenProperties.setStringProperty(tokenId2, "X", "X2");
+
+      expect(await tokenProperties.getStringTokenProperty(tokenId, "X")).to.eql("X1");
+      expect(await tokenProperties.getStringTokenProperty(tokenId2, "X")).to.eql("X2");
+    });
+
+    it("can reuse keys among different properties and values are fine", async function() {
+      await tokenProperties.setStringProperty(tokenId, "X", "test description");
+      await tokenProperties.setBoolProperty(tokenId, "X", true);
+      await tokenProperties.setAddressProperty(tokenId, "X", owner.address);
+      await tokenProperties.setUintProperty(tokenId, "X", bn(100));
+      await tokenProperties.setBytesProperty(tokenId, "X", "0x1234");
+
+      expect(await tokenProperties.getStringTokenProperty(tokenId, "X")).to.eql("test description");
+      expect(await tokenProperties.getBoolTokenProperty(tokenId, "X")).to.eql(true);
+      expect(await tokenProperties.getAddressTokenProperty(tokenId, "X")).to.eql(owner.address);
+      expect(await tokenProperties.getUintTokenProperty(tokenId, "X")).to.eql(bn(100));
+      expect(await tokenProperties.getBytesTokenProperty(tokenId, "X")).to.eql("0x1234");
+    });
+
+    it("can reuse string values and values are fine", async function() {
+      await tokenProperties.setStringProperty(tokenId, "X", "common string");
+      await tokenProperties.setStringProperty(tokenId2, "Y", "common string");
+
+      expect(await tokenProperties.getStringTokenProperty(tokenId, "X")).to.eql("common string");
+      expect(await tokenProperties.getStringTokenProperty(tokenId2, "Y")).to.eql("common string");
+    });
   });
 })
 ;

--- a/test/extensions/tokenProperties.ts
+++ b/test/extensions/tokenProperties.ts
@@ -1,17 +1,15 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import {
-  IERC165, IRMRKTokenProperties
-} from "../interfaces";
-import { RMRKTokenPropertiesMock } from "../../typechain-types";
-import { bn } from "../utils";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { IERC165, IRMRKTokenProperties } from '../interfaces';
+import { RMRKTokenPropertiesMock } from '../../typechain-types';
+import { bn } from '../utils';
 
 // --------------- FIXTURES -----------------------
 
 async function tokenPropertiesFixture() {
-  const factory = await ethers.getContractFactory("RMRKTokenPropertiesMock");
+  const factory = await ethers.getContractFactory('RMRKTokenPropertiesMock');
   const tokenProperties = await factory.deploy();
   await tokenProperties.deployed();
 
@@ -20,10 +18,10 @@ async function tokenPropertiesFixture() {
 
 // --------------- TESTS -----------------------
 
-describe.only("RMRKTokenPropertiesMock", async function() {
+describe.only('RMRKTokenPropertiesMock', async function () {
   let tokenProperties: RMRKTokenPropertiesMock;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     ({ tokenProperties } = await loadFixture(tokenPropertiesFixture));
 
     this.tokenProperties = tokenProperties;
@@ -31,80 +29,85 @@ describe.only("RMRKTokenPropertiesMock", async function() {
 
   shouldBehaveLikeTokenPropertiesInterface();
 
-  describe("RMRKTokenProperties", async function() {
+  describe('RMRKTokenProperties', async function () {
     let owner: SignerWithAddress;
     const tokenId = 1;
     const tokenId2 = 2;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       ({ tokenProperties } = await loadFixture(tokenPropertiesFixture));
 
       const signers = await ethers.getSigners();
       owner = signers[1];
     });
 
-    it("can set and get token properties", async function() {
-      await tokenProperties.setStringProperty(tokenId, "description", "test description");
-      await tokenProperties.setStringProperty(tokenId, "description1", "test description");
-      await tokenProperties.setBoolProperty(tokenId, "rare", true);
-      await tokenProperties.setAddressProperty(tokenId, "owner", owner.address);
-      await tokenProperties.setUintProperty(tokenId, "atk", bn(100));
-      await tokenProperties.setUintProperty(tokenId, "health", bn(100));
-      await tokenProperties.setUintProperty(tokenId, "health", bn(95));
-      await tokenProperties.setUintProperty(tokenId, "health", bn(80));
-      await tokenProperties.setBytesProperty(tokenId, "data", "0x1234");
+    it('can set and get token properties', async function () {
+      await tokenProperties.setStringProperty(tokenId, 'description', 'test description');
+      await tokenProperties.setStringProperty(tokenId, 'description1', 'test description');
+      await tokenProperties.setBoolProperty(tokenId, 'rare', true);
+      await tokenProperties.setAddressProperty(tokenId, 'owner', owner.address);
+      await tokenProperties.setUintProperty(tokenId, 'atk', bn(100));
+      await tokenProperties.setUintProperty(tokenId, 'health', bn(100));
+      await tokenProperties.setUintProperty(tokenId, 'health', bn(95));
+      await tokenProperties.setUintProperty(tokenId, 'health', bn(80));
+      await tokenProperties.setBytesProperty(tokenId, 'data', '0x1234');
 
-      expect(await tokenProperties.getStringTokenProperty(tokenId, "description")).to.eql("test description");
-      expect(await tokenProperties.getStringTokenProperty(tokenId, "description1")).to.eql("test description");
-      expect(await tokenProperties.getBoolTokenProperty(tokenId, "rare")).to.eql(true);
-      expect(await tokenProperties.getAddressTokenProperty(tokenId, "owner")).to.eql(owner.address);
-      expect(await tokenProperties.getUintTokenProperty(tokenId, "atk")).to.eql(bn(100));
-      expect(await tokenProperties.getUintTokenProperty(tokenId, "health")).to.eql(bn(80));
-      expect(await tokenProperties.getBytesTokenProperty(tokenId, "data")).to.eql("0x1234");
+      expect(await tokenProperties.getStringTokenProperty(tokenId, 'description')).to.eql(
+        'test description',
+      );
+      expect(await tokenProperties.getStringTokenProperty(tokenId, 'description1')).to.eql(
+        'test description',
+      );
+      expect(await tokenProperties.getBoolTokenProperty(tokenId, 'rare')).to.eql(true);
+      expect(await tokenProperties.getAddressTokenProperty(tokenId, 'owner')).to.eql(owner.address);
+      expect(await tokenProperties.getUintTokenProperty(tokenId, 'atk')).to.eql(bn(100));
+      expect(await tokenProperties.getUintTokenProperty(tokenId, 'health')).to.eql(bn(80));
+      expect(await tokenProperties.getBytesTokenProperty(tokenId, 'data')).to.eql('0x1234');
 
-      await tokenProperties.setStringProperty(tokenId, "description", "test description update");
-      expect(await tokenProperties.getStringTokenProperty(tokenId, "description")).to.eql("test description update");
+      await tokenProperties.setStringProperty(tokenId, 'description', 'test description update');
+      expect(await tokenProperties.getStringTokenProperty(tokenId, 'description')).to.eql(
+        'test description update',
+      );
     });
 
-    it("can reuse keys and values are fine", async function() {
-      await tokenProperties.setStringProperty(tokenId, "X", "X1");
-      await tokenProperties.setStringProperty(tokenId2, "X", "X2");
+    it('can reuse keys and values are fine', async function () {
+      await tokenProperties.setStringProperty(tokenId, 'X', 'X1');
+      await tokenProperties.setStringProperty(tokenId2, 'X', 'X2');
 
-      expect(await tokenProperties.getStringTokenProperty(tokenId, "X")).to.eql("X1");
-      expect(await tokenProperties.getStringTokenProperty(tokenId2, "X")).to.eql("X2");
+      expect(await tokenProperties.getStringTokenProperty(tokenId, 'X')).to.eql('X1');
+      expect(await tokenProperties.getStringTokenProperty(tokenId2, 'X')).to.eql('X2');
     });
 
-    it("can reuse keys among different properties and values are fine", async function() {
-      await tokenProperties.setStringProperty(tokenId, "X", "test description");
-      await tokenProperties.setBoolProperty(tokenId, "X", true);
-      await tokenProperties.setAddressProperty(tokenId, "X", owner.address);
-      await tokenProperties.setUintProperty(tokenId, "X", bn(100));
-      await tokenProperties.setBytesProperty(tokenId, "X", "0x1234");
+    it('can reuse keys among different properties and values are fine', async function () {
+      await tokenProperties.setStringProperty(tokenId, 'X', 'test description');
+      await tokenProperties.setBoolProperty(tokenId, 'X', true);
+      await tokenProperties.setAddressProperty(tokenId, 'X', owner.address);
+      await tokenProperties.setUintProperty(tokenId, 'X', bn(100));
+      await tokenProperties.setBytesProperty(tokenId, 'X', '0x1234');
 
-      expect(await tokenProperties.getStringTokenProperty(tokenId, "X")).to.eql("test description");
-      expect(await tokenProperties.getBoolTokenProperty(tokenId, "X")).to.eql(true);
-      expect(await tokenProperties.getAddressTokenProperty(tokenId, "X")).to.eql(owner.address);
-      expect(await tokenProperties.getUintTokenProperty(tokenId, "X")).to.eql(bn(100));
-      expect(await tokenProperties.getBytesTokenProperty(tokenId, "X")).to.eql("0x1234");
+      expect(await tokenProperties.getStringTokenProperty(tokenId, 'X')).to.eql('test description');
+      expect(await tokenProperties.getBoolTokenProperty(tokenId, 'X')).to.eql(true);
+      expect(await tokenProperties.getAddressTokenProperty(tokenId, 'X')).to.eql(owner.address);
+      expect(await tokenProperties.getUintTokenProperty(tokenId, 'X')).to.eql(bn(100));
+      expect(await tokenProperties.getBytesTokenProperty(tokenId, 'X')).to.eql('0x1234');
     });
 
-    it("can reuse string values and values are fine", async function() {
-      await tokenProperties.setStringProperty(tokenId, "X", "common string");
-      await tokenProperties.setStringProperty(tokenId2, "Y", "common string");
+    it('can reuse string values and values are fine', async function () {
+      await tokenProperties.setStringProperty(tokenId, 'X', 'common string');
+      await tokenProperties.setStringProperty(tokenId2, 'X', 'common string');
 
-      expect(await tokenProperties.getStringTokenProperty(tokenId, "X")).to.eql("common string");
-      expect(await tokenProperties.getStringTokenProperty(tokenId2, "Y")).to.eql("common string");
+      expect(await tokenProperties.getStringTokenProperty(tokenId, 'X')).to.eql('common string');
+      expect(await tokenProperties.getStringTokenProperty(tokenId2, 'X')).to.eql('common string');
     });
   });
-})
-;
+});
 
 async function shouldBehaveLikeTokenPropertiesInterface() {
-  it("can support IERC165", async function() {
+  it('can support IERC165', async function () {
     expect(await this.tokenProperties.supportsInterface(IERC165)).to.equal(true);
   });
 
-  it("can support IRMRKTokenProperties", async function() {
+  it('can support IRMRKTokenProperties', async function () {
     expect(await this.tokenProperties.supportsInterface(IRMRKTokenProperties)).to.equal(true);
   });
 }


### PR DESCRIPTION
Adds tests for duplicate keys, keys shared among different types and values shared among different string properties.
Caches string values to reduce gas when same value is used several times.
Splits minimal abstract implementation and mock to make it easier to extend.
