### PR TITLE
Moves emotable events to interfaces and adds after emote hook.

### DIFF
--- a/contracts/RMRK/extension/emotable/IRMRKEmotable.sol
+++ b/contracts/RMRK/extension/emotable/IRMRKEmotable.sol
@@ -11,6 +11,21 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  */
 interface IRMRKEmotable is IERC165 {
     /**
+     * @notice Used to notify listeners of that the token with ID tokenId has been emoted or unemoted.
+     * @dev The event is only emitted if the state of the emote is changed.
+     * @param emoter Address of the account that emoted or unemoted the token
+     * @param tokenId ID of the token being emoted or unemoted
+     * @param emoji Unicode identifier of the emoji
+     * @param on Boolean value signifying whether the token was emoted (`true`) or unemoted (`false`)
+     */
+    event Emoted(
+        address indexed emoter,
+        uint256 indexed tokenId,
+        bytes4 emoji,
+        bool on
+    );
+
+    /**
      * @notice Used to get the number of emotes for a specific emoji on a token.
      * @param tokenId ID of the token to check for emoji count
      * @param emoji Unicode identifier of the emoji

--- a/contracts/RMRK/extension/emotable/IRMRKEmoteTracker.sol
+++ b/contracts/RMRK/extension/emotable/IRMRKEmoteTracker.sol
@@ -11,6 +11,23 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  */
 interface IRMRKEmoteTracker is IERC165 {
     /**
+     * @notice Used to notify listeners of that the token with ID tokenId on collection has been emoted or unemoted.
+     * @dev The event is only emitted if the state of the emote is changed.
+     * @param emoter Address of the account that emoted or unemoted the token
+     * @param collection Address of the collection containing the token being emoted or unemoted
+     * @param tokenId ID of the token being emoted or unemoted
+     * @param emoji Unicode identifier of the emoji
+     * @param on Boolean value signifying whether the token was emoted (`true`) or unemoted (`false`)
+     */
+    event Emoted(
+        address indexed emoter,
+        address indexed collection,
+        uint256 indexed tokenId,
+        bytes4 emoji,
+        bool on
+    );
+
+    /**
      * @notice Used to get the number of emotes for a specific emoji on a token.
      * @param collection Address of the collection containing the token being checked for emoji count
      * @param tokenId ID of the token to check for emoji count

--- a/contracts/RMRK/extension/emotable/RMRKEmotable.sol
+++ b/contracts/RMRK/extension/emotable/RMRKEmotable.sol
@@ -15,13 +15,6 @@ abstract contract RMRKEmotable is IRMRKEmotable {
         private _emotesPerAddress; // Cheaper than using a bool
     mapping(uint256 => mapping(bytes4 => uint256)) private _emotesPerToken;
 
-    event Emoted(
-        address indexed emoter,
-        uint256 indexed tokenId,
-        bytes4 emoji,
-        bool on
-    );
-
     /**
      * @inheritdoc IRMRKEmotable
      */
@@ -53,6 +46,7 @@ abstract contract RMRKEmotable is IRMRKEmotable {
             }
             _emotesPerAddress[msg.sender][tokenId][emoji] = state ? 1 : 0;
             emit Emoted(msg.sender, tokenId, emoji, state);
+            _afterEmote(tokenId, emoji, state);
         }
     }
 
@@ -63,6 +57,18 @@ abstract contract RMRKEmotable is IRMRKEmotable {
      * @param state Boolean value signifying whether to emote (`true`) or undo (`false`) emote
      */
     function _beforeEmote(
+        uint256 tokenId,
+        bytes4 emoji,
+        bool state
+    ) internal virtual {}
+
+    /**
+     * @notice Hook that is called after emote is added or removed.
+     * @param tokenId ID of the token being emoted
+     * @param emoji Unicode identifier of the emoji
+     * @param state Boolean value signifying whether to emote (`true`) or undo (`false`) emote
+     */
+    function _afterEmote(
         uint256 tokenId,
         bytes4 emoji,
         bool state

--- a/contracts/RMRK/extension/emotable/RMRKEmoteTracker.sol
+++ b/contracts/RMRK/extension/emotable/RMRKEmoteTracker.sol
@@ -18,14 +18,6 @@ abstract contract RMRKEmoteTracker is IRMRKEmoteTracker {
     mapping(address => mapping(uint256 => mapping(bytes4 => uint256)))
         private _emotesPerToken;
 
-    event Emoted(
-        address indexed emoter,
-        address indexed collection,
-        uint256 indexed tokenId,
-        bytes4 emoji,
-        bool on
-    );
-
     /**
      * @inheritdoc IRMRKEmoteTracker
      */
@@ -64,6 +56,7 @@ abstract contract RMRKEmoteTracker is IRMRKEmoteTracker {
                 ? 1
                 : 0;
             emit Emoted(msg.sender, collection, tokenId, emoji, state);
+            _afterEmote(collection, tokenId, emoji, state);
         }
     }
 
@@ -75,6 +68,20 @@ abstract contract RMRKEmoteTracker is IRMRKEmoteTracker {
      * @param state Boolean value signifying whether to emote (`true`) or undo (`false`) emote
      */
     function _beforeEmote(
+        address collection,
+        uint256 tokenId,
+        bytes4 emoji,
+        bool state
+    ) internal virtual {}
+
+    /**
+     * @notice Hook that is called after emote is added or removed.
+     * @param collection Address of the collection containing the token being emoted
+     * @param tokenId ID of the token being emoted
+     * @param emoji Unicode identifier of the emoji
+     * @param state Boolean value signifying whether to emote (`true`) or undo (`false`) emote
+     */
+    function _afterEmote(
         address collection,
         uint256 tokenId,
         bytes4 emoji,

--- a/docs/RMRK/extension/emotable/IRMRKEmotable.md
+++ b/docs/RMRK/extension/emotable/IRMRKEmotable.md
@@ -75,4 +75,26 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 
 
 
+## Events
+
+### Emoted
+
+```solidity
+event Emoted(address indexed emoter, uint256 indexed tokenId, bytes4 emoji, bool on)
+```
+
+Used to notify listeners of that the token with ID tokenId has been emoted or unemoted.
+
+*The event is only emitted if the state of the emote is changed.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| emoter `indexed` | address | Address of the account that emoted or unemoted the token |
+| tokenId `indexed` | uint256 | ID of the token being emoted or unemoted |
+| emoji  | bytes4 | Unicode identifier of the emoji |
+| on  | bool | Boolean value signifying whether the token was emoted (`true`) or unemoted (`false`) |
+
+
 

--- a/docs/RMRK/extension/emotable/IRMRKEmoteTracker.md
+++ b/docs/RMRK/extension/emotable/IRMRKEmoteTracker.md
@@ -77,4 +77,27 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 
 
 
+## Events
+
+### Emoted
+
+```solidity
+event Emoted(address indexed emoter, address indexed collection, uint256 indexed tokenId, bytes4 emoji, bool on)
+```
+
+Used to notify listeners of that the token with ID tokenId on collection has been emoted or unemoted.
+
+*The event is only emitted if the state of the emote is changed.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| emoter `indexed` | address | Address of the account that emoted or unemoted the token |
+| collection `indexed` | address | Address of the collection containing the token being emoted or unemoted |
+| tokenId `indexed` | uint256 | ID of the token being emoted or unemoted |
+| emoji  | bytes4 | Unicode identifier of the emoji |
+| on  | bool | Boolean value signifying whether the token was emoted (`true`) or unemoted (`false`) |
+
+
 

--- a/docs/RMRK/extension/emotable/RMRKEmotable.md
+++ b/docs/RMRK/extension/emotable/RMRKEmotable.md
@@ -83,7 +83,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 event Emoted(address indexed emoter, uint256 indexed tokenId, bytes4 emoji, bool on)
 ```
 
-
+Used to notify listeners of that the token with ID tokenId has been emoted or unemoted.
 
 
 

--- a/docs/RMRK/extension/emotable/RMRKEmoteTracker.md
+++ b/docs/RMRK/extension/emotable/RMRKEmoteTracker.md
@@ -85,7 +85,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 event Emoted(address indexed emoter, address indexed collection, uint256 indexed tokenId, bytes4 emoji, bool on)
 ```
 
-
+Used to notify listeners of that the token with ID tokenId on collection has been emoted or unemoted.
 
 
 

--- a/docs/mocks/extensions/emotable/RMRKEmoteTrackerMock.md
+++ b/docs/mocks/extensions/emotable/RMRKEmoteTrackerMock.md
@@ -85,7 +85,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 event Emoted(address indexed emoter, address indexed collection, uint256 indexed tokenId, bytes4 emoji, bool on)
 ```
 
-
+Used to notify listeners of that the token with ID tokenId on collection has been emoted or unemoted.
 
 
 

--- a/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
+++ b/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
@@ -747,7 +747,7 @@ Used to notify listeners that an asset object is initialized at `assetId`.
 event Emoted(address indexed emoter, uint256 indexed tokenId, bytes4 emoji, bool on)
 ```
 
-
+Used to notify listeners of that the token with ID tokenId has been emoted or unemoted.
 
 
 


### PR DESCRIPTION
# Description

Moves emotable events to interfaces and adds after emote hook.

# Actions

- Moves emotable events to `IRMRKEmotable` and `IRMRKEmoteTracker`.
- Adds `_afterEmote` hook. `_beforeEmote` already existed.

# Checklist

- [ ] Verified code additions
- [ ] Updated NatSpec comments (if applicable)
- [ ] Regenerated docs
- [ ] Ran prettier
- [ ] Added tests to fully cover the changes
