### PR TITLE
Add event for contributor management

### DIFF
--- a/contracts/RMRK/access/Ownable.sol
+++ b/contracts/RMRK/access/Ownable.sol
@@ -59,6 +59,7 @@ contract Ownable is Context {
 
     /**
      * @notice Returns the address of the current owner.
+     * @return Address of the current owner
      */
     function owner() public view virtual returns (address) {
         return _owner;

--- a/contracts/RMRK/access/Ownable.sol
+++ b/contracts/RMRK/access/Ownable.sol
@@ -15,10 +15,24 @@ contract Ownable is Context {
     address private _owner;
     mapping(address => uint256) private _contributors;
 
+    /**
+     * @notice Used to anounce the transfer of ownership.
+     * @param previousOwner Address of the account that transferred their ownership role
+     * @param newOwner Address of the account receiving the ownership role
+     */
     event OwnershipTransferred(
         address indexed previousOwner,
         address indexed newOwner
     );
+
+    /**
+     * @notice Event that signifies that an address was granted contributor role or that the permission has been
+     *  revoked.
+     * @dev This can only be triggered by a current owner, so there is no need to include that information in the event.
+     * @param contributor Address of the account that had contributor role status updated
+     * @param isContributor A boolean value signifying whether the role has been granted (`true`) or revoked (`false`)
+     */
+    event ContributorUpdate(address indexed contributor, bool isContributor);
 
     /**
      * @dev Reverts if called by any account other than the owner or an approved contributor.
@@ -89,6 +103,7 @@ contract Ownable is Context {
     function addContributor(address contributor) external onlyOwner {
         if (contributor == address(0)) revert RMRKNewContributorIsZeroAddress();
         _contributors[contributor] = 1;
+        emit ContributorUpdate(contributor, true);
     }
 
     /**
@@ -98,6 +113,7 @@ contract Ownable is Context {
      */
     function revokeContributor(address contributor) external onlyOwner {
         delete _contributors[contributor];
+        emit ContributorUpdate(contributor, false);
     }
 
     /**

--- a/contracts/RMRK/access/Ownable.sol
+++ b/contracts/RMRK/access/Ownable.sol
@@ -97,24 +97,21 @@ contract Ownable is Context {
     }
 
     /**
-     * @notice Adds a contributor to the smart contract.
+     * @notice Adds or removes a contributor to the smart contract.
      * @dev Can only be called by the owner.
      * @param contributor Address of the contributor's account
+     * @param grantRole A boolean value signifying whether the contributor role is being granted (`true`) or revoked
+     *  (`false`)
      */
-    function addContributor(address contributor) external onlyOwner {
+    function manageContributor(
+        address contributor,
+        bool grantRole
+    ) external onlyOwner {
         if (contributor == address(0)) revert RMRKNewContributorIsZeroAddress();
-        _contributors[contributor] = 1;
-        emit ContributorUpdate(contributor, true);
-    }
-
-    /**
-     * @notice Removes a contributor from the smart contract.
-     * @dev Can only be called by the owner.
-     * @param contributor Address of the contributor's account
-     */
-    function revokeContributor(address contributor) external onlyOwner {
-        delete _contributors[contributor];
-        emit ContributorUpdate(contributor, false);
+        grantRole
+            ? _contributors[contributor] = 1
+            : _contributors[contributor] = 0;
+        emit ContributorUpdate(contributor, grantRole);
     }
 
     /**

--- a/docs/RMRK/access/Ownable.md
+++ b/docs/RMRK/access/Ownable.md
@@ -63,7 +63,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### renounceOwnership
 

--- a/docs/RMRK/access/Ownable.md
+++ b/docs/RMRK/access/Ownable.md
@@ -112,13 +112,30 @@ Transfers ownership of the contract to a new owner.
 
 ## Events
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+*This can only be triggered by a current owner, so there is no need to include that information in the event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | Address of the account that had contributor role status updated |
+| isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 
@@ -126,8 +143,8 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 
 | Name | Type | Description |
 |---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
+| previousOwner `indexed` | address | Address of the account that transferred their ownership role |
+| newOwner `indexed` | address | Address of the account receiving the ownership role |
 
 
 

--- a/docs/RMRK/access/Ownable.md
+++ b/docs/RMRK/access/Ownable.md
@@ -10,22 +10,6 @@ A minimal ownable smart contractf or owner and contributors.
 
 ## Methods
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### isContributor
 
 ```solidity
@@ -47,6 +31,23 @@ Used to check if the address is one of the contributors.
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
+
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
 
 ### owner
 
@@ -75,22 +76,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### transferOwnership
 

--- a/docs/RMRK/access/OwnableLock.md
+++ b/docs/RMRK/access/OwnableLock.md
@@ -80,7 +80,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### renounceOwnership
 

--- a/docs/RMRK/access/OwnableLock.md
+++ b/docs/RMRK/access/OwnableLock.md
@@ -10,22 +10,6 @@ A minimal ownable lock smart contract.
 
 ## Methods
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### getLock
 
 ```solidity
@@ -65,6 +49,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### owner
 
 ```solidity
@@ -92,22 +93,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### setLock
 

--- a/docs/RMRK/access/OwnableLock.md
+++ b/docs/RMRK/access/OwnableLock.md
@@ -140,13 +140,30 @@ Transfers ownership of the contract to a new owner.
 
 ## Events
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/RMRK/utils/RMRKMintingUtils.md
+++ b/docs/RMRK/utils/RMRKMintingUtils.md
@@ -97,7 +97,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### pricePerMint
 

--- a/docs/RMRK/utils/RMRKMintingUtils.md
+++ b/docs/RMRK/utils/RMRKMintingUtils.md
@@ -208,13 +208,30 @@ Used to withdraw the minting proceedings to a specified address.
 
 ## Events
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/RMRK/utils/RMRKMintingUtils.md
+++ b/docs/RMRK/utils/RMRKMintingUtils.md
@@ -10,22 +10,6 @@ Smart contract of the RMRK minting utils module.
 
 ## Methods
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### getLock
 
 ```solidity
@@ -64,6 +48,23 @@ Used to check if the address is one of the contributors.
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
+
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
 
 ### maxSupply
 
@@ -126,22 +127,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### setLock
 

--- a/docs/implementations/RMRKCatalogImpl.md
+++ b/docs/implementations/RMRKCatalogImpl.md
@@ -252,7 +252,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### renounceOwnership
 

--- a/docs/implementations/RMRKCatalogImpl.md
+++ b/docs/implementations/RMRKCatalogImpl.md
@@ -420,13 +420,30 @@ Event to announce addition of a new part.
 | equippableAddresses  | address[] | undefined |
 | metadataURI  | string | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/RMRKCatalogImpl.md
+++ b/docs/implementations/RMRKCatalogImpl.md
@@ -10,22 +10,6 @@ Implementation of RMRK catalog.
 
 ## Methods
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### addEquippableAddresses
 
 ```solidity
@@ -237,6 +221,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### owner
 
 ```solidity
@@ -280,22 +281,6 @@ Used to remove all of the `equippableAddresses` for a `Part` associated with the
 | Name | Type | Description |
 |---|---|---|
 | partId | uint64 | ID of the part that we are clearing the `equippableAddresses` from |
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### setEquippableAddresses
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -1612,6 +1612,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1638,7 +1655,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -826,7 +826,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### addEquippableAssetEntry
 
 ```solidity
@@ -757,6 +741,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -974,22 +975,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -514,7 +514,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -85,22 +85,6 @@ Used to add an asset to a token.
 | assetId | uint64 | ID of the asset to add to the token |
 | replacesAssetWithId | uint64 | ID of the asset to replace from the token&#39;s list of active assets |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -465,6 +449,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -600,22 +601,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -1063,13 +1063,30 @@ Used to notify listeners that an asset object is initialized at `assetId`.
 |---|---|---|
 | assetId `indexed` | uint64 | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -454,7 +454,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -955,6 +955,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -981,7 +998,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -64,22 +64,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -385,6 +369,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -567,22 +568,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -617,6 +601,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -834,22 +835,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -1394,6 +1394,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1420,7 +1437,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -686,7 +686,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### addEquippableAssetEntry
 
 ```solidity
@@ -774,6 +758,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -1026,22 +1027,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -878,7 +878,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -1664,6 +1664,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1690,7 +1707,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -1097,13 +1097,30 @@ Used to notify listeners that an asset object is initialized at `assetId`.
 |---|---|---|
 | assetId `indexed` | uint64 | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -85,22 +85,6 @@ Used to add an asset to a token.
 | assetId | uint64 | ID of the asset to add to the token |
 | replacesAssetWithId | uint64 | ID of the asset to replace from the token&#39;s list of active assets |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -482,6 +466,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -634,22 +635,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -548,7 +548,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -1007,6 +1007,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1033,7 +1050,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -506,7 +506,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -64,22 +64,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -402,6 +386,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -619,22 +620,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -738,7 +738,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -634,6 +618,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -886,22 +887,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -1446,6 +1446,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1472,7 +1489,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -1647,6 +1647,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1673,7 +1690,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -861,7 +861,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### addEquippableAssetEntry
 
 ```solidity
@@ -757,6 +741,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -1009,22 +1010,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
@@ -852,6 +852,23 @@ Used to notify listeners that a child&#39;s asset has been unequipped from one o
 | childAddress  | address | undefined |
 | childAssetId  | uint64 | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestableAddressSet
 
 ```solidity
@@ -875,7 +892,7 @@ Used to notify listeners of a new `Nestable` associated  smart contract address 
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
@@ -469,7 +469,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### rejectAllAssets
 

--- a/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
@@ -68,22 +68,6 @@ Used to add an asset to a token.
 | assetId | uint64 | ID of the asset to add to the token |
 | replacesAssetWithId | uint64 | ID of the asset to replace from the token&#39;s list of active assets |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### addEquippableAssetEntry
 
 ```solidity
@@ -454,6 +438,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### owner
 
 ```solidity
@@ -516,22 +517,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### setApprovalForAllForAssets
 

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -1080,13 +1080,30 @@ Used to notify listeners that an asset object is initialized at `assetId`.
 |---|---|---|
 | assetId `indexed` | uint64 | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -85,22 +85,6 @@ Used to add an asset to a token.
 | assetId | uint64 | ID of the asset to add to the token |
 | replacesAssetWithId | uint64 | ID of the asset to replace from the token&#39;s list of active assets |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -465,6 +449,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -617,22 +618,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -531,7 +531,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -1046,6 +1046,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### EquippableAddressSet
 
 ```solidity
@@ -1089,7 +1106,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -64,22 +64,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -425,6 +409,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -642,22 +643,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -529,7 +529,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -64,22 +64,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -385,6 +369,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -602,22 +603,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -489,7 +489,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -990,6 +990,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1016,7 +1033,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -617,6 +601,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -869,22 +870,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -721,7 +721,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -1429,6 +1429,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1455,7 +1472,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -1647,6 +1647,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1673,7 +1690,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -861,7 +861,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### addEquippableAssetEntry
 
 ```solidity
@@ -757,6 +741,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -1009,22 +1010,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -1080,13 +1080,30 @@ Used to notify listeners that an asset object is initialized at `assetId`.
 |---|---|---|
 | assetId `indexed` | uint64 | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -85,22 +85,6 @@ Used to add an asset to a token.
 | assetId | uint64 | ID of the asset to add to the token |
 | replacesAssetWithId | uint64 | ID of the asset to replace from the token&#39;s list of active assets |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -465,6 +449,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -617,22 +618,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -531,7 +531,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -64,22 +64,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -385,6 +369,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -602,22 +603,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -489,7 +489,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -990,6 +990,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1016,7 +1033,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -122,22 +122,6 @@ Used to add a child token to a given parent token.
 | childId | uint256 | ID of the new proposed child token |
 | data | bytes | Additional data with no specified format |
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### approve
 
 ```solidity
@@ -617,6 +601,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### maxSupply
 
 ```solidity
@@ -869,22 +870,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### royaltyInfo
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -721,7 +721,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### ownerOf
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -1429,6 +1429,23 @@ Used to notify listeners a child token has been transferred from parent token.
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### NestTransfer
 
 ```solidity
@@ -1455,7 +1472,7 @@ Used to notify listeners that the token is being transferred.
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/mocks/MintingUtilsMock.md
+++ b/docs/mocks/MintingUtilsMock.md
@@ -252,13 +252,30 @@ Used to withdraw the minting proceedings to a specified address.
 
 ## Events
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/mocks/MintingUtilsMock.md
+++ b/docs/mocks/MintingUtilsMock.md
@@ -10,22 +10,6 @@
 
 ## Methods
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### getLock
 
 ```solidity
@@ -64,6 +48,23 @@ Used to check if the address is one of the contributors.
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
+
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
 
 ### maxSupply
 
@@ -142,22 +143,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### setLock
 

--- a/docs/mocks/MintingUtilsMock.md
+++ b/docs/mocks/MintingUtilsMock.md
@@ -113,7 +113,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### pricePerMint
 

--- a/docs/mocks/OwnableLockMock.md
+++ b/docs/mocks/OwnableLockMock.md
@@ -157,13 +157,30 @@ Transfers ownership of the contract to a new owner.
 
 ## Events
 
+### ContributorUpdate
+
+```solidity
+event ContributorUpdate(address indexed contributor, bool isContributor)
+```
+
+Event that signifies that an address was granted contributor role or that the permission has been  revoked.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor `indexed` | address | undefined |
+| isContributor  | bool | undefined |
+
 ### OwnershipTransferred
 
 ```solidity
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
+Used to anounce the transfer of ownership.
 
 
 

--- a/docs/mocks/OwnableLockMock.md
+++ b/docs/mocks/OwnableLockMock.md
@@ -10,22 +10,6 @@
 
 ## Methods
 
-### addContributor
-
-```solidity
-function addContributor(address contributor) external nonpayable
-```
-
-Adds a contributor to the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
-
 ### getLock
 
 ```solidity
@@ -65,6 +49,23 @@ Used to check if the address is one of the contributors.
 |---|---|---|
 | _0 | bool | Boolean value indicating whether the address is a contributor or not |
 
+### manageContributor
+
+```solidity
+function manageContributor(address contributor, bool grantRole) external nonpayable
+```
+
+Adds or removes a contributor to the smart contract.
+
+*Can only be called by the owner.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| contributor | address | Address of the contributor&#39;s account |
+| grantRole | bool | A boolean value signifying whether the contributor role is being granted (`true`) or revoked  (`false`) |
+
 ### owner
 
 ```solidity
@@ -92,22 +93,6 @@ Leaves the contract without owner. Functions using the `onlyOwner` modifier will
 
 *Can only be called by the current owner.Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is  only available to the owner.*
 
-
-### revokeContributor
-
-```solidity
-function revokeContributor(address contributor) external nonpayable
-```
-
-Removes a contributor from the smart contract.
-
-*Can only be called by the owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| contributor | address | Address of the contributor&#39;s account |
 
 ### setLock
 

--- a/docs/mocks/OwnableLockMock.md
+++ b/docs/mocks/OwnableLockMock.md
@@ -80,7 +80,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the current owner |
 
 ### renounceOwnership
 

--- a/test/implementations/abstracts.ts
+++ b/test/implementations/abstracts.ts
@@ -88,7 +88,7 @@ async function shouldControlValidAssetsManagement(): Promise<void> {
   beforeEach(async function () {
     [owner, notOwner, contributor, tokenOwner] = await ethers.getSigners();
     await this.token.connect(owner).mint(tokenOwner.address, 1);
-    await this.token.connect(owner).addContributor(contributor.address);
+    await this.token.connect(owner).manageContributor(contributor.address, true);
   });
 
   it('cannot add asset if not owner or contributor', async function () {
@@ -141,7 +141,7 @@ async function shouldControlValidEquippablesManagement(): Promise<void> {
   beforeEach(async function () {
     [owner, notOwner, contributor, tokenOwner, catalog, parent] = await ethers.getSigners();
     await this.token.connect(owner).mint(tokenOwner.address, 1);
-    await this.token.connect(owner).addContributor(contributor.address);
+    await this.token.connect(owner).manageContributor(contributor.address, true);
   });
 
   it('cannot add asset if not owner or contributor', async function () {

--- a/test/implementations/catalog.ts
+++ b/test/implementations/catalog.ts
@@ -79,7 +79,7 @@ describe('CatalogImpl', async () => {
     });
 
     it('can add part if contributor', async function () {
-      await catalog.connect(owner).addContributor(contributor.address);
+      await catalog.connect(owner).manageContributor(contributor.address, true);
       await catalog.connect(contributor).addPart({ partId: partId, part: partData });
       expect(await catalog.getPart(partId)).to.eql([fixedType, 0, [], 'ipfs://metadata']);
     });

--- a/test/implementations/externalEquippable.ts
+++ b/test/implementations/externalEquippable.ts
@@ -85,7 +85,7 @@ describe('ExternalEquippableImpl Other', async function () {
     ({ nestable, equip } = await loadFixture(equipFixture));
     this.token = nestable;
     [owner, contributor, ...addrs] = await ethers.getSigners();
-    await equip.addContributor(contributor.address);
+    await equip.manageContributor(contributor.address, true);
   });
 
   it('auto accepts resource if send is token owner', async function () {

--- a/test/mintingUtils.ts
+++ b/test/mintingUtils.ts
@@ -53,6 +53,13 @@ describe('Minting Utils', async () => {
       expect(await mintingUtils.owner()).to.eql(newOwner.address);
     });
 
+    it('emits OwnershipTransferred event when transferring ownership', async function () {
+      const newOwner = addrs[1];
+      await expect(mintingUtils.connect(owner).transferOwnership(newOwner.address))
+        .to.emit(mintingUtils, 'OwnershipTransferred')
+        .withArgs(owner.address, newOwner.address);
+    });
+
     it('cannot transfer ownership to address 0', async function () {
       await expect(
         mintingUtils.connect(owner).transferOwnership(ethers.constants.AddressZero),
@@ -70,6 +77,21 @@ describe('Minting Utils', async () => {
       expect(await mintingUtils.connect(owner).isContributor(contributor.address)).to.eql(true);
       await mintingUtils.connect(owner).revokeContributor(contributor.address);
       expect(await mintingUtils.connect(owner).isContributor(contributor.address)).to.eql(false);
+    });
+
+    it('emits ContributorUpdate when adding a contributor', async function () {
+      const contributor = addrs[1];
+      await expect(mintingUtils.connect(owner).addContributor(contributor.address))
+        .to.emit(mintingUtils, 'ContributorUpdate')
+        .withArgs(contributor.address, true);
+    });
+
+    it('emits ContributorUpdate when removing a contributor', async function () {
+      const contributor = addrs[1];
+      await mintingUtils.connect(owner).addContributor(contributor.address);
+      await expect(mintingUtils.connect(owner).revokeContributor(contributor.address))
+        .to.emit(mintingUtils, 'ContributorUpdate')
+        .withArgs(contributor.address, false);
     });
 
     it('cannot add zero address as contributor', async function () {

--- a/test/mintingUtils.ts
+++ b/test/mintingUtils.ts
@@ -73,30 +73,30 @@ describe('Minting Utils', async () => {
 
     it('can add and revoke contributor', async function () {
       const contributor = addrs[1];
-      await mintingUtils.connect(owner).addContributor(contributor.address);
+      await mintingUtils.connect(owner).manageContributor(contributor.address, true);
       expect(await mintingUtils.connect(owner).isContributor(contributor.address)).to.eql(true);
-      await mintingUtils.connect(owner).revokeContributor(contributor.address);
+      await mintingUtils.connect(owner).manageContributor(contributor.address, false);
       expect(await mintingUtils.connect(owner).isContributor(contributor.address)).to.eql(false);
     });
 
     it('emits ContributorUpdate when adding a contributor', async function () {
       const contributor = addrs[1];
-      await expect(mintingUtils.connect(owner).addContributor(contributor.address))
+      await expect(mintingUtils.connect(owner).manageContributor(contributor.address, true))
         .to.emit(mintingUtils, 'ContributorUpdate')
         .withArgs(contributor.address, true);
     });
 
     it('emits ContributorUpdate when removing a contributor', async function () {
       const contributor = addrs[1];
-      await mintingUtils.connect(owner).addContributor(contributor.address);
-      await expect(mintingUtils.connect(owner).revokeContributor(contributor.address))
+      await mintingUtils.connect(owner).manageContributor(contributor.address, true);
+      await expect(mintingUtils.connect(owner).manageContributor(contributor.address, false))
         .to.emit(mintingUtils, 'ContributorUpdate')
         .withArgs(contributor.address, false);
     });
 
     it('cannot add zero address as contributor', async function () {
       await expect(
-        mintingUtils.connect(owner).addContributor(ethers.constants.AddressZero),
+        mintingUtils.connect(owner).manageContributor(ethers.constants.AddressZero, true),
       ).to.be.revertedWithCustomError(mintingUtils, 'RMRKNewContributorIsZeroAddress');
     });
 
@@ -110,10 +110,10 @@ describe('Minting Utils', async () => {
         mintingUtils.connect(notOwner).renounceOwnership(),
       ).to.be.revertedWithCustomError(mintingUtils, 'RMRKNotOwner');
       await expect(
-        mintingUtils.connect(notOwner).addContributor(otherUser.address),
+        mintingUtils.connect(notOwner).manageContributor(otherUser.address, true),
       ).to.be.revertedWithCustomError(mintingUtils, 'RMRKNotOwner');
       await expect(
-        mintingUtils.connect(notOwner).revokeContributor(otherUser.address),
+        mintingUtils.connect(notOwner).manageContributor(otherUser.address, false),
       ).to.be.revertedWithCustomError(mintingUtils, 'RMRKNotOwner');
     });
 


### PR DESCRIPTION
# Description

An event denoting `contributor` status change was added.

# Actions

In order to preserve space a single event was added that includes a flag denoting whether the role was granted or revoked:

```solidity
    event ContributorUpdate(address indexed contributor, bool isContributor);
```

Other actions:

- Added documentation comments to `OwnershipTransferred`
- Documented `ContributorUpdate`
- Add the event to relevant functions
- Add test examples verifying correct emission of the event
- Add test examples verifying correct emission of `OwnershipTransferred`

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
