### PR TITLE
MultiAssetAutoIndex extension

### DIFF
--- a/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.16;
+
+import "../../multiasset/IRMRKMultiAsset.sol";
+
+interface IRMRKMultiAssetAutoIndex is IRMRKMultiAsset {
+    /**
+     * @notice Accepts an asset at from the pending array of given token.
+     * @dev Migrates the asset from the token's pending asset array to the token's active asset array.
+     * @dev Active assets cannot be removed by anyone, but can be replaced by a new asset.
+     * @dev Requirements:
+     *
+     *  - The caller must own the token or be approved to manage the token's assets
+     *  - `tokenId` must exist.
+     *  - `index` must be in range of the length of the pending asset array.
+     * @dev Emits an {AssetAccepted} event.
+     * @param tokenId ID of the token for which to accept the pending asset
+     * @param assetId Id of the asset expected to be in the index
+     */
+    function acceptAsset(uint256 tokenId, uint64 assetId) external;
+
+    /**
+     * @notice Rejects an asset from the pending array of given token.
+     * @dev Removes the asset from the token's pending asset array.
+     * @dev Requirements:
+     *
+     *  - The caller must own the token or be approved to manage the token's assets
+     *  - `tokenId` must exist.
+     *  - `index` must be in range of the length of the pending asset array.
+     * @dev Emits a {AssetRejected} event.
+     * @param tokenId ID of the token that the asset is being rejected from
+     * @param assetId Id of the asset expected to be in the index
+     */
+    function rejectAsset(uint256 tokenId, uint64 assetId) external;
+}

--- a/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
@@ -4,23 +4,19 @@ pragma solidity ^0.8.16;
 
 import "./IRMRKMultiAssetAutoIndex.sol";
 import "../../multiasset/RMRKMultiAsset.sol";
-import "hardhat/console.sol";
 
 contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
     // Mapping of tokenId to assetId to index on the _pendingAssetIndex array
     mapping(uint256 => mapping(uint256 => uint256)) private _pendingAssetIndex;
 
-    constructor(string memory name_, string memory symbol_)
-        RMRKMultiAsset(name_, symbol_)
-    {}
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) RMRKMultiAsset(name_, symbol_) {}
 
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(IERC165, RMRKMultiAsset)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165, RMRKMultiAsset) returns (bool) {
         return
             interfaceId == type(IRMRKMultiAssetAutoIndex).interfaceId ||
             super.supportsInterface(interfaceId);
@@ -63,7 +59,9 @@ contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
         } else {
             // Rejected intermediate asset --> update indexes
             uint256 replacingAssetId = pendingAssetsIds[index];
-            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[tokenId][assetId];
+            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[
+                tokenId
+            ][assetId];
             delete _pendingAssetIndex[tokenId][assetId];
         }
     }
@@ -89,7 +87,9 @@ contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
         } else {
             // Rejected intermediate asset --> update indexes
             uint256 replacingAssetId = pendingAssetsIds[index];
-            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[tokenId][assetId];
+            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[
+                tokenId
+            ][assetId];
             delete _pendingAssetIndex[tokenId][assetId];
         }
     }

--- a/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.16;
+
+import "./IRMRKMultiAssetAutoIndex.sol";
+import "../../multiasset/RMRKMultiAsset.sol";
+import "hardhat/console.sol";
+
+contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
+    // Mapping of tokenId to assetId to index on the _pendingAssetIndex array
+    mapping(uint256 => mapping(uint256 => uint256)) private _pendingAssetIndex;
+
+    constructor(string memory name_, string memory symbol_)
+        RMRKMultiAsset(name_, symbol_)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, RMRKMultiAsset)
+        returns (bool)
+    {
+        return
+            interfaceId == type(IRMRKMultiAssetAutoIndex).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @inheritdoc IRMRKMultiAssetAutoIndex
+     */
+    function acceptAsset(uint256 tokenId, uint64 assetId) public {
+        uint256 index = _pendingAssetIndex[tokenId][assetId];
+        _acceptAsset(tokenId, index, assetId);
+    }
+
+    /**
+     * @inheritdoc IRMRKMultiAssetAutoIndex
+     */
+    function rejectAsset(uint256 tokenId, uint64 assetId) public {
+        uint256 index = _pendingAssetIndex[tokenId][assetId];
+        _rejectAsset(tokenId, index, assetId);
+    }
+
+    /**
+     * @inheritdoc AbstractMultiAsset
+     */
+    function _afterAcceptAsset(
+        uint256 tokenId,
+        uint256 index,
+        uint256 assetId
+    ) internal override {
+        require(
+            _pendingAssetIndex[tokenId][assetId] == index,
+            "Trying to delete asset at the wrong index"
+        );
+
+        uint64[] memory pendingAssetsIds = getPendingAssets(tokenId);
+
+        if (pendingAssetsIds.length == index) {
+            // Rejected last pending asset
+            delete _pendingAssetIndex[tokenId][assetId];
+        } else {
+            // Rejected intermediate asset --> update indexes
+            uint256 replacingAssetId = pendingAssetsIds[index];
+            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[tokenId][assetId];
+            delete _pendingAssetIndex[tokenId][assetId];
+        }
+    }
+
+    /**
+     * @inheritdoc AbstractMultiAsset
+     */
+    function _afterRejectAsset(
+        uint256 tokenId,
+        uint256 index,
+        uint256 assetId
+    ) internal override {
+        require(
+            _pendingAssetIndex[tokenId][assetId] == index,
+            "Trying to delete asset at the wrong index"
+        );
+
+        uint64[] memory pendingAssetsIds = getPendingAssets(tokenId);
+
+        if (pendingAssetsIds.length == index) {
+            // Rejected last pending asset
+            delete _pendingAssetIndex[tokenId][assetId];
+        } else {
+            // Rejected intermediate asset --> update indexes
+            uint256 replacingAssetId = pendingAssetsIds[index];
+            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[tokenId][assetId];
+            delete _pendingAssetIndex[tokenId][assetId];
+        }
+    }
+
+    /**
+     * @inheritdoc AbstractMultiAsset
+     */
+    function _beforeAddAssetToToken(
+        uint256 tokenId,
+        uint64 assetId,
+        uint64
+    ) internal virtual override {
+        // The asset has already been put into the pending asset list
+        _pendingAssetIndex[tokenId][assetId] = _pendingAssets[tokenId].length;
+    }
+}

--- a/contracts/mocks/RMRKMultiAssetAutoIndexMock.sol
+++ b/contracts/mocks/RMRKMultiAssetAutoIndexMock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.16;
+
+import "../RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol";
+
+contract RMRKMultiAssetAutoIndexMock is RMRKMultiAssetAutoIndex {
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) RMRKMultiAssetAutoIndex(name_, symbol_) {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function addAssetToToken(
+        uint256 tokenId,
+        uint64 assetId,
+        uint64 replacesAssetWithId
+    ) external {
+        _addAssetToToken(tokenId, assetId, replacesAssetWithId);
+    }
+
+    function addAssetEntry(uint64 id, string memory metadataURI) external {
+        _addAssetEntry(id, metadataURI);
+    }
+}

--- a/test/extensions/multiAssetAutoIndex.ts
+++ b/test/extensions/multiAssetAutoIndex.ts
@@ -1,11 +1,10 @@
-import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { expect } from 'chai';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { bn } from '../utils';
 import { IERC165, IRMRKMultiAsset, IRMRKMultiAssetAutoIndex, IOtherInterface } from '../interfaces';
 import { RMRKMultiAssetAutoIndexMock } from '../../typechain-types';
-
-import { bn } from '../utils';
 
 // --------------- FIXTURES -----------------------
 
@@ -23,11 +22,9 @@ describe('RMRKMultiAssetAutoIndexMock', async function () {
   let user: SignerWithAddress;
   let tokenId = bn(1);
 
-
   beforeEach(async function () {
     [owner, user] = await ethers.getSigners();
     token = await loadFixture(multiAssetAutoIndexFixture);
-
   });
 
   it('can support IERC165', async function () {
@@ -47,12 +44,11 @@ describe('RMRKMultiAssetAutoIndexMock', async function () {
   });
 
   describe('With minted tokens', async function () {
-
     const assetId = bn(1);
 
     beforeEach(async function () {
       await token.mint(user.address, tokenId);
-      await token.addAssetEntry(assetId, "ipfs/something.json");
+      await token.addAssetEntry(assetId, 'ipfs/something.json');
       await token.addAssetToToken(tokenId, assetId, 0);
     });
 
@@ -70,20 +66,18 @@ describe('RMRKMultiAssetAutoIndexMock', async function () {
   });
 
   describe('With multiple assets in the pending list', async function () {
-
     const asseOneId = bn(1);
     const assetTwoId = bn(2);
     const assetThreeId = bn(3);
 
     beforeEach(async function () {
-      await token.connect(owner).addAssetEntry(asseOneId, "ipfs/asset1.json");
+      await token.connect(owner).addAssetEntry(asseOneId, 'ipfs/asset1.json');
       await token.connect(owner).addAssetToToken(tokenId, asseOneId, 0);
-      await token.connect(owner).addAssetEntry(assetTwoId, "ipfs/asset2.json");
+      await token.connect(owner).addAssetEntry(assetTwoId, 'ipfs/asset2.json');
       await token.addAssetToToken(tokenId, assetTwoId, 0);
-      await token.connect(owner).addAssetEntry(assetThreeId, "ipfs/asset3.json");
+      await token.connect(owner).addAssetEntry(assetThreeId, 'ipfs/asset3.json');
       await token.addAssetToToken(tokenId, assetThreeId, 0);
       expect(await token.getPendingAssets(tokenId)).to.be.eql([bn(1), bn(2), bn(3)]);
-
     });
 
     it('can reject a middle asset in the pending list', async function () {
@@ -96,7 +90,7 @@ describe('RMRKMultiAssetAutoIndexMock', async function () {
       await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
       expect(await token.getPendingAssets(tokenId)).to.be.eql([asseOneId, assetThreeId]);
       expect(await token.getActiveAssets(tokenId)).to.be.eql([assetTwoId]);
-    }); 
+    });
 
     it('can reject first asset in the pending list', async function () {
       await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, asseOneId);
@@ -127,25 +121,25 @@ describe('RMRKMultiAssetAutoIndexMock', async function () {
     });
 
     describe('With multiple assets in the active list', async function () {
-
       const assetFourId = bn(4);
 
       beforeEach(async function () {
         await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, asseOneId);
         await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetThreeId);
         await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
-  
       });
 
       it('can replace the first active asset', async function () {
-        await token.connect(owner).addAssetEntry(assetFourId, "ipfs/asset4.json");
+        await token.connect(owner).addAssetEntry(assetFourId, 'ipfs/asset4.json');
         await token.connect(owner).addAssetToToken(tokenId, assetFourId, asseOneId);
         await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetFourId);
         expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
-        expect(await token.getActiveAssets(tokenId)).to.be.eql([assetFourId, assetThreeId, assetTwoId]);
+        expect(await token.getActiveAssets(tokenId)).to.be.eql([
+          assetFourId,
+          assetThreeId,
+          assetTwoId,
+        ]);
       });
     });
   });
-
-
 });

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -10,6 +10,7 @@ const IRMRKExternalEquip = '0x289dfee5';
 const IRMRKMultiAsset = '0xd1526708';
 const IRMRKNestable = '0x42b0e56f';
 const IRMRKNestableAutoIndex = '0x1884d52d';
+const IRMRKMultiAssetAutoIndex = '0x1cf132fe';
 const IRMRKNestableExternalEquip = '0x8b7f3e99';
 const IRMRKReclaimableChild = '0x2fb59acf';
 const IRMRKSoulbound = '0x911ec470';
@@ -29,6 +30,7 @@ export {
   IRMRKMultiAsset,
   IRMRKNestable,
   IRMRKNestableAutoIndex,
+  IRMRKMultiAssetAutoIndex,
   IRMRKNestableExternalEquip,
   IRMRKReclaimableChild,
   IRMRKSoulbound,

--- a/test/multiAssetAutoIndex.ts
+++ b/test/multiAssetAutoIndex.ts
@@ -1,0 +1,151 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { IERC165, IRMRKMultiAsset, IRMRKMultiAssetAutoIndex, IOtherInterface } from '../interfaces';
+import { RMRKMultiAssetAutoIndexMock } from '../../typechain-types';
+
+import { bn } from '../utils';
+
+// --------------- FIXTURES -----------------------
+
+async function multiAssetAutoIndexFixture() {
+  const factory = await ethers.getContractFactory('RMRKMultiAssetAutoIndexMock');
+  const token = await factory.deploy('Chunky', 'CHNK');
+  await token.deployed();
+
+  return token;
+}
+
+describe('RMRKMultiAssetAutoIndexMock', async function () {
+  let token: RMRKMultiAssetAutoIndexMock;
+  let owner: SignerWithAddress;
+  let user: SignerWithAddress;
+  let tokenId = bn(1);
+
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    token = await loadFixture(multiAssetAutoIndexFixture);
+
+  });
+
+  it('can support IERC165', async function () {
+    expect(await token.supportsInterface(IERC165)).to.equal(true);
+  });
+
+  it('can support IRMRKMultiAsset', async function () {
+    expect(await token.supportsInterface(IRMRKMultiAsset)).to.equal(true);
+  });
+
+  it('can support IRMRKMultiAssetAutoIndex', async function () {
+    expect(await token.supportsInterface(IRMRKMultiAssetAutoIndex)).to.equal(true);
+  });
+
+  it('does not support other interfaces', async function () {
+    expect(await token.supportsInterface(IOtherInterface)).to.equal(false);
+  });
+
+  describe('With minted tokens', async function () {
+
+    const assetId = bn(1);
+
+    beforeEach(async function () {
+      await token.mint(user.address, tokenId);
+      await token.addAssetEntry(assetId, "ipfs/something.json");
+      await token.addAssetToToken(tokenId, assetId, 0);
+    });
+
+    it('can accept an asset', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([assetId]);
+    });
+
+    it('can reject an asset', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+  });
+
+  describe('With multiple assets in the pending list', async function () {
+
+    const asseOneId = bn(1);
+    const assetTwoId = bn(2);
+    const assetThreeId = bn(3);
+
+    beforeEach(async function () {
+      await token.connect(owner).addAssetEntry(asseOneId, "ipfs/asset1.json");
+      await token.connect(owner).addAssetToToken(tokenId, asseOneId, 0);
+      await token.connect(owner).addAssetEntry(assetTwoId, "ipfs/asset2.json");
+      await token.addAssetToToken(tokenId, assetTwoId, 0);
+      await token.connect(owner).addAssetEntry(assetThreeId, "ipfs/asset3.json");
+      await token.addAssetToToken(tokenId, assetThreeId, 0);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([bn(1), bn(2), bn(3)]);
+
+    });
+
+    it('can reject a middle asset in the pending list', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([bn(1), bn(3)]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+
+    it('can accept a middle asset in the pending list', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([asseOneId, assetThreeId]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([assetTwoId]);
+    }); 
+
+    it('can reject first asset in the pending list', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, asseOneId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([assetThreeId, assetTwoId]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+
+    it('can accept first asset in the pending list', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, asseOneId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([assetThreeId, assetTwoId]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([asseOneId]);
+    });
+
+    it('can reject all assets in the pending list', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, asseOneId);
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetThreeId);
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+
+    it('can accept all assets in the pending list', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, asseOneId);
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetThreeId);
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([asseOneId, assetThreeId, assetTwoId]);
+    });
+
+    describe('With multiple assets in the active list', async function () {
+
+      const assetFourId = bn(4);
+
+      beforeEach(async function () {
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, asseOneId);
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetThreeId);
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
+  
+      });
+
+      it('can replace the first active asset', async function () {
+        await token.connect(owner).addAssetEntry(assetFourId, "ipfs/asset4.json");
+        await token.connect(owner).addAssetToToken(tokenId, assetFourId, asseOneId);
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetFourId);
+        expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+        expect(await token.getActiveAssets(tokenId)).to.be.eql([assetFourId, assetThreeId, assetTwoId]);
+      });
+    });
+  });
+
+
+});


### PR DESCRIPTION
# Description

This extension allow the user to call MultiAsset function without the help of an index.

# Actions

For this feature I've create a new interface and its implementation along with a Mock contract and a test file:
- IRMRKMultiAssetAutoIndex.sol (interface)
- RMRKMultiAssetAutoIndex.sol (implementation)
- RMRKMultiAssetAutoIndexMock.sol (Mock)
- multiAssetAutoIndex.ts (testing)

# Checklist

- [x] Verified code additions
- [ ] Updated NatSpec comments (if applicable)
- [ ] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
