### PR TITLE
Fix pr template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The Github accounts listed here will automatically be requested to review PRs.
+*       @stevyhacker @steven2308 @ThunderDeliverer

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Description
+
+Describe the additions/improvements this PR contains.
+
+# Actions
+
+Provide overview of actions taken to address the additions/improvements.
+
+# Checklist
+
+- [ ] Verified code additions
+- [ ] Updated NatSpec comments (if applicable)
+- [ ] Regenerated docs
+- [ ] Ran prettier
+- [ ] Added tests to fully cover the changes


### PR DESCRIPTION
The PR template wasn't loading as it should have been merged directly to master. I also added CODEOWNERS while I was at it.