### PR TITLE
Resolve undefined instances in docs where available

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ user to create NFT systems of arbitrary complexity.
 There are various possibilities on how to combine these legos, all of which are ERC721 compatible:
 
 1. MultiAsset (Context-Dependent Multi-Asset Tokens)
-    - Only uses the MultiAsset RMRK lego
+   - Only uses the MultiAsset RMRK lego
 2. Nestable (Parent-Governed Nestable Non-Fungible Tokens)
-    - Only uses the Nestable RMRK lego
+   - Only uses the Nestable RMRK lego
 3. Nestable with MultiAsset
-    - Uses both Nestable and MultiAsset RMRK legos
+   - Uses both Nestable and MultiAsset RMRK legos
 4. Equippable MultiAsset with Nestable and Catalog
-    - Merged equippable is a more compact RMRK lego composite that uses less smart contracts, but has less space for
-    custom logic implementation
-    - Split equippable is a more customizable RMRK lego composite that uses more smart contracts, but has more space for
-    custom logic implementation
+   - Merged equippable is a more compact RMRK lego composite that uses less smart contracts, but has less space for
+     custom logic implementation
+   - Split equippable is a more customizable RMRK lego composite that uses more smart contracts, but has more space for
+     custom logic implementation
 
 ![RMRK Legos infographic](img/RMRKLegoInfographics.png)
 
@@ -52,7 +52,7 @@ the use of our legos:
 ### MultiAsset ([RMRKMultiAsset](./contracts/RMRK/multiasset/RMRKMultiAsset.sol)): [ERC-5773: Context-Dependent Multi-Asset Tokens](https://eips.ethereum.org/EIPS/eip-5773)
 
 1. Deploy the `MultiAsset` contract.
-2. Admin must add assets on a ***per-token*** basis. This could be very gas-intensive, so we recommend adding them in
+2. Admin must add assets on a **_per-token_** basis. This could be very gas-intensive, so we recommend adding them in
    batches.
 3. Mint the tokens using your preferred method.
 

--- a/contracts/RMRK/access/Ownable.sol
+++ b/contracts/RMRK/access/Ownable.sol
@@ -88,6 +88,7 @@ contract Ownable is Context {
     /**
      * @notice Transfers ownership of the contract to a new owner.
      * @dev Internal function without access restriction.
+     * @dev Emits ***OwnershipTransferred*** event.
      * @param newOwner Address of the new owner's account
      */
     function _transferOwnership(address newOwner) internal virtual {
@@ -99,6 +100,7 @@ contract Ownable is Context {
     /**
      * @notice Adds or removes a contributor to the smart contract.
      * @dev Can only be called by the owner.
+     * @dev Emits ***ContributorUpdate*** event.
      * @param contributor Address of the contributor's account
      * @param grantRole A boolean value signifying whether the contributor role is being granted (`true`) or revoked
      *  (`false`)

--- a/contracts/RMRK/access/OwnableLock.sol
+++ b/contracts/RMRK/access/OwnableLock.sol
@@ -31,7 +31,7 @@ contract OwnableLock is Ownable {
 
     /**
      * @notice Used to retrieve the status of a lockable smart contract.
-     * @return bool A boolean value signifying whether the smart contract has been locked
+     * @return A boolean value signifying whether the smart contract has been locked
      */
     function getLock() public view returns (bool) {
         return _lock == 1;

--- a/contracts/RMRK/catalog/IRMRKCatalog.sol
+++ b/contracts/RMRK/catalog/IRMRKCatalog.sol
@@ -110,7 +110,7 @@ interface IRMRKCatalog is IERC165 {
 
     /**
      * @notice Used to return the metadata URI of the associated Catalog.
-     * @return Case metadata URI
+     * @return Catalog metadata URI
      */
     function getMetadataURI() external view returns (string memory);
 

--- a/contracts/RMRK/catalog/IRMRKCatalog.sol
+++ b/contracts/RMRK/catalog/IRMRKCatalog.sol
@@ -110,13 +110,13 @@ interface IRMRKCatalog is IERC165 {
 
     /**
      * @notice Used to return the metadata URI of the associated Catalog.
-     * @return string Case metadata URI
+     * @return Case metadata URI
      */
     function getMetadataURI() external view returns (string memory);
 
     /**
      * @notice Used to return the `itemType` of the associated Catalog
-     * @return string `itemType` of the associated Catalog
+     * @return `itemType` of the associated Catalog
      */
     function getType() external view returns (string memory);
 
@@ -125,7 +125,7 @@ interface IRMRKCatalog is IERC165 {
      * @dev Returns true if a collection may equip asset with `partId`.
      * @param partId The ID of the part that we are checking
      * @param targetAddress The address that we are checking for whether the part can be equipped into it or not
-     * @return bool The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not
+     * @return The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not
      */
     function checkIsEquippable(
         uint64 partId,
@@ -136,21 +136,21 @@ interface IRMRKCatalog is IERC165 {
      * @notice Used to check if the part is equippable by all addresses.
      * @dev Returns true if part is equippable to all.
      * @param partId ID of the part that we are checking
-     * @return bool The status indicating whether the part with `partId` can be equipped by any address or not
+     * @return The status indicating whether the part with `partId` can be equipped by any address or not
      */
     function checkIsEquippableToAll(uint64 partId) external view returns (bool);
 
     /**
      * @notice Used to retrieve a `Part` with id `partId`
      * @param partId ID of the part that we are retrieving
-     * @return struct The `Part` struct associated with given `partId`
+     * @return The `Part` struct associated with given `partId`
      */
     function getPart(uint64 partId) external view returns (Part memory);
 
     /**
      * @notice Used to retrieve multiple parts at the same time.
      * @param partIds An array of part IDs that we want to retrieve
-     * @return struct An array of `Part` structs associated with given `partIds`
+     * @return An array of `Part` structs associated with given `partIds`
      */
     function getParts(
         uint64[] calldata partIds

--- a/contracts/RMRK/catalog/RMRKCatalog.sol
+++ b/contracts/RMRK/catalog/RMRKCatalog.sol
@@ -20,7 +20,8 @@ contract RMRKCatalog is IRMRKCatalog {
     mapping(uint64 => Part) private _parts;
 
     /**
-     * @notice Mapping of uint64 `partId` to boolean flag, indicating that a given `Part` can be equippable by any address
+     * @notice Mapping of uint64 `partId` to boolean flag, indicating that a given `Part` can be equippable by any
+     *  address
      */
     mapping(uint64 => bool) private _isEquippableToAll;
 
@@ -50,6 +51,11 @@ contract RMRKCatalog is IRMRKCatalog {
         _;
     }
 
+    /**
+     * @notice Used to verify that an operation is only executed on slot Parts.
+     * @dev If the Part is not Slot type, the execution will be reverted.
+     * @param partId ID of the part to check
+     */
     function _onlySlot(uint64 partId) private view {
         ItemType itemType = _parts[partId].itemType;
         if (itemType == ItemType.None) revert RMRKPartDoesNotExist();
@@ -143,6 +149,7 @@ contract RMRKCatalog is IRMRKCatalog {
     /**
      * @notice Internal function used to add multiple `equippableAddresses` to a single catalog entry.
      * @dev Can only be called on `Part`s of `Slot` type.
+     * @dev Emits ***AddedEquippables*** event.
      * @param partId ID of the `Part` that we are adding the equippable addresses to
      * @param equippableAddresses An array of addresses that can be equipped into the `Part` associated with the `partId`
      */
@@ -168,6 +175,7 @@ contract RMRKCatalog is IRMRKCatalog {
      * @notice Internal function used to set the new list of `equippableAddresses`.
      * @dev Overwrites existing `equippableAddresses`.
      * @dev Can only be called on `Part`s of `Slot` type.
+     * @dev Emits ***SetEquippable*** event.
      * @param partId ID of the `Part`s that we are overwiting the `equippableAddresses` for
      * @param equippableAddresses A full array of addresses that can be equipped into this `Part`
      */
@@ -185,6 +193,7 @@ contract RMRKCatalog is IRMRKCatalog {
     /**
      * @notice Internal function used to remove all of the `equippableAddresses` for a `Part` associated with the `partId`.
      * @dev Can only be called on `Part`s of `Slot` type.
+     * @dev Emits ***SetEquippable*** event.
      * @param partId ID of the part that we are clearing the `equippableAddresses` from
      */
     function _resetEquippableAddresses(
@@ -200,6 +209,7 @@ contract RMRKCatalog is IRMRKCatalog {
      * @notice Sets the isEquippableToAll flag to true, meaning that any collection may be equipped into the `Part` with this
      *  `partId`.
      * @dev Can only be called on `Part`s of `Slot` type.
+     * @dev Emits ***SetEquippableToAll*** event.
      * @param partId ID of the `Part` that we are setting as equippable by any address
      */
     function _setEquippableToAll(uint64 partId) internal onlySlot(partId) {

--- a/contracts/RMRK/core/IRMRKCore.sol
+++ b/contracts/RMRK/core/IRMRKCore.sol
@@ -10,13 +10,13 @@ pragma solidity ^0.8.16;
 interface IRMRKCore {
     /**
      * @notice Used to retrieve the collection name.
-     * @return string Name of the collection
+     * @return Name of the collection
      */
     function name() external view returns (string memory);
 
     /**
      * @notice Used to retrieve the collection symbol.
-     * @return string Symbol of the collection
+     * @return Symbol of the collection
      */
     function symbol() external view returns (string memory);
 }

--- a/contracts/RMRK/core/RMRKCore.sol
+++ b/contracts/RMRK/core/RMRKCore.sol
@@ -11,7 +11,10 @@ import "./IRMRKCore.sol";
  * @dev This is currently just a passthrough contract which allows for granular editing of base-level ERC721 functions.
  */
 contract RMRKCore is IRMRKCore {
-    /// @notice Version of the @rmrk-team/evm-contracts package
+    /**
+     * @notice Version of the @rmrk-team/evm-contracts package
+     * @return Version identifier of the smart contract
+     */
     string public constant VERSION = "0.24.2";
 
     /**
@@ -32,7 +35,7 @@ contract RMRKCore is IRMRKCore {
 
     /**
      * @notice Used to retrieve the collection name.
-     * @return string Name of the collection
+     * @return Name of the collection
      */
     function name() public view virtual override returns (string memory) {
         return _name;
@@ -40,7 +43,7 @@ contract RMRKCore is IRMRKCore {
 
     /**
      * @notice Used to retrieve the collection symbol.
-     * @return string Symbol of the collection
+     * @return Symbol of the collection
      */
     function symbol() public view virtual override returns (string memory) {
         return _symbol;

--- a/contracts/RMRK/equippable/IRMRKEquippable.sol
+++ b/contracts/RMRK/equippable/IRMRKEquippable.sol
@@ -127,7 +127,7 @@ interface IRMRKEquippable is IRMRKMultiAsset {
      * @param tokenId ID of the parent token for which we are querying for
      * @param childAddress Address of the child token's smart contract
      * @param childId ID of the child token
-     * @return The boolean value indicating whether the child token is equipped into the given token or not
+     * @return A boolean value indicating whether the child token is equipped into the given token or not
      */
     function isChildEquipped(
         uint256 tokenId,
@@ -141,7 +141,7 @@ interface IRMRKEquippable is IRMRKMultiAsset {
      * @param tokenId ID of the token we want to equip
      * @param assetId ID of the asset associated with the token we want to equip
      * @param slotId ID of the slot that we want to equip the token into
-     * @return The boolean indicating whether the token with the given asset can be equipped into the desired slot
+     * @return A boolean indicating whether the token with the given asset can be equipped into the desired slot
      */
     function canTokenBeEquippedWithAssetIntoSlot(
         address parent,

--- a/contracts/RMRK/equippable/IRMRKEquippable.sol
+++ b/contracts/RMRK/equippable/IRMRKEquippable.sol
@@ -127,7 +127,7 @@ interface IRMRKEquippable is IRMRKMultiAsset {
      * @param tokenId ID of the parent token for which we are querying for
      * @param childAddress Address of the child token's smart contract
      * @param childId ID of the child token
-     * @return bool The boolean value indicating whether the child token is equipped into the given token or not
+     * @return The boolean value indicating whether the child token is equipped into the given token or not
      */
     function isChildEquipped(
         uint256 tokenId,
@@ -141,8 +141,7 @@ interface IRMRKEquippable is IRMRKMultiAsset {
      * @param tokenId ID of the token we want to equip
      * @param assetId ID of the asset associated with the token we want to equip
      * @param slotId ID of the slot that we want to equip the token into
-     * @return bool The boolean indicating whether the token with the given asset can be equipped into the desired
-     *  slot
+     * @return The boolean indicating whether the token with the given asset can be equipped into the desired slot
      */
     function canTokenBeEquippedWithAssetIntoSlot(
         address parent,
@@ -163,7 +162,7 @@ interface IRMRKEquippable is IRMRKMultiAsset {
      * @param tokenId ID of the token for which we are retrieving the equipped object
      * @param targetCatalogAddress Address of the `Catalog` associated with the `Slot` part of the token
      * @param slotPartId ID of the `Slot` part that we are checking for equipped objects
-     * @return struct The `Equipment` struct containing data about the equipped object
+     * @return The `Equipment` struct containing data about the equipped object
      */
     function getEquipment(
         uint256 tokenId,

--- a/contracts/RMRK/equippable/IRMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/IRMRKExternalEquip.sol
@@ -20,7 +20,7 @@ interface IRMRKExternalEquip is IRMRKEquippable {
 
     /**
      * @notice Returns the Equippable contract's corresponding nestable address.
-     * @return address Address of the Nestable module of the external equip composite
+     * @return Address of the Nestable module of the external equip composite
      */
     function getNestableAddress() external view returns (address);
 }

--- a/contracts/RMRK/equippable/IRMRKNestableExternalEquip.sol
+++ b/contracts/RMRK/equippable/IRMRKNestableExternalEquip.sol
@@ -20,7 +20,7 @@ interface IRMRKNestableExternalEquip is IERC165 {
 
     /**
      * @notice Used to retrieve the `Equippable` smart contract's address.
-     * @return address Address of the `Equippable` smart contract
+     * @return Address of the `Equippable` smart contract
      */
     function getEquippableAddress() external view returns (address);
 
@@ -29,8 +29,8 @@ interface IRMRKNestableExternalEquip is IERC165 {
      *  it.
      * @param spender Address of the account we are checking for ownership or approval
      * @param tokenId ID of the token that we are checking
-     * @return bool A boolean value indicating whether the specified address is the owner of the given token or approved
-     *  to manage it
+     * @return A boolean value indicating whether the specified address is the owner of the given token or approved to
+     *  manage it
      */
     function isApprovedOrOwner(
         address spender,

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -116,6 +116,7 @@ contract RMRKEquippable is
      * @dev Emits an {AssetAccepted} event.
      * @param tokenId ID of the token for which to accept the pending asset
      * @param index Index of the asset in the pending array to accept
+     * @param assetId ID of the asset that is being accepted
      */
     function acceptAsset(
         uint256 tokenId,
@@ -136,6 +137,7 @@ contract RMRKEquippable is
      * @dev Emits a {AssetRejected} event.
      * @param tokenId ID of the token that the asset is being rejected from
      * @param index Index of the asset in the pending array to be rejected
+     * @param assetId ID of the asset that is being rejected
      */
     function rejectAsset(
         uint256 tokenId,
@@ -238,7 +240,7 @@ contract RMRKEquippable is
      * @notice Used to get the address of the user that is approved to manage the specified token from the current
      *  owner.
      * @param tokenId ID of the token we are checking
-     * @return address Address of the account that is approved to manage the token
+     * @return Address of the account that is approved to manage the token
      */
     function getApprovedForAssets(
         uint256 tokenId
@@ -254,7 +256,7 @@ contract RMRKEquippable is
      *   3. Is granted approval for the specific tokenId for asset management via the `approveForAssets` function.
      * @param user Address of the user we are checking for permission
      * @param tokenId ID of the token to query for permission for a given `user`
-     * @return bool A boolean value indicating whether the user is approved to manage the token or not
+     * @return A boolean value indicating whether the user is approved to manage the token or not
      */
     function _isApprovedForAssetsOrOwner(
         address user,
@@ -338,6 +340,7 @@ contract RMRKEquippable is
      *      slotPartId,
      *      childAssetId
      *  ]
+     * @dev Emits ***ChildAssetEquipped*** event.
      * @param data An `IntakeEquip` struct specifying the equip data
      */
     function _equip(IntakeEquip memory data) internal virtual {
@@ -427,6 +430,7 @@ contract RMRKEquippable is
 
     /**
      * @notice Private function used to unequip child from parent token.
+     * @dev Emits ***ChildAssetUnequipped*** event.
      * @param tokenId ID of the parent from which the child is being unequipped
      * @param assetId ID of the parent's asset that contains the `Slot` into which the child is equipped
      * @param slotPartId ID of the `Slot` from which to unequip the child
@@ -475,7 +479,8 @@ contract RMRKEquippable is
 
     /**
      * @notice Internal function used to declare that the assets belonging to a given `equippableGroupId` are
-     *  equippable into the `Slot` associated with the `partId` of the collection at the specified `parentAddress`
+     *  equippable into the `Slot` associated with the `partId` of the collection at the specified `parentAddress`.
+     * @dev Emits ***ValidParentEquippableGroupIdSet*** event.
      * @param equippableGroupId ID of the equippable group
      * @param parentAddress Address of the parent into which the equippable group can be equipped into
      * @param slotPartId ID of the `Slot` that the items belonging to the equippable group can be equipped into

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -94,7 +94,7 @@ contract RMRKExternalEquip is
      *   3. Is granted approval for the specific tokenId for asset management via the `approveForAssets` function.
      * @param user Address of the user we are checking for permission
      * @param tokenId ID of the token to query for permission for a given `user`
-     * @return bool A boolean value indicating whether the user is approved to manage the token or not
+     * @return A boolean value indicating whether the user is approved to manage the token or not
      */
     function _isApprovedForAssetsOrOwner(
         address user,
@@ -210,8 +210,8 @@ contract RMRKExternalEquip is
      * @dev If the number of pending assets is greater than the value of `maxRejections`, the exectuion will be
      *  reverted.
      * @param tokenId ID of the token for which we are clearing the pending array.
-     * @param maxRejections Maximum number of expected assets to reject, used to prevent from
-     *  rejecting assets which arrive just before this operation.
+     * @param maxRejections Maximum number of expected assets to reject, used to prevent from rejecting assets which
+     *  arrive just before this operation.
      */
     function rejectAllAssets(
         uint256 tokenId,
@@ -266,7 +266,7 @@ contract RMRKExternalEquip is
      * @notice Used to get the address of the user that is approved to manage the specified token from the current
      *  owner.
      * @param tokenId ID of the token we are checking
-     * @return address Address of the account that is approved to manage the token
+     * @return Address of the account that is approved to manage the token
      */
     function getApprovedForAssets(
         uint256 tokenId
@@ -277,6 +277,7 @@ contract RMRKExternalEquip is
 
     /**
      * @notice Internal function for granting approvals for a specific token.
+     * @dev Emits ***ApprovalForAssets*** event.
      * @param to Address of the account we are granting an approval to
      * @param tokenId ID of the token we are granting the approval for
      */
@@ -310,6 +311,7 @@ contract RMRKExternalEquip is
      *      slotPartId,
      *      childAssetId
      *  ]
+     * @dev Emits ***ChildAssetEquipped*** event.
      * @param data An `IntakeEquip` struct specifying the equip data
      */
     function _equip(IntakeEquip memory data) internal virtual {
@@ -399,6 +401,7 @@ contract RMRKExternalEquip is
 
     /**
      * @notice Private function used to unequip child from parent token.
+     * @dev Emits ***ChildAssetUnequipped*** event.
      * @param tokenId ID of the parent from which the child is being unequipped
      * @param assetId ID of the parent's asset that contains the `Slot` into which the child is equipped
      * @param slotPartId ID of the `Slot` from which to unequip the child
@@ -455,7 +458,8 @@ contract RMRKExternalEquip is
 
     /**
      * @notice Internal function used to declare that the assets belonging to a given `equippableGroupId` are
-     *  equippable into the `Slot` associated with the `partId` of the collection at the specified `parentAddress`
+     *  equippable into the `Slot` associated with the `partId` of the collection at the specified `parentAddress`.
+     * @dev Emit ***ValidParentEquippableGroupIdSet*** event.
      * @param equippableGroupId ID of the equippable group
      * @param parentAddress Address of the parent into which the equippable group can be equipped into
      * @param slotPartId ID of the `Slot` that the items belonging to the equippable group can be equipped into
@@ -574,7 +578,7 @@ contract RMRKExternalEquip is
      * @dev As the check validates that the owner is not the `0x0` address, the token is marked as non-existent if it
      *  hasn't been minted yet, or if has already been burned.
      * @param tokenId ID of the token we are checking
-     * @return bool A boolean value specifying whether the token exists
+     * @return A boolean value specifying whether the token exists
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return ownerOf(tokenId) != address(0);
@@ -585,7 +589,7 @@ contract RMRKExternalEquip is
      * @dev This returns the root owner of the token. In case where the token is nested into a parent token, the owner
      *  is iteratively searched for, until non-smart contract owner is found.
      * @param tokenId ID of the token we are checking
-     * @return address Address of the root owner of the token
+     * @return Address of the root owner of the token
      */
     function ownerOf(uint256 tokenId) internal view returns (address) {
         return IRMRKNestable(_nestableAddress).ownerOf(tokenId);

--- a/contracts/RMRK/equippable/RMRKNestableExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKNestableExternalEquip.sol
@@ -78,6 +78,7 @@ contract RMRKNestableExternalEquip is IRMRKNestableExternalEquip, RMRKNestable {
 
     /**
      * @notice Used to set the address of the `Equippable` smart contract.
+     * @dev Emits ***EquippableAddressSet*** event.
      * @param equippable Address of the `Equippable` smart contract
      */
     function _setEquippableAddress(address equippable) internal virtual {

--- a/contracts/RMRK/extension/RMRKRoyalties.sol
+++ b/contracts/RMRK/extension/RMRKRoyalties.sol
@@ -28,7 +28,6 @@ abstract contract RMRKRoyalties is IERC2981 {
         _royaltyPercentageBps = royaltyPercentageBps;
     }
 
-    //@notice Requires access control on the implementation contract like implementing Ownable and setting onlyOwner modifier
     /**
      * @notice Used to update recipient of royalties.
      * @dev Custom access control has to be implemented to ensure that only the intended actors can update the
@@ -49,7 +48,7 @@ abstract contract RMRKRoyalties is IERC2981 {
 
     /**
      * @notice Used to retrieve the recipient of royalties.
-     * @return address Address of the recipient of royalties
+     * @return Address of the recipient of royalties
      */
     function getRoyaltyRecipient() external view virtual returns (address) {
         return _royaltyRecipient;
@@ -57,7 +56,7 @@ abstract contract RMRKRoyalties is IERC2981 {
 
     /**
      * @notice Used to retrieve the specified royalty percentage.
-     + @return uint256 The royalty percentage expressed in the basis points
+     * @return The royalty percentage expressed in the basis points
      */
     function getRoyaltyPercentage() external view virtual returns (uint256) {
         return _royaltyPercentageBps;

--- a/contracts/RMRK/extension/emotable/RMRKEmotable.sol
+++ b/contracts/RMRK/extension/emotable/RMRKEmotable.sol
@@ -27,6 +27,7 @@ abstract contract RMRKEmotable is IRMRKEmotable {
 
     /**
      * @notice Used to emote or undo an emote on a token.
+     * @dev Emits ***Emoted*** event.
      * @param tokenId ID of the token being emoted
      * @param emoji Unicode identifier of the emoji
      * @param state Boolean value signifying whether to emote (`true`) or undo (`false`) emote

--- a/contracts/RMRK/extension/emotable/RMRKEmoteTracker.sol
+++ b/contracts/RMRK/extension/emotable/RMRKEmoteTracker.sol
@@ -31,6 +31,7 @@ abstract contract RMRKEmoteTracker is IRMRKEmoteTracker {
 
     /**
      * @notice Used to emote or undo an emote on a token.
+     * @dev Emits ***Emoted*** event.
      * @param collection Address of the collection containing the token being emoted
      * @param tokenId ID of the token being emoted
      * @param emoji Unicode identifier of the emoji

--- a/contracts/RMRK/extension/tokenProperties/IRMRKTokenProperties.sol
+++ b/contracts/RMRK/extension/tokenProperties/IRMRKTokenProperties.sol
@@ -14,7 +14,7 @@ interface IRMRKTokenProperties is IERC165 {
      * @notice Used to retrieve the string type token properties.
      * @param tokenId The token ID
      * @param key The key of the property
-     * @return string The value of the string property
+     * @return The value of the string property
      */
     function getStringTokenProperty(
         uint256 tokenId,
@@ -25,7 +25,7 @@ interface IRMRKTokenProperties is IERC165 {
      * @notice Used to retrieve the uint type token properties.
      * @param tokenId The token ID
      * @param key The key of the property
-     * @return uint256 The value of the uint property
+     * @return The value of the uint property
      */
     function getUintTokenProperty(
         uint256 tokenId,
@@ -36,7 +36,7 @@ interface IRMRKTokenProperties is IERC165 {
      * @notice Used to retrieve the bool type token properties.
      * @param tokenId The token ID
      * @param key The key of the property
-     * @return bool The value of the bool property
+     * @return The value of the bool property
      */
     function getBoolTokenProperty(
         uint256 tokenId,
@@ -47,7 +47,7 @@ interface IRMRKTokenProperties is IERC165 {
      * @notice Used to retrieve the address type token properties.
      * @param tokenId The token ID
      * @param key The key of the property
-     * @return address The value of the address property
+     * @return The value of the address property
      */
     function getAddressTokenProperty(
         uint256 tokenId,
@@ -58,7 +58,7 @@ interface IRMRKTokenProperties is IERC165 {
      * @notice Used to retrieve the bytes type token properties.
      * @param tokenId The token ID
      * @param key The key of the property
-     * @return bytes The value of the bytes property
+     * @return The value of the bytes property
      */
     function getBytesTokenProperty(
         uint256 tokenId,

--- a/contracts/RMRK/extension/tokenProperties/RMRKTokenProperties.sol
+++ b/contracts/RMRK/extension/tokenProperties/RMRKTokenProperties.sol
@@ -155,7 +155,7 @@ abstract contract RMRKTokenProperties is IRMRKTokenProperties {
      * @notice Used to get the Id for a key. If the key does not exist, a new Id is created.
      *  Ids are shared among all tokens and types
      * @param key The property key
-     * @return uint256 The id for the key
+     * @return The id for the key
      */
     function _getIdForKey(string memory key) internal returns (uint256) {
         if (_keysToIds[key] == 0) {
@@ -171,7 +171,7 @@ abstract contract RMRKTokenProperties is IRMRKTokenProperties {
      * @notice Used to get the Id for a string value. If the value does not exist, a new Id is created.
      *  Ids are shared among all tokens and used only for strings.
      * @param value The property value
-     * @return uint256 The id for the value
+     * @return The id for the value
      */
     function _getStringIdForValue(
         string memory value

--- a/contracts/RMRK/extension/tokenProperties/RMRKTokenProperties.sol
+++ b/contracts/RMRK/extension/tokenProperties/RMRKTokenProperties.sol
@@ -171,7 +171,7 @@ abstract contract RMRKTokenProperties is IRMRKTokenProperties {
      * @notice Used to get the Id for a string value. If the value does not exist, a new Id is created.
      *  Ids are shared among all tokens and used only for strings.
      * @param value The property value
-     * @return The id for the value
+     * @return The id for the string value
      */
     function _getStringIdForValue(
         string memory value

--- a/contracts/RMRK/extension/typedMultiAsset/IRMRKTypedMultiAsset.sol
+++ b/contracts/RMRK/extension/typedMultiAsset/IRMRKTypedMultiAsset.sol
@@ -14,7 +14,7 @@ interface IRMRKTypedMultiAsset is IERC165 {
     /**
      * @notice Used to get the type of the asset.
      * @param assetId ID of the asset to check
-     * @return string The type of the asset
+     * @return The type of the asset
      */
     function getAssetType(uint64 assetId) external view returns (string memory);
 }

--- a/contracts/RMRK/library/RMRKLib.sol
+++ b/contracts/RMRK/library/RMRKLib.sol
@@ -27,8 +27,8 @@ library RMRKLib {
      * @dev If the item is not found the index returned will equal `0`.
      * @param A The array containing the item to be found
      * @param a The value of the item to find the index of
-     * @return uint256 The index of the item in the array
-     * @return bool A boolean value specifying whether the item was found
+     * @return The index of the item in the array
+     * @return A boolean value specifying whether the item was found
      */
     function indexOf(
         uint64[] memory A,

--- a/contracts/RMRK/multiasset/AbstractMultiAsset.sol
+++ b/contracts/RMRK/multiasset/AbstractMultiAsset.sol
@@ -114,6 +114,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
     /**
      * @notice Used to accept a pending asset.
      * @dev The call is reverted if there is no pending asset at a given index.
+     * @dev Emits ***AssetAccepted*** event.
      * @param tokenId ID of the token for which to accept the pending asset
      * @param index Index of the asset in the pending array to accept
      * @param assetId ID of the asset to accept in token's pending array
@@ -156,6 +157,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
     /**
      * @notice Used to reject the specified asset from the pending array.
      * @dev The call is reverted if there is no pending asset at a given index.
+     * @dev Emits ***AssetRejected*** event.
      * @param tokenId ID of the token that the asset is being rejected from
      * @param index Index of the asset in the pending array to be rejected
      * @param assetId ID of the asset expected to be in the index
@@ -213,6 +215,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
      * @dev When rejecting all assets, the pending array is indiscriminately cleared.
      * @dev If the number of pending assets is greater than the value of `maxRejections`, the exectuion will be
      *  reverted.
+     * @dev Emits ***AssetRejected*** event.
      * @param tokenId ID of the token to reject all of the pending assets.
      * @param maxRejections Maximum number of expected assets to reject, used to prevent from
      *  rejecting assets which arrive just before this operation.
@@ -245,6 +248,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
      *  will be reverted.
      * @dev The position of the priority value in the array corresponds the position of the asset in the active
      *  assets array it will be applied to.
+     * @dev Emits ***AssetPrioritySet*** event.
      * @param tokenId ID of the token for which the priorities are being set
      * @param priorities Array of priorities for the assets
      */
@@ -267,6 +271,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
      * @notice Used to add an asset entry.
      * @dev If the specified ID is already used by another asset, the execution will be reverted.
      * @dev This internal function warrants custom access control to be implemented when used.
+     * @dev Emits ***AssetSet*** event.
      * @param id ID of the asset to assign to the new asset
      * @param metadataURI Metadata URI of the asset
      */
@@ -290,6 +295,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
      * @dev If the asset ID is invalid, the execution will be reverted.
      * @dev If the token already has the maximum amount of pending assets (128), the execution will be
      *  reverted.
+     * @dev Emits ***AssetAddedToToken*** event.
      * @param tokenId ID of the token to add the asset to
      * @param assetId ID of the asset to add to the token
      * @param replacesAssetWithId ID of the asset to replace from the token's list of active assets

--- a/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
@@ -270,7 +270,7 @@ interface IRMRKMultiAsset is IERC165 {
      * @dev See {setApprovalForAllForAssets}.
      * @param owner Address of the account that we are checking for whether it has granted the operator role
      * @param operator Address of the account that we are checking whether it has the operator role or not
-     * @return The boolean value indicating wehter the account we are checking has been granted the operator role
+     * @return A boolean value indicating wehter the account we are checking has been granted the operator role
      */
     function isApprovedForAllForAssets(
         address owner,

--- a/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
@@ -163,7 +163,7 @@ interface IRMRKMultiAsset is IERC165 {
      *  `getAssetMetadata(tokenId, assetId)`.
      * @dev You can safely get 10k
      * @param tokenId ID of the token to retrieve the IDs of the active assets
-     * @return uint64[] An array of active asset IDs of the given token
+     * @return An array of active asset IDs of the given token
      */
     function getActiveAssets(
         uint256 tokenId
@@ -174,7 +174,7 @@ interface IRMRKMultiAsset is IERC165 {
      * @dev Asset data is stored by reference, in order to access the data corresponding to the ID, call
      *  `getAssetMetadata(tokenId, assetId)`.
      * @param tokenId ID of the token to retrieve the IDs of the pending assets
-     * @return uint64[] An array of pending asset IDs of the given token
+     * @return An array of pending asset IDs of the given token
      */
     function getPendingAssets(
         uint256 tokenId
@@ -185,7 +185,7 @@ interface IRMRKMultiAsset is IERC165 {
      * @dev Asset priorities are a non-sequential array of uint16 values with an array size equal to active asset
      *  priorites.
      * @param tokenId ID of the token for which to retrieve the priorities of the active assets
-     * @return uint16[] An array of priorities of the active assets of the given token
+     * @return An array of priorities of the active assets of the given token
      */
     function getActiveAssetPriorities(
         uint256 tokenId
@@ -198,7 +198,7 @@ interface IRMRKMultiAsset is IERC165 {
      *  `getAssetMetadata(tokenId, assetId)`.
      * @param tokenId ID of the token to check
      * @param newAssetId ID of the pending asset which will be accepted
-     * @return uint64 ID of the asset which will be replaced
+     * @return ID of the asset which will be replaced
      */
     function getAssetReplacements(
         uint256 tokenId,
@@ -211,7 +211,7 @@ interface IRMRKMultiAsset is IERC165 {
      * @dev Can be overriden to implement enumerate, fallback or other custom logic.
      * @param tokenId ID of the token from which to retrieve the asset metadata
      * @param assetId Asset Id, must be in the active assets array
-     * @return string The metadata of the asset belonging to the specified index in the token's active assets
+     * @return The metadata of the asset belonging to the specified index in the token's active assets
      *  array
      */
     function getAssetMetadata(
@@ -242,7 +242,7 @@ interface IRMRKMultiAsset is IERC165 {
      *
      *  - `tokenId` must exist.
      * @param tokenId ID of the token for which to retrieve the approved address
-     * @return address Address of the account that is approved to manage the specified token's assets
+     * @return Address of the account that is approved to manage the specified token's assets
      */
     function getApprovedForAssets(
         uint256 tokenId
@@ -270,7 +270,7 @@ interface IRMRKMultiAsset is IERC165 {
      * @dev See {setApprovalForAllForAssets}.
      * @param owner Address of the account that we are checking for whether it has granted the operator role
      * @param operator Address of the account that we are checking whether it has the operator role or not
-     * @return bool The boolean value indicating wehter the account we are checking has been granted the operator role
+     * @return The boolean value indicating wehter the account we are checking has been granted the operator role
      */
     function isApprovedForAllForAssets(
         address owner,

--- a/contracts/RMRK/multiasset/RMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/RMRKMultiAsset.sol
@@ -67,7 +67,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      *   3. Is granted approval for the specific tokenId for asset management via the `approveForAssets` function.
      * @param user Address of the user we are checking for permission
      * @param tokenId ID of the token to query for permission for a given `user`
-     * @return bool A boolean value indicating whether the user is approved to manage the token or not
+     * @return A boolean value indicating whether the user is approved to manage the token or not
      */
     function _isApprovedForAssetsOrOwner(
         address user,
@@ -128,7 +128,9 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to retrieve the number of tokens in ``owner``'s account.
+     * @param owner Address of the account being checked
+     * @return The balance of the given account
      */
     function balanceOf(address owner) public view virtual returns (uint256) {
         if (owner == address(0)) revert ERC721AddressZeroIsNotaValidOwner();
@@ -136,7 +138,12 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to retireve the owner of the given token.
+     * @dev Requirements:
+     *
+     *  - `tokenId` must exist.
+     * @param tokenId ID of the token for which to retrieve the token for
+     * @return Address of the account owning the token
      */
     function ownerOf(uint256 tokenId) public view virtual returns (address) {
         address owner = _owners[tokenId];
@@ -145,7 +152,17 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to grant a one-time approval to manage one's token.
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * @dev The approval is cleared when the token is transferred.
+     * @dev Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     * @dev Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     * @dev Emits an {Approval} event.
+     * @param to Address receiving the approval
+     * @param tokenId ID of the token for which the approval is being granted
      */
     function approve(address to, uint256 tokenId) public virtual {
         address owner = ownerOf(tokenId);
@@ -158,7 +175,12 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to retireve the account approved to manage given token.
+     * @dev Requirements:
+     *
+     *  - `tokenId` must exist.
+     * @param tokenId ID of the token to check for approval
+     * @return Address of the account approved to manage the token
      */
     function getApproved(
         uint256 tokenId
@@ -169,14 +191,25 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to approve or remove `operator` as an operator for the caller.
+     * @dev Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     * @dev Requirements:
+     *
+     * - The `operator` cannot be the caller.
+     * @dev Emits an {ApprovalForAll} event.
+     * @param operator Address of the operator being managed
+     * @param approved A boolean value signifying whether the approval is being granted (`true`) or (`revoked`)
      */
     function setApprovalForAll(address operator, bool approved) public virtual {
         _setApprovalForAll(_msgSender(), operator, approved);
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to check if the given address is allowed to manage the tokens of the specified address.
+     * @param owner Address of the owner of the tokens
+     * @param operator Address being checked for approval
+     * @return A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)
+     *  or not (`false`)
      */
     function isApprovedForAll(
         address owner,
@@ -186,7 +219,17 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Transfers a given token from `from` to `to`.
+     * @dev Requirements:
+     *
+     *  - `from` cannot be the zero address.
+     *  - `to` cannot be the zero address.
+     *  - `tokenId` token must be owned by `from`.
+     *  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     * @dev Emits a {Transfer} event.
+     * @param from Address from which to transfer the token from
+     * @param to Address to which to transfer the token to
+     * @param tokenId ID of the token to transfer
      */
     function transferFrom(
         address from,
@@ -197,7 +240,18 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to safely transfer a given token token from `from` to `to`.
+     * @dev Requirements:
+     *
+     *  - `from` cannot be the zero address.
+     *  - `to` cannot be the zero address.
+     *  - `tokenId` token must exist and be owned by `from`.
+     *  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * @dev Emits a {Transfer} event.
+     * @param from Address to transfer the tokens from
+     * @param to Address to transfer the tokens to
+     * @param tokenId ID of the token to transfer
      */
     function safeTransferFrom(
         address from,
@@ -208,7 +262,19 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to safely transfer a given token token from `from` to `to`.
+     * @dev Requirements:
+     *
+     *  - `from` cannot be the zero address.
+     *  - `to` cannot be the zero address.
+     *  - `tokenId` token must exist and be owned by `from`.
+     *  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * @dev Emits a {Transfer} event.
+     * @param from Address to transfer the tokens from
+     * @param to Address to transfer the tokens to
+     * @param tokenId ID of the token to transfer
+     * @param data Additional data without a specified format to be sent along with the token transaction
      */
     function safeTransferFrom(
         address from,
@@ -254,7 +320,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      * @dev Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
      * @dev Tokens start existing when they are minted (`_mint`) and stop existing when they are burned (`_burn`).
      * @param tokenId ID of the token being checked
-     * @return bool The boolean value signifying whether the token exists
+     * @return The boolean value signifying whether the token exists
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return _owners[tokenId] != address(0);
@@ -267,7 +333,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      *  - `tokenId` must exist.
      * @param spender Address that is being checked for approval
      * @param tokenId ID of the token being checked
-     * @return bool The boolean value indicating whether the `spender` is approved to manage the given token
+     * @return The boolean value indicating whether the `spender` is approved to manage the given token
      */
     function _isApprovedOrOwner(
         address spender,
@@ -525,6 +591,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
 
     /**
      * @notice Used to grant an approval to an address to manage assets of a given token.
+     * @dev Emits ***ApprovalForAssets*** event.
      * @param to Address of the account to grant the approval to
      * @param tokenId ID of the token for which the approval is being given
      */

--- a/contracts/RMRK/multiasset/RMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/RMRKMultiAsset.sol
@@ -138,7 +138,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @notice Used to retireve the owner of the given token.
+     * @notice Used to retrieve the owner of the given token.
      * @dev Requirements:
      *
      *  - `tokenId` must exist.
@@ -175,7 +175,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     }
 
     /**
-     * @notice Used to retireve the account approved to manage given token.
+     * @notice Used to retrieve the account approved to manage given token.
      * @dev Requirements:
      *
      *  - `tokenId` must exist.
@@ -320,7 +320,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      * @dev Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
      * @dev Tokens start existing when they are minted (`_mint`) and stop existing when they are burned (`_burn`).
      * @param tokenId ID of the token being checked
-     * @return The boolean value signifying whether the token exists
+     * @return A boolean value signifying whether the token exists
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return _owners[tokenId] != address(0);
@@ -333,7 +333,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      *  - `tokenId` must exist.
      * @param spender Address that is being checked for approval
      * @param tokenId ID of the token being checked
-     * @return The boolean value indicating whether the `spender` is approved to manage the given token
+     * @return A boolean value indicating whether the `spender` is approved to manage the given token
      */
     function _isApprovedOrOwner(
         address spender,

--- a/contracts/RMRK/nestable/IRMRKNestable.sol
+++ b/contracts/RMRK/nestable/IRMRKNestable.sol
@@ -49,9 +49,9 @@ interface IRMRKNestable is IERC165 {
      * @notice Used to notify listeners that a new token has been added to a given token's pending children array.
      * @dev Emitted when a child NFT is added to a token's pending array.
      * @param tokenId ID of the token that received a new pending child token
+     * @param childIndex Index of the proposed child token in the parent token's pending children array
      * @param childAddress Address of the proposed child token's collection smart contract
      * @param childId ID of the child token in the child token's collection smart contract
-     * @param childIndex Index of the proposed child token in the parent token's pending children array
      */
     event ChildProposed(
         uint256 indexed tokenId,
@@ -64,9 +64,9 @@ interface IRMRKNestable is IERC165 {
      * @notice Used to notify listeners that a new child token was accepted by the parent token.
      * @dev Emitted when a parent token accepts a token from its pending array, migrating it to the active array.
      * @param tokenId ID of the token that accepted a new child token
+     * @param childIndex Index of the newly accepted child token in the parent token's active children array
      * @param childAddress Address of the child token's collection smart contract
      * @param childId ID of the child token in the child token's collection smart contract
-     * @param childIndex Index of the newly accepted child token in the parent token's active children array
      */
     event ChildAccepted(
         uint256 indexed tokenId,
@@ -86,9 +86,9 @@ interface IRMRKNestable is IERC165 {
      * @notice Used to notify listeners a child token has been transferred from parent token.
      * @dev Emitted when a token transfers a child from itself, transferring ownership to the root owner.
      * @param tokenId ID of the token that transferred a child token
+     * @param childIndex Index of a child in the array from which it is being transferred
      * @param childAddress Address of the child token's collection smart contract
      * @param childId ID of the child token in the child token's collection smart contract
-     * @param childIndex Index of a child in the array from which it is being transferred
      * @param fromPending A boolean value signifying whether the token was in the pending child tokens array (`true`) or
      *  in the active child tokens array (`false`)
      */
@@ -124,9 +124,9 @@ interface IRMRKNestable is IERC165 {
      * @dev If the immediate owner is another token, the address returned, should be the one of the parent token's
      *  collection smart contract.
      * @param tokenId ID of the token for which the RMRK owner is being retrieved
-     * @return address Address of the given token's owner
-     * @return uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account
-     * @return bool The boolean value signifying whether the owner is an NFT or not
+     * @return Address of the given token's owner
+     * @return The ID of the parent token. Should be `0` if the owner is an externally owned account
+     * @return The boolean value signifying whether the owner is an NFT or not
      */
     function directOwnerOf(
         uint256 tokenId
@@ -146,7 +146,7 @@ interface IRMRKNestable is IERC165 {
      * @dev Emits a {Transfer} event.
      * @param tokenId ID of the token to burn
      * @param maxRecursiveBurns Maximum number of tokens to recursively burn
-     * @return uint256 Number of recursively burned children
+     * @return Number of recursively burned children
      */
     function burn(
         uint256 tokenId,
@@ -199,8 +199,8 @@ interface IRMRKNestable is IERC165 {
      *
      * - `parentId` must exist
      * @param parentId ID of the parent token for which to reject all of the pending tokens.
-     * @param maxRejections Maximum number of expected children to reject, used to prevent from
-     *  rejecting children which arrive just before this operation.
+     * @param maxRejections Maximum number of expected children to reject, used to prevent from rejecting children which
+     *  arrive just before this operation.
      */
     function rejectAllChildren(
         uint256 parentId,
@@ -242,7 +242,7 @@ interface IRMRKNestable is IERC165 {
      *      contractAddress
      *  ]
      * @param parentId ID of the parent token for which to retrieve the active child tokens
-     * @return struct[] An array of Child structs containing the parent token's active child tokens
+     * @return An array of Child structs containing the parent token's active child tokens
      */
     function childrenOf(
         uint256 parentId
@@ -257,7 +257,7 @@ interface IRMRKNestable is IERC165 {
      *      contractAddress
      *  ]
      * @param parentId ID of the parent token for which to retrieve the pending child tokens
-     * @return struct[] An array of Child structs containing the parent token's pending child tokens
+     * @return An array of Child structs containing the parent token's pending child tokens
      */
     function pendingChildrenOf(
         uint256 parentId
@@ -273,7 +273,7 @@ interface IRMRKNestable is IERC165 {
      *  ]
      * @param parentId ID of the parent token for which the child is being retrieved
      * @param index Index of the child token in the parent token's active child tokens array
-     * @return struct A Child struct containing data about the specified child
+     * @return A Child struct containing data about the specified child
      */
     function childOf(
         uint256 parentId,
@@ -290,7 +290,7 @@ interface IRMRKNestable is IERC165 {
      *  ]
      * @param parentId ID of the parent token for which the pending child token is being retrieved
      * @param index Index of the child token in the parent token's pending child tokens array
-     * @return struct A Child struct containting data about the specified child
+     * @return A Child struct containting data about the specified child
      */
     function pendingChildOf(
         uint256 parentId,

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -124,7 +124,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @notice Used to retrieve the number of tokens in ``owner``'s account.
+     * @notice Used to retrieve the number of tokens in `owner`'s account.
      * @param owner Address of the account being checked
      * @return The balance of the given account
      */
@@ -697,7 +697,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @notice Used to retireve the account approved to manage given token.
+     * @notice Used to retrieve the account approved to manage given token.
      * @dev Requirements:
      *
      *  - `tokenId` must exist.
@@ -797,7 +797,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      *  - `tokenId` must exist.
      * @param spender Address that is being checked for approval
      * @param tokenId ID of the token being checked
-     * @return The boolean value indicating whether the `spender` is approved to manage the given token
+     * @return A boolean value indicating whether the `spender` is approved to manage the given token
      */
     function _isApprovedOrOwner(
         address spender,
@@ -813,7 +813,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      * @notice Used to check whether the account is approved to manage the token or its direct owner.
      * @param spender Address that is being checked for approval or direct ownership
      * @param tokenId ID of the token being checked
-     * @return The boolean value indicating whether the `spender` is approved to manage the given token or its
+     * @return A boolean value indicating whether the `spender` is approved to manage the given token or its
      *  direct owner
      */
     function _isApprovedOrDirectOwner(
@@ -847,7 +847,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      * @notice Used to check whether the given token exists.
      * @dev Tokens start existing when they are minted (`_mint`) and stop existing when they are burned (`_burn`).
      * @param tokenId ID of the token being checked
-     * @return The boolean value signifying whether the token exists
+     * @return A boolean value signifying whether the token exists
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return _RMRKOwners[tokenId].ownerAddress != address(0);

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -124,7 +124,9 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to retrieve the number of tokens in ``owner``'s account.
+     * @param owner Address of the account being checked
+     * @return The balance of the given account
      */
     function balanceOf(address owner) public view virtual returns (uint256) {
         if (owner == address(0)) revert ERC721AddressZeroIsNotaValidOwner();
@@ -136,7 +138,17 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     ////////////////////////////////////////
 
     /**
-     * @inheritdoc IERC721
+     * @notice Transfers a given token from `from` to `to`.
+     * @dev Requirements:
+     *
+     *  - `from` cannot be the zero address.
+     *  - `to` cannot be the zero address.
+     *  - `tokenId` token must be owned by `from`.
+     *  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     * @dev Emits a {Transfer} event.
+     * @param from Address from which to transfer the token from
+     * @param to Address to which to transfer the token to
+     * @param tokenId ID of the token to transfer
      */
     function transferFrom(
         address from,
@@ -147,7 +159,18 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to safely transfer a given token token from `from` to `to`.
+     * @dev Requirements:
+     *
+     *  - `from` cannot be the zero address.
+     *  - `to` cannot be the zero address.
+     *  - `tokenId` token must exist and be owned by `from`.
+     *  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * @dev Emits a {Transfer} event.
+     * @param from Address to transfer the tokens from
+     * @param to Address to transfer the tokens to
+     * @param tokenId ID of the token to transfer
      */
     function safeTransferFrom(
         address from,
@@ -158,7 +181,19 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to safely transfer a given token token from `from` to `to`.
+     * @dev Requirements:
+     *
+     *  - `from` cannot be the zero address.
+     *  - `to` cannot be the zero address.
+     *  - `tokenId` token must exist and be owned by `from`.
+     *  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     * @dev Emits a {Transfer} event.
+     * @param from Address to transfer the tokens from
+     * @param to Address to transfer the tokens to
+     * @param tokenId ID of the token to transfer
+     * @param data Additional data without a specified format to be sent along with the token transaction
      */
     function safeTransferFrom(
         address from,
@@ -412,6 +447,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      *  - `tokenId` must not exist.
      *  - `to` cannot be the zero address.
      * @dev Emits a {Transfer} event.
+     * @dev Emits a {NestTransfer} event.
      * @param to Address to mint the token to
      * @param tokenId ID of the token to mint
      * @param data Additional data with no specified format, sent in call to `to`
@@ -557,7 +593,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      * @dev Emits a {NestTransfer} event.
      * @param tokenId ID of the token to burn
      * @param maxChildrenBurns Maximum children to recursively burn
-     * @return uint256 The number of recursive burns it took to burn all of the children
+     * @return The number of recursive burns it took to burn all of the children
      */
     function _burn(
         uint256 tokenId,
@@ -638,7 +674,17 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     ////////////////////////////////////////
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to grant a one-time approval to manage one's token.
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * @dev The approval is cleared when the token is transferred.
+     * @dev Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     * @dev Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     * @dev Emits an {Approval} event.
+     * @param to Address receiving the approval
+     * @param tokenId ID of the token for which the approval is being granted
      */
     function approve(address to, uint256 tokenId) public virtual {
         address owner = ownerOf(tokenId);
@@ -651,7 +697,12 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to retireve the account approved to manage given token.
+     * @dev Requirements:
+     *
+     *  - `tokenId` must exist.
+     * @param tokenId ID of the token to check for approval
+     * @return Address of the account approved to manage the token
      */
     function getApproved(
         uint256 tokenId
@@ -662,7 +713,14 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to approve or remove `operator` as an operator for the caller.
+     * @dev Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     * @dev Requirements:
+     *
+     * - The `operator` cannot be the caller.
+     * @dev Emits an {ApprovalForAll} event.
+     * @param operator Address of the operator being managed
+     * @param approved A boolean value signifying whether the approval is being granted (`true`) or (`revoked`)
      */
     function setApprovalForAll(address operator, bool approved) public virtual {
         if (_msgSender() == operator) revert ERC721ApproveToCaller();
@@ -671,7 +729,11 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
     }
 
     /**
-     * @inheritdoc IERC721
+     * @notice Used to check if the given address is allowed to manage the tokens of the specified address.
+     * @param owner Address of the owner of the tokens
+     * @param operator Address being checked for approval
+     * @return A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)
+     *  or not (`false`)
      */
     function isApprovedForAll(
         address owner,
@@ -735,7 +797,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      *  - `tokenId` must exist.
      * @param spender Address that is being checked for approval
      * @param tokenId ID of the token being checked
-     * @return bool The boolean value indicating whether the `spender` is approved to manage the given token
+     * @return The boolean value indicating whether the `spender` is approved to manage the given token
      */
     function _isApprovedOrOwner(
         address spender,
@@ -751,7 +813,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      * @notice Used to check whether the account is approved to manage the token or its direct owner.
      * @param spender Address that is being checked for approval or direct ownership
      * @param tokenId ID of the token being checked
-     * @return bool The boolean value indicating whether the `spender` is approved to manage the given token or its
+     * @return The boolean value indicating whether the `spender` is approved to manage the given token or its
      *  direct owner
      */
     function _isApprovedOrDirectOwner(
@@ -785,7 +847,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      * @notice Used to check whether the given token exists.
      * @dev Tokens start existing when they are minted (`_mint`) and stop existing when they are burned (`_burn`).
      * @param tokenId ID of the token being checked
-     * @return bool The boolean value signifying whether the token exists
+     * @return The boolean value signifying whether the token exists
      */
     function _exists(uint256 tokenId) internal view virtual returns (bool) {
         return _RMRKOwners[tokenId].ownerAddress != address(0);
@@ -889,6 +951,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      *
      *  - `tokenId` must exist
      *  - `index` must be in range of the pending children array
+     * @dev Emits ***ChildAccepted*** event.
      * @param parentId ID of the parent token for which the child token is being accepted
      * @param childIndex Index of a child tokem in the given parent's pending children array
      * @param childAddress Address of the collection smart contract of the child token expected to be located at the
@@ -939,9 +1002,10 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      * @dev Requirements:
      *
      *  - `tokenId` must exist
+     * @dev Emits ***AllChildrenRejected*** event.
      * @param tokenId ID of the parent token for which to reject all of the pending tokens.
-     * @param maxRejections Maximum number of expected children to reject, used to prevent from
-     *  rejecting children which arrive just before this operation.
+     * @param maxRejections Maximum number of expected children to reject, used to prevent from rejecting children which
+     *  arrive just before this operation.
      */
     function _rejectAllChildren(
         uint256 tokenId,
@@ -1149,8 +1213,8 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
      * @notice Used to verify that the given child tokwn is included in an active array of a token.
      * @param childAddress Address of the given token's collection smart contract
      * @param childId ID of the child token being checked
-     * @return bool A boolean value signifying whether the given child token is included in an active child tokens array
-     *  of a token (`true`) or not (`false`)
+     * @return A boolean value signifying whether the given child token is included in an active child tokens array of a
+     *  token (`true`) or not (`false`)
      */
     function childIsInActive(
         address childAddress,

--- a/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
+++ b/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
@@ -173,7 +173,7 @@ contract RMRKNestableMultiAsset is RMRKNestable, AbstractMultiAsset {
      *   3. Is granted approval for the specific tokenId for asset management via the `approveForAssets` function.
      * @param user Address of the user we are checking for permission
      * @param tokenId ID of the token to query for permission for a given `user`
-     * @return bool A boolean value indicating whether the user is approved to manage the token or not
+     * @return A boolean value indicating whether the user is approved to manage the token or not
      */
     function _isApprovedForAssetsOrOwner(
         address user,

--- a/contracts/RMRK/utils/IERC20.sol
+++ b/contracts/RMRK/utils/IERC20.sol
@@ -12,7 +12,7 @@ interface IERC20 {
      * @param from Address of the account from which the the tokens are being transferred
      * @param to Address of the account to which the tokens are being transferred
      * @param amount Amount of tokens that are being transferred
-     * @return bool A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`)
+     * @return A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`)
      */
     function transferFrom(
         address from,
@@ -24,7 +24,7 @@ interface IERC20 {
      * @notice Used to grant permission to an account to spend the tokens of another
      * @param owner Address that owns the tokens
      * @param spender Address that is being granted the permission to spend the tokens of the `owner`
-     * @return uint256 Amount of tokens that the `spender` can manage
+     * @return Amount of tokens that the `spender` can manage
      */
     function allowance(
         address owner,

--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -138,7 +138,7 @@ contract RMRKEquipRenderUtils is
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the extended active assets for
-     * @return ExtendedEquippableActiveAsset[] An array of ExtendedEquippableActiveAssets present on the given token
+     * @return An array of ExtendedEquippableActiveAssets present on the given token
      */
     function getExtendedEquippableActiveAssets(
         address target,
@@ -199,7 +199,7 @@ contract RMRKEquipRenderUtils is
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the extended pending assets for
-     * @return ExtendedPendingAssets[] An array of ExtendedPendingAssets present on the given token
+     * @return An array of ExtendedPendingAssets present on the given token
      */
     function getExtendedPendingAssets(
         address target,
@@ -386,7 +386,8 @@ contract RMRKEquipRenderUtils is
         );
     }
 
-    /** @notice Used to get the child's assets and slot parts pairs, identifying parts the said assets can be equipped into, for all of parent's assets.
+    /** @notice Used to get the child's assets and slot parts pairs, identifying parts the said assets can be equipped
+     *  into, for all of parent's assets.
      * @dev Reverts if child token is not owned by an NFT.
      * @dev The full `EquippableData` struct looks like this:
      *  [
@@ -483,7 +484,8 @@ contract RMRKEquipRenderUtils is
     }
 
     /**
-     * @notice Used to get the child's assets and slot parts pairs, identifying parts the said assets can be equipped into, for a specific parent asset.
+     * @notice Used to get the child's assets and slot parts pairs, identifying parts the said assets can be equipped
+     *  into, for a specific parent asset.
      * @dev Reverts if child token is not owned by an NFT.
      * @dev The full `EquippableData` struct looks like this:
      *  [
@@ -501,7 +503,8 @@ contract RMRKEquipRenderUtils is
      * @param childId ID of the child token whose assets will be matched against parent's slot parts
      * @param parentAssetId ID of the target parent asset to use to equip the child
      * @return childIndex Index of the child in the parent's list of active children
-     * @return equippableData An array of `EquippableData` structs containing info about the equippable child assets and their corresponding slot parts
+     * @return equippableData An array of `EquippableData` structs containing info about the equippable child assets and
+     *  their corresponding slot parts
      */
     function getEquippableSlotsFromParent(
         address targetChild,
@@ -549,9 +552,11 @@ contract RMRKEquipRenderUtils is
      *  ]
      * @param childAddress Address of the smart contract of the given token
      * @param childId ID of the child token whose assets will be matched against parent's slot parts
-     * @param parentAddress Address of the parent smart contract
+     * @param parentAddress Address of the parent token's smart contract
+     * @param parentId ID of the parent token
      * @param parentAssetId ID of the target parent asset to use to equip the child
-     * @return equippableData An array of `EquippableData` structs containing info about the equippable child assets and their corresponding slot parts
+     * @return equippableData An array of `EquippableData` structs containing info about the equippable child assets and
+     *  their corresponding slot parts
      */
     function _getEquippableSlotsFromParent(
         address childAddress,
@@ -600,8 +605,9 @@ contract RMRKEquipRenderUtils is
             equippableData[i].parentCatalogAddress = parentAssetCatalog;
             equippableData[i].childAssetMetadata = IRMRKMultiAsset(childAddress)
                 .getAssetMetadata(childId, tempAssetsWithSlots[i].childAssetId);
-            equippableData[i].parentAssetMetadata = IRMRKMultiAsset(parentAddress)
-                .getAssetMetadata(parentId, parentAssetId);
+            equippableData[i].parentAssetMetadata = IRMRKMultiAsset(
+                parentAddress
+            ).getAssetMetadata(parentId, parentAssetId);
             unchecked {
                 ++i;
             }
@@ -612,7 +618,8 @@ contract RMRKEquipRenderUtils is
      * @notice Used to retrieve the equippable data of the specified token's asset with the highest priority.
      * @param target Address of the collection smart contract of the specified token
      * @param tokenId ID of the token for which to retrieve the equippable data of the asset with the highest priority
-     * @return topAsset `ExtendedEquippableActiveAsset` struct with the equippable data containing the asset with the highest priority
+     * @return topAsset `ExtendedEquippableActiveAsset` struct with the equippable data containing the asset with the
+     *  highest priority
      */
     function getTopAssetAndEquippableDataForToken(
         address target,
@@ -653,14 +660,18 @@ contract RMRKEquipRenderUtils is
      *       isEquipped
      *       partMetadata
      *  ]
-     * @dev The size of the returning array is equal to the total of available parent slots, even if there's not a match for each one.
-     * @dev The valid matches are located at the beginning of the array, and the rest of the slots are filled with empty structs. Use totalMatches to know how many valid matches there are.
-     * @dev Some data from the returned structs is not filled due to stack to deep limitation: parentAssetId, parentCatalogAddress, isEquipped and partMetadata.
+     * @dev The size of the returning array is equal to the total of available parent slots, even if there's not a match
+     *  for each one.
+     * @dev The valid matches are located at the beginning of the array, and the rest of the slots are filled with empty
+     *  structs. Use totalMatches to know how many valid matches there are.
+     * @dev Some data from the returned structs is not filled due to stack to deep limitation: parentAssetId,
+     *  parentCatalogAddress, isEquipped and partMetadata.
      * @param childContract IRMRKEquippable instance of the child smart contract
      * @param childId ID of the child token whose assets will be matched against parent's slot parts
      * @param parentSlotPartIds Array of slot part IDs of the parent token's asset
      * @param parentAddress Address of the parent smart contract
-     * @return allAssetsWithSlots An array of `EquippableData` structs containing info about the equippable child assets and their corresponding slot parts
+     * @return allAssetsWithSlots An array of `EquippableData` structs containing info about the equippable child assets
+     *  and their corresponding slot parts
      * @return totalMatches Total of valid matches found
      */
     function _matchAllAssetsWithSlots(

--- a/contracts/RMRK/utils/RMRKMintingUtils.sol
+++ b/contracts/RMRK/utils/RMRKMintingUtils.sol
@@ -46,7 +46,7 @@ contract RMRKMintingUtils is OwnableLock {
 
     /**
      * @notice Used to retrieve the total supply of the tokens in a collection.
-     * @return uint256 The number of tokens in a collection
+     * @return The number of tokens in a collection
      */
     function totalSupply() public view returns (uint256) {
         return _totalSupply;
@@ -54,7 +54,7 @@ contract RMRKMintingUtils is OwnableLock {
 
     /**
      * @notice Used to retrieve the maximum supply of the collection.
-     * @return uint256 The maximum supply of tokens in the collection
+     * @return The maximum supply of tokens in the collection
      */
     function maxSupply() public view returns (uint256) {
         return _maxSupply;
@@ -62,7 +62,7 @@ contract RMRKMintingUtils is OwnableLock {
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return uint256 The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
      */
     function pricePerMint() public view returns (uint256) {
         return _pricePerMint;

--- a/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
@@ -48,7 +48,7 @@ contract RMRKMultiAssetRenderUtils {
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the active assets for
-     * @return struct[] An array of ActiveAssets present on the given token
+     * @return An array of ActiveAssets present on the given token
      */
     function getExtendedActiveAssets(
         address target,
@@ -92,7 +92,7 @@ contract RMRKMultiAssetRenderUtils {
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the pending assets for
-     * @return struct[] An array of PendingAssets present on the given token
+     * @return An array of PendingAssets present on the given token
      */
     function getPendingAssets(
         address target,
@@ -136,7 +136,7 @@ contract RMRKMultiAssetRenderUtils {
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the specified assets for
      * @param assetIds[] An array of asset IDs for which to retrieve the metadata URIs
-     * @return string[] An array of metadata URIs belonging to specified assets
+     * @return An array of metadata URIs belonging to specified assets
      */
     function getAssetsById(
         address target,
@@ -159,7 +159,7 @@ contract RMRKMultiAssetRenderUtils {
      * @notice Used to retrieve the metadata URI of the specified token's asset with the highest priority.
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token for which to retrieve the metadata URI of the asset with the highest priority
-     * @return string The metadata URI of the asset with the highest priority
+     * @return The metadata URI of the asset with the highest priority
      */
     function getTopAssetMetaForToken(
         address target,

--- a/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
@@ -12,7 +12,7 @@ import "../library/RMRKErrors.sol";
  */
 contract RMRKNestableRenderUtils {
     /**
-     * @notice Used to retrieve the given child's index in its paren's child tokens array.
+     * @notice Used to retrieve the given child's index in its parent's child tokens array.
      * @param parentAddress Address of the parent token's collection smart contract
      * @param parentId ID of the parent token
      * @param childAddress Address of the child token's colection smart contract

--- a/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
@@ -11,6 +11,14 @@ import "../library/RMRKErrors.sol";
  * @notice Smart contract of the RMRK Nestable render utils module.
  */
 contract RMRKNestableRenderUtils {
+    /**
+     * @notice Used to retrieve the given child's index in its paren's child tokens array.
+     * @param parentAddress Address of the parent token's collection smart contract
+     * @param parentId ID of the parent token
+     * @param childAddress Address of the child token's colection smart contract
+     * @param childId ID of the child token
+     * @return The index of the child token in the parent token's child tokens array
+     */
     function getChildIndex(
         address parentAddress,
         uint256 parentId,

--- a/contracts/RMRK/utils/RMRKRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKRenderUtils.sol
@@ -61,7 +61,8 @@ contract RMRKRenderUtils {
 
     /**
      * @notice Used to get a list of existing token IDs in the range between `pageStart` and `pageSize`.
-     * @dev It is not optimized to avoid checking IDs out of max supply nor total supply, since this is not meant to be used during transaction execution; it is only meant to be used as a getter.
+     * @dev It is not optimized to avoid checking IDs out of max supply nor total supply, since this is not meant to be
+     *  used during transaction execution; it is only meant to be used as a getter.
      * @dev The resulting array might be smaller than the given `pageSize` since no-existent IDs are not included.
      * @param target Address of the collection smart contract of the given token
      * @param pageStart The first ID to check

--- a/contracts/RMRK/utils/RMRKTokenURI.sol
+++ b/contracts/RMRK/utils/RMRKTokenURI.sol
@@ -28,7 +28,7 @@ contract RMRKTokenURI {
     /**
      * @notice Used to retrieve the metadata URI of a token.
      * @param tokenId ID of the token to retrieve the metadata URI for
-     * @return string Metadata URI of the specified token
+     * @return Metadata URI of the specified token
      */
     function tokenURI(
         uint256 tokenId

--- a/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
@@ -31,8 +31,8 @@ abstract contract RMRKAbstractEquippableImpl is
     /**
      * @notice Used to calculate the token IDs of tokens to be minted.
      * @param numToMint Amount of tokens to be minted
-     * @return uint256 The ID of the first token to be minted in the current minting cycle
-     * @return uint256 The ID of the last token to be minted in the current minting cycle
+     * @return The ID of the first token to be minted in the current minting cycle
+     * @return The ID of the last token to be minted in the current minting cycle
      */
     function _preMint(uint256 numToMint) internal returns (uint256, uint256) {
         if (numToMint == uint256(0)) revert RMRKMintZero();
@@ -86,7 +86,7 @@ abstract contract RMRKAbstractEquippableImpl is
      * @param catalogAddress Address of the `Catalog` smart contract this asset belongs to
      * @param metadataURI Metadata URI of the asset
      * @param partIds An array of IDs of fixed and slot parts to be included in the asset
-     * @return uint256 The total number of assets after this asset has been added
+     * @return The total number of assets after this asset has been added
      */
     function addEquippableAssetEntry(
         uint64 equippableGroupId,
@@ -111,6 +111,7 @@ abstract contract RMRKAbstractEquippableImpl is
      * @notice Used to add a asset entry.
      * @dev The ID of the asset is automatically assigned to be the next available asset ID.
      * @param metadataURI Metadata URI of the asset
+     * @return ID of the newly added asset
      */
     function addAssetEntry(
         string memory metadataURI
@@ -143,7 +144,7 @@ abstract contract RMRKAbstractEquippableImpl is
 
     /**
      * @notice Used to retrieve the total number of assets.
-     * @return uint256 The total number of assets
+     * @return The total number of assets
      */
     function totalAssets() public view virtual returns (uint256) {
         return _totalAssets;

--- a/contracts/implementations/abstracts/RMRKAbstractMultiAssetImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractMultiAssetImpl.sol
@@ -30,7 +30,6 @@ abstract contract RMRKAbstractMultiAssetImpl is
      * @notice Used to destroy the specified token.
      * @dev The approval is cleared when the token is burned.
      * @dev Requirements:
-     *
      *  - `tokenId` must exist.
      * @param tokenId ID of the token to burn
      */
@@ -65,6 +64,7 @@ abstract contract RMRKAbstractMultiAssetImpl is
      * @notice Used to add a asset entry.
      * @dev The ID of the asset is automatically assigned to be the next available asset ID.
      * @param metadataURI Metadata URI of the asset
+     * @return ID of the newly added asset
      */
     function addAssetEntry(
         string memory metadataURI
@@ -78,7 +78,7 @@ abstract contract RMRKAbstractMultiAssetImpl is
 
     /**
      * @notice Used to retrieve the total number of assets.
-     * @return uint256 The total number of assets
+     * @return The total number of assets
      */
     function totalAssets() public view virtual returns (uint256) {
         return _totalAssets;

--- a/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
@@ -27,8 +27,8 @@ abstract contract RMRKAbstractNestableImpl is
     /**
      * @notice Used to calculate the token IDs of tokens to be minted.
      * @param numToMint Amount of tokens to be minted
-     * @return uint256 The ID of the first token to be minted in the current minting cycle
-     * @return uint256 The ID of the last token to be minted in the current minting cycle
+     * @return The ID of the first token to be minted in the current minting cycle
+     * @return The ID of the last token to be minted in the current minting cycle
      */
     function _preMint(
         uint256 numToMint

--- a/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
@@ -29,8 +29,8 @@ abstract contract RMRKAbstractNestableMultiAssetImpl is
     /**
      * @notice Used to calculate the token IDs of tokens to be minted.
      * @param numToMint Amount of tokens to be minted
-     * @return uint256 The ID of the first token to be minted in the current minting cycle
-     * @return uint256 The ID of the last token to be minted in the current minting cycle
+     * @return The ID of the first token to be minted in the current minting cycle
+     * @return The ID of the last token to be minted in the current minting cycle
      */
     function _preMint(uint256 numToMint) internal returns (uint256, uint256) {
         if (numToMint == uint256(0)) revert RMRKMintZero();
@@ -81,6 +81,7 @@ abstract contract RMRKAbstractNestableMultiAssetImpl is
      * @notice Used to add a asset entry.
      * @dev The ID of the asset is automatically assigned to be the next available asset ID.
      * @param metadataURI Metadata URI of the asset
+     * @return ID of the newly added asset
      */
     function addAssetEntry(
         string memory metadataURI
@@ -94,7 +95,7 @@ abstract contract RMRKAbstractNestableMultiAssetImpl is
 
     /**
      * @notice Used to retrieve the total number of assets.
-     * @return uint256 The total number of assets
+     * @return The total number of assets
      */
     function totalAssets() public view returns (uint256) {
         return _totalAssets;

--- a/contracts/implementations/erc20Pay/IRMRKErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/IRMRKErc20Pay.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.8.16;
 interface IRMRKErc20Pay {
     /**
      * @notice Used to retrieve the address of the ERC20 token this smart contract supports.
-     * @return address Address of the ERC20 token's smart contract
+     * @return Address of the ERC20 token's smart contract
      */
     function erc20TokenAddress() external view returns (address);
 }

--- a/contracts/implementations/erc20Pay/RMRKErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKErc20Pay.sol
@@ -41,7 +41,7 @@ abstract contract RMRKErc20Pay is IRMRKErc20Pay {
 
     /**
      * @notice Used to retrieve the address of the ERC20 token this smart contract supports.
-     * @return address Address of the ERC20 token's smart contract
+     * @return Address of the ERC20 token's smart contract
      */
     function erc20TokenAddress() public view virtual returns (address) {
         return _erc20TokenAddress;

--- a/contracts/implementations/nativeTokenPay/RMRKExternalEquipImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKExternalEquipImpl.sol
@@ -57,7 +57,7 @@ contract RMRKExternalEquipImpl is OwnableLock, RMRKExternalEquip {
      * @param catalogAddress Address of the `Catalog` smart contract this asset belongs to
      * @param metadataURI Metadata URI of the asset
      * @param partIds An array of IDs of fixed and slot parts to be included in the asset
-     * @return uint256 The total number of assets after this asset has been added
+     * @return The total number of assets after this asset has been added
      */
     function addEquippableAssetEntry(
         uint64 equippableGroupId,
@@ -82,6 +82,7 @@ contract RMRKExternalEquipImpl is OwnableLock, RMRKExternalEquip {
      * @notice Used to add a asset entry.
      * @dev The ID of the asset is automatically assigned to be the next available asset ID.
      * @param metadataURI Metadata URI of the asset
+     * @return ID of the newly added asset
      */
     function addAssetEntry(
         string memory metadataURI
@@ -114,7 +115,7 @@ contract RMRKExternalEquipImpl is OwnableLock, RMRKExternalEquip {
 
     /**
      * @notice Used to retrieve the total number of assets.
-     * @return uint256 The total number of assets
+     * @return The total number of assets
      */
     function totalAssets() public view virtual returns (uint256) {
         return _totalAssets;

--- a/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
@@ -110,8 +110,8 @@ contract RMRKNestableExternalEquipImpl is
     /**
      * @notice Used to calculate the token IDs of tokens to be minted.
      * @param numToMint Amount of tokens to be minted
-     * @return uint256 The ID of the first token to be minted in the current minting cycle
-     * @return uint256 The ID of the last token to be minted in the current minting cycle
+     * @return The ID of the first token to be minted in the current minting cycle
+     * @return The ID of the last token to be minted in the current minting cycle
      */
     function _preMint(uint256 numToMint) private returns (uint256, uint256) {
         if (numToMint == uint256(0)) revert RMRKMintZero();

--- a/docs/RMRK/access/Ownable.md
+++ b/docs/RMRK/access/Ownable.md
@@ -40,7 +40,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 

--- a/docs/RMRK/access/OwnableLock.md
+++ b/docs/RMRK/access/OwnableLock.md
@@ -25,7 +25,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### isContributor
 
@@ -57,7 +57,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 

--- a/docs/RMRK/catalog/IRMRKCatalog.md
+++ b/docs/RMRK/catalog/IRMRKCatalog.md
@@ -31,7 +31,7 @@ Used to check whether the given address is allowed to equip the desired `Part`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
+| _0 | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
 
 ### checkIsEquippableToAll
 
@@ -53,7 +53,7 @@ Used to check if the part is equippable by all addresses.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the part with `partId` can be equipped by any address or not |
+| _0 | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
 
 ### getMetadataURI
 
@@ -70,7 +70,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Case metadata URI |
+| _0 | string | Case metadata URI |
 
 ### getPart
 
@@ -92,7 +92,7 @@ Used to retrieve a `Part` with id `partId`
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part | struct The `Part` struct associated with given `partId` |
+| _0 | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
 
 ### getParts
 
@@ -114,7 +114,7 @@ Used to retrieve multiple parts at the same time.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part[] | struct An array of `Part` structs associated with given `partIds` |
+| _0 | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
 
 ### getType
 
@@ -131,7 +131,7 @@ Used to return the `itemType` of the associated Catalog
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string `itemType` of the associated Catalog |
+| _0 | string | `itemType` of the associated Catalog |
 
 ### supportsInterface
 

--- a/docs/RMRK/catalog/RMRKCatalog.md
+++ b/docs/RMRK/catalog/RMRKCatalog.md
@@ -31,7 +31,7 @@ Used to check whether the given address is allowed to equip the desired `Part`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
+| _0 | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
 
 ### checkIsEquippableToAll
 
@@ -53,7 +53,7 @@ Used to check if the part is equippable by all addresses.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the part with `partId` can be equipped by any address or not |
+| _0 | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
 
 ### getMetadataURI
 
@@ -70,7 +70,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Case metadata URI |
+| _0 | string | Case metadata URI |
 
 ### getPart
 
@@ -92,7 +92,7 @@ Used to retrieve a `Part` with id `partId`
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part | struct The `Part` struct associated with given `partId` |
+| _0 | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
 
 ### getParts
 
@@ -114,7 +114,7 @@ Used to retrieve multiple parts at the same time.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part[] | struct An array of `Part` structs associated with given `partIds` |
+| _0 | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
 
 ### getType
 
@@ -131,7 +131,7 @@ Used to return the `itemType` of the associated Catalog
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string `itemType` of the associated Catalog |
+| _0 | string | `itemType` of the associated Catalog |
 
 ### supportsInterface
 

--- a/docs/RMRK/core/IRMRKCore.md
+++ b/docs/RMRK/core/IRMRKCore.md
@@ -25,7 +25,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### symbol
 
@@ -42,7 +42,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 
 

--- a/docs/RMRK/core/RMRKCore.md
+++ b/docs/RMRK/core/RMRKCore.md
@@ -25,7 +25,7 @@ Version of the @rmrk-team/evm-contracts package
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | undefined |
+| _0 | string | Version identifier of the smart contract |
 
 ### name
 
@@ -42,7 +42,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### symbol
 
@@ -59,7 +59,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 
 

--- a/docs/RMRK/equippable/IRMRKEquippable.md
+++ b/docs/RMRK/equippable/IRMRKEquippable.md
@@ -68,7 +68,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -106,7 +106,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -128,7 +128,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -150,7 +150,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetAndEquippableData
 
@@ -199,7 +199,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -222,7 +222,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -246,7 +246,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
@@ -268,7 +268,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -291,7 +291,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -315,7 +315,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/equippable/IRMRKExternalEquip.md
+++ b/docs/RMRK/equippable/IRMRKExternalEquip.md
@@ -68,7 +68,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -106,7 +106,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -128,7 +128,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -150,7 +150,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetAndEquippableData
 
@@ -199,7 +199,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -222,7 +222,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -246,7 +246,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getNestableAddress
 
@@ -263,7 +263,7 @@ Returns the Equippable contract&#39;s corresponding nestable address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the Nestable module of the external equip composite |
+| _0 | address | Address of the Nestable module of the external equip composite |
 
 ### getPendingAssets
 
@@ -285,7 +285,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -308,7 +308,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -332,7 +332,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/equippable/IRMRKNestableExternalEquip.md
+++ b/docs/RMRK/equippable/IRMRKNestableExternalEquip.md
@@ -25,7 +25,7 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the `Equippable` smart contract |
+| _0 | address | Address of the `Equippable` smart contract |
 
 ### isApprovedOrOwner
 
@@ -48,7 +48,7 @@ Used to verify that the specified address is either the owner of the given token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value indicating whether the specified address is the owner of the given token or approved  to manage it |
+| _0 | bool | A boolean value indicating whether the specified address is the owner of the given token or approved to  manage it |
 
 ### supportsInterface
 

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -88,16 +88,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -122,21 +122,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -175,7 +175,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -200,7 +200,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -223,7 +223,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -246,7 +246,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -268,7 +268,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -290,9 +290,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -330,7 +330,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -352,7 +352,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -360,21 +360,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -396,7 +396,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -445,7 +445,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -468,7 +468,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -492,7 +492,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
@@ -514,7 +514,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -522,22 +522,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -560,7 +560,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -584,7 +584,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### name
 
@@ -601,7 +601,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -666,7 +666,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -688,7 +688,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -722,7 +722,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -740,7 +740,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### safeTransferFrom
 
@@ -748,17 +748,17 @@ Rejects a asset from the pending array of given token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -766,18 +766,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -785,16 +785,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -867,7 +867,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferChild
 
@@ -898,17 +898,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### unequip
 

--- a/docs/RMRK/equippable/RMRKExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKExternalEquip.md
@@ -68,7 +68,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -106,7 +106,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -128,7 +128,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -150,7 +150,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -199,7 +199,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -222,7 +222,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -246,7 +246,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getNestableAddress
 
@@ -263,7 +263,7 @@ Returns the Equippable contract&#39;s corresponding nestable address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the Nestable module of the external equip composite |
+| _0 | address | Address of the Nestable module of the external equip composite |
 
 ### getPendingAssets
 
@@ -285,7 +285,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -308,7 +308,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -349,7 +349,7 @@ Used to reject all pending assets of a given token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | ID of the token for which we are clearing the pending array. |
-| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from  rejecting assets which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from rejecting assets which  arrive just before this operation. |
 
 ### rejectAsset
 

--- a/docs/RMRK/equippable/RMRKNestableExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKNestableExternalEquip.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -230,9 +230,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -240,21 +240,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getEquippableAddress
 
@@ -271,7 +271,7 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the `Equippable` smart contract |
+| _0 | address | Address of the `Equippable` smart contract |
 
 ### isApprovedForAll
 
@@ -279,22 +279,22 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedOrOwner
 
@@ -317,7 +317,7 @@ Used to verify that the specified address is either the owner of the given token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value indicating whether the specified address is the owner of the given token or approved  to manage it |
+| _0 | bool | A boolean value indicating whether the specified address is the owner of the given token or approved to  manage it |
 
 ### name
 
@@ -334,7 +334,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -399,7 +399,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -421,7 +421,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -438,7 +438,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeTransferFrom
 
@@ -446,17 +446,17 @@ Used to reject all pending children of a given parent token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -464,18 +464,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -483,16 +483,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -531,7 +531,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferChild
 
@@ -562,17 +562,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/RMRK/extension/RMRKRoyalties.md
+++ b/docs/RMRK/extension/RMRKRoyalties.md
@@ -25,7 +25,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -42,7 +42,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### royaltyInfo
 

--- a/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
@@ -86,7 +86,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childOf
 
@@ -109,7 +109,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -131,7 +131,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -153,9 +153,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### nestTransferFrom
 
@@ -220,7 +220,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -242,7 +242,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -259,7 +259,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | parentId | uint256 | ID of the parent token for which to reject all of the pending tokens. |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -88,16 +88,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -105,21 +105,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -158,7 +158,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -181,7 +181,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -204,7 +204,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -226,7 +226,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -248,9 +248,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -258,21 +258,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
@@ -280,22 +280,22 @@ function getApproved(uint256 tokenId) external view returns (address)
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### name
 
@@ -312,7 +312,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -377,7 +377,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -399,7 +399,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -416,7 +416,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeTransferFrom
 
@@ -424,17 +424,17 @@ Used to reject all pending children of a given parent token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -442,18 +442,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -461,16 +461,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -509,7 +509,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferChild
 
@@ -562,17 +562,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
+++ b/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -230,9 +230,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -240,21 +240,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
@@ -262,22 +262,22 @@ function getApproved(uint256 tokenId) external view returns (address)
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### name
 
@@ -294,7 +294,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -359,7 +359,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -381,7 +381,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### reclaimChild
 
@@ -416,7 +416,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeTransferFrom
 
@@ -424,17 +424,17 @@ Used to reject all pending children of a given parent token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -442,18 +442,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -461,16 +461,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -509,7 +509,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferChild
 
@@ -540,17 +540,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulbound.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulbound.md
@@ -64,7 +64,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### supportsInterface
 
@@ -103,7 +103,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.md
@@ -81,7 +81,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### supportsInterface
 
@@ -120,7 +120,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.md
@@ -103,7 +103,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### supportsInterface
 
@@ -142,7 +142,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundPerToken.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundPerToken.md
@@ -64,7 +64,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### supportsInterface
 
@@ -103,7 +103,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 
 

--- a/docs/RMRK/extension/tokenProperties/IRMRKTokenProperties.md
+++ b/docs/RMRK/extension/tokenProperties/IRMRKTokenProperties.md
@@ -31,7 +31,7 @@ Used to retrieve the address type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address The value of the address property |
+| _0 | address | The value of the address property |
 
 ### getBoolTokenProperty
 
@@ -54,7 +54,7 @@ Used to retrieve the bool type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The value of the bool property |
+| _0 | bool | The value of the bool property |
 
 ### getBytesTokenProperty
 
@@ -77,7 +77,7 @@ Used to retrieve the bytes type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes | bytes The value of the bytes property |
+| _0 | bytes | The value of the bytes property |
 
 ### getStringTokenProperty
 
@@ -100,7 +100,7 @@ Used to retrieve the string type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The value of the string property |
+| _0 | string | The value of the string property |
 
 ### getUintTokenProperty
 
@@ -123,7 +123,7 @@ Used to retrieve the uint type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The value of the uint property |
+| _0 | uint256 | The value of the uint property |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/tokenProperties/RMRKTokenProperties.md
+++ b/docs/RMRK/extension/tokenProperties/RMRKTokenProperties.md
@@ -31,7 +31,7 @@ Used to retrieve the address type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address The value of the address property |
+| _0 | address | The value of the address property |
 
 ### getBoolTokenProperty
 
@@ -54,7 +54,7 @@ Used to retrieve the bool type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The value of the bool property |
+| _0 | bool | The value of the bool property |
 
 ### getBytesTokenProperty
 
@@ -77,7 +77,7 @@ Used to retrieve the bytes type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes | bytes The value of the bytes property |
+| _0 | bytes | The value of the bytes property |
 
 ### getStringTokenProperty
 
@@ -100,7 +100,7 @@ Used to retrieve the string type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The value of the string property |
+| _0 | string | The value of the string property |
 
 ### getUintTokenProperty
 
@@ -123,7 +123,7 @@ Used to retrieve the uint type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The value of the uint property |
+| _0 | uint256 | The value of the uint property |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/typedMultiAsset/IRMRKTypedMultiAsset.md
+++ b/docs/RMRK/extension/typedMultiAsset/IRMRKTypedMultiAsset.md
@@ -30,7 +30,7 @@ Used to get the type of the asset.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The type of the asset |
+| _0 | string | The type of the asset |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.md
+++ b/docs/RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.md
@@ -30,7 +30,7 @@ Used to get the type of the asset.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The type of the asset |
+| _0 | string | The type of the asset |
 
 ### supportsInterface
 

--- a/docs/RMRK/multiasset/AbstractMultiAsset.md
+++ b/docs/RMRK/multiasset/AbstractMultiAsset.md
@@ -65,7 +65,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -87,7 +87,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -109,7 +109,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -132,7 +132,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -155,7 +155,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -177,7 +177,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -200,7 +200,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/multiasset/IRMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/IRMRKMultiAsset.md
@@ -65,7 +65,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -87,7 +87,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -109,7 +109,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -132,7 +132,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -155,7 +155,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -177,7 +177,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -200,7 +200,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/multiasset/RMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/RMRKMultiAsset.md
@@ -51,16 +51,16 @@ Accepts an asset at from the pending array of given token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -85,21 +85,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### getActiveAssetPriorities
 
@@ -121,7 +121,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -143,7 +143,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -151,21 +151,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -187,7 +187,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -210,7 +210,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -233,7 +233,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -255,7 +255,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -263,22 +263,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -301,7 +301,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### name
 
@@ -318,7 +318,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### ownerOf
 
@@ -326,21 +326,21 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -383,17 +383,17 @@ Rejects an asset from the pending array of given token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -401,18 +401,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -420,16 +420,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -502,7 +502,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferFrom
 
@@ -510,17 +510,17 @@ Used to retrieve the collection symbol.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/RMRK/nestable/IRMRKNestable.md
+++ b/docs/RMRK/nestable/IRMRKNestable.md
@@ -68,7 +68,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childOf
 
@@ -91,7 +91,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -113,7 +113,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -135,9 +135,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### nestTransferFrom
 
@@ -202,7 +202,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -224,7 +224,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -241,7 +241,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | parentId | uint256 | ID of the parent token for which to reject all of the pending tokens. |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### supportsInterface
 

--- a/docs/RMRK/nestable/RMRKNestable.md
+++ b/docs/RMRK/nestable/RMRKNestable.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -230,9 +230,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -240,21 +240,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
@@ -262,22 +262,22 @@ function getApproved(uint256 tokenId) external view returns (address)
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### name
 
@@ -294,7 +294,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -359,7 +359,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -381,7 +381,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -398,7 +398,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeTransferFrom
 
@@ -406,17 +406,17 @@ Used to reject all pending children of a given parent token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -424,18 +424,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -443,16 +443,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -491,7 +491,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferChild
 
@@ -522,17 +522,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -88,16 +88,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -122,21 +122,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -175,7 +175,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -198,7 +198,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -221,7 +221,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -243,7 +243,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -265,9 +265,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
@@ -289,7 +289,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -311,7 +311,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -319,21 +319,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -355,7 +355,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -378,7 +378,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -401,7 +401,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -423,7 +423,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -431,22 +431,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -469,7 +469,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### name
 
@@ -486,7 +486,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -551,7 +551,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -573,7 +573,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -607,7 +607,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -633,17 +633,17 @@ Rejects an asset from the pending array of given token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -651,18 +651,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -670,16 +670,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -752,7 +752,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferChild
 
@@ -783,17 +783,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/RMRK/utils/IERC20.md
+++ b/docs/RMRK/utils/IERC20.md
@@ -31,7 +31,7 @@ Used to grant permission to an account to spend the tokens of another
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Amount of tokens that the `spender` can manage |
+| _0 | uint256 | Amount of tokens that the `spender` can manage |
 
 ### transferFrom
 
@@ -55,7 +55,7 @@ Used to transfer tokens from one address to another.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`) |
 
 
 

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -63,7 +63,7 @@ Used to compose the given equippables.
 function getAllEquippableSlotsFromParent(address targetChild, uint256 childId, bool onlyEquipped) external view returns (uint256 childIndex, struct RMRKEquipRenderUtils.EquippableData[] equippableData)
 ```
 
-Used to get the child&#39;s assets and slot parts pairs, identifying parts the said assets can be equipped into, for all of parent&#39;s assets.
+Used to get the child&#39;s assets and slot parts pairs, identifying parts the said assets can be equipped  into, for all of parent&#39;s assets.
 
 *Reverts if child token is not owned by an NFT.The full `EquippableData` struct looks like this:  [      slotPartId,      childAssetId,      parentAssetId,      priority,      parentCatalogAddress,      isEquipped,      partMetadata  ]*
 
@@ -128,7 +128,7 @@ Used to retrieve the metadata URI of specified assets in the specified token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string[] | string[] An array of metadata URIs belonging to specified assets |
+| _0 | string[] | An array of metadata URIs belonging to specified assets |
 
 ### getChildIndex
 
@@ -136,7 +136,7 @@ Used to retrieve the metadata URI of specified assets in the specified token.
 function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
 ```
 
-
+Used to retrieve the given child&#39;s index in its paren&#39;s child tokens array.
 
 
 
@@ -144,16 +144,16 @@ function getChildIndex(address parentAddress, uint256 parentId, address childAdd
 
 | Name | Type | Description |
 |---|---|---|
-| parentAddress | address | undefined |
-| parentId | uint256 | undefined |
-| childAddress | address | undefined |
-| childId | uint256 | undefined |
+| parentAddress | address | Address of the parent token&#39;s collection smart contract |
+| parentId | uint256 | ID of the parent token |
+| childAddress | address | Address of the child token&#39;s colection smart contract |
+| childId | uint256 | ID of the child token |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The index of the child token in the parent token&#39;s child tokens array |
 
 ### getEquippableSlotsFromParent
 
@@ -161,7 +161,7 @@ function getChildIndex(address parentAddress, uint256 parentId, address childAdd
 function getEquippableSlotsFromParent(address targetChild, uint256 childId, uint64 parentAssetId) external view returns (uint256 childIndex, struct RMRKEquipRenderUtils.EquippableData[] equippableData)
 ```
 
-Used to get the child&#39;s assets and slot parts pairs, identifying parts the said assets can be equipped into, for a specific parent asset.
+Used to get the child&#39;s assets and slot parts pairs, identifying parts the said assets can be equipped  into, for a specific parent asset.
 
 *Reverts if child token is not owned by an NFT.The full `EquippableData` struct looks like this:  [      slotPartId,      childAssetId,      parentAssetId,      priority,      parentCatalogAddress,      isEquipped,      partMetadata,      childAssetMetadata,      parentAssetMetadata  ]*
 
@@ -178,7 +178,7 @@ Used to get the child&#39;s assets and slot parts pairs, identifying parts the s
 | Name | Type | Description |
 |---|---|---|
 | childIndex | uint256 | Index of the child in the parent&#39;s list of active children |
-| equippableData | RMRKEquipRenderUtils.EquippableData[] | An array of `EquippableData` structs containing info about the equippable child assets and their corresponding slot parts |
+| equippableData | RMRKEquipRenderUtils.EquippableData[] | An array of `EquippableData` structs containing info about the equippable child assets and  their corresponding slot parts |
 
 ### getEquipped
 
@@ -227,7 +227,7 @@ Used to get the active assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | struct[] An array of ActiveAssets present on the given token |
+| _0 | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | An array of ActiveAssets present on the given token |
 
 ### getExtendedEquippableActiveAssets
 
@@ -250,7 +250,7 @@ Used to get extended active assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKEquipRenderUtils.ExtendedEquippableActiveAsset[] | ExtendedEquippableActiveAsset[] An array of ExtendedEquippableActiveAssets present on the given token |
+| _0 | RMRKEquipRenderUtils.ExtendedEquippableActiveAsset[] | An array of ExtendedEquippableActiveAssets present on the given token |
 
 ### getExtendedNft
 
@@ -296,7 +296,7 @@ Used to get the extended pending assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKEquipRenderUtils.ExtendedPendingAsset[] | ExtendedPendingAssets[] An array of ExtendedPendingAssets present on the given token |
+| _0 | RMRKEquipRenderUtils.ExtendedPendingAsset[] | An array of ExtendedPendingAssets present on the given token |
 
 ### getPaginatedMintedIds
 
@@ -306,7 +306,7 @@ function getPaginatedMintedIds(address target, uint256 pageStart, uint256 pageSi
 
 Used to get a list of existing token IDs in the range between `pageStart` and `pageSize`.
 
-*It is not optimized to avoid checking IDs out of max supply nor total supply, since this is not meant to be used during transaction execution; it is only meant to be used as a getter.The resulting array might be smaller than the given `pageSize` since no-existent IDs are not included.*
+*It is not optimized to avoid checking IDs out of max supply nor total supply, since this is not meant to be  used during transaction execution; it is only meant to be used as a getter.The resulting array might be smaller than the given `pageSize` since no-existent IDs are not included.*
 
 #### Parameters
 
@@ -367,7 +367,7 @@ Used to get the pending assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.PendingAsset[] | struct[] An array of PendingAssets present on the given token |
+| _0 | RMRKMultiAssetRenderUtils.PendingAsset[] | An array of PendingAssets present on the given token |
 
 ### getSlotParts
 
@@ -439,7 +439,7 @@ Used to retrieve the equippable data of the specified token&#39;s asset with the
 
 | Name | Type | Description |
 |---|---|---|
-| topAsset | RMRKEquipRenderUtils.ExtendedEquippableActiveAsset | `ExtendedEquippableActiveAsset` struct with the equippable data containing the asset with the highest priority |
+| topAsset | RMRKEquipRenderUtils.ExtendedEquippableActiveAsset | `ExtendedEquippableActiveAsset` struct with the equippable data containing the asset with the  highest priority |
 
 ### getTopAssetMetaForToken
 
@@ -462,7 +462,7 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the asset with the highest priority |
+| _0 | string | The metadata URI of the asset with the highest priority |
 
 ### isAssetEquipped
 

--- a/docs/RMRK/utils/RMRKMintingUtils.md
+++ b/docs/RMRK/utils/RMRKMintingUtils.md
@@ -25,7 +25,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### isContributor
 
@@ -57,7 +57,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -81,7 +81,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### owner
 
@@ -115,7 +115,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### renounceOwnership
 
@@ -154,7 +154,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferOwnership
 

--- a/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
+++ b/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
@@ -56,7 +56,7 @@ Used to retrieve the metadata URI of specified assets in the specified token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string[] | string[] An array of metadata URIs belonging to specified assets |
+| _0 | string[] | An array of metadata URIs belonging to specified assets |
 
 ### getExtendedActiveAssets
 
@@ -79,7 +79,7 @@ Used to get the active assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | struct[] An array of ActiveAssets present on the given token |
+| _0 | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | An array of ActiveAssets present on the given token |
 
 ### getPendingAssets
 
@@ -102,7 +102,7 @@ Used to get the pending assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.PendingAsset[] | struct[] An array of PendingAssets present on the given token |
+| _0 | RMRKMultiAssetRenderUtils.PendingAsset[] | An array of PendingAssets present on the given token |
 
 ### getTopAsset
 
@@ -150,7 +150,7 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the asset with the highest priority |
+| _0 | string | The metadata URI of the asset with the highest priority |
 
 
 

--- a/docs/RMRK/utils/RMRKNestableRenderUtils.md
+++ b/docs/RMRK/utils/RMRKNestableRenderUtils.md
@@ -35,7 +35,7 @@ Check if the child is owned by the expected parent.
 function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
 ```
 
-
+Used to retrieve the given child&#39;s index in its paren&#39;s child tokens array.
 
 
 
@@ -43,16 +43,16 @@ function getChildIndex(address parentAddress, uint256 parentId, address childAdd
 
 | Name | Type | Description |
 |---|---|---|
-| parentAddress | address | undefined |
-| parentId | uint256 | undefined |
-| childAddress | address | undefined |
-| childId | uint256 | undefined |
+| parentAddress | address | Address of the parent token&#39;s collection smart contract |
+| parentId | uint256 | ID of the parent token |
+| childAddress | address | Address of the child token&#39;s colection smart contract |
+| childId | uint256 | ID of the child token |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The index of the child token in the parent token&#39;s child tokens array |
 
 ### getParent
 

--- a/docs/RMRK/utils/RMRKRenderUtils.md
+++ b/docs/RMRK/utils/RMRKRenderUtils.md
@@ -41,7 +41,7 @@ function getPaginatedMintedIds(address target, uint256 pageStart, uint256 pageSi
 
 Used to get a list of existing token IDs in the range between `pageStart` and `pageSize`.
 
-*It is not optimized to avoid checking IDs out of max supply nor total supply, since this is not meant to be used during transaction execution; it is only meant to be used as a getter.The resulting array might be smaller than the given `pageSize` since no-existent IDs are not included.*
+*It is not optimized to avoid checking IDs out of max supply nor total supply, since this is not meant to be  used during transaction execution; it is only meant to be used as a getter.The resulting array might be smaller than the given `pageSize` since no-existent IDs are not included.*
 
 #### Parameters
 

--- a/docs/RMRK/utils/RMRKTokenURI.md
+++ b/docs/RMRK/utils/RMRKTokenURI.md
@@ -30,7 +30,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 
 

--- a/docs/implementations/RMRKCatalogImpl.md
+++ b/docs/implementations/RMRKCatalogImpl.md
@@ -80,7 +80,7 @@ Used to check whether the given address is allowed to equip the desired `Part`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
+| _0 | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
 
 ### checkIsEquippableToAll
 
@@ -102,7 +102,7 @@ Used to check if the part is equippable by all addresses.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the part with `partId` can be equipped by any address or not |
+| _0 | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
 
 ### getLock
 
@@ -119,7 +119,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getMetadataURI
 
@@ -136,7 +136,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Case metadata URI |
+| _0 | string | Case metadata URI |
 
 ### getPart
 
@@ -158,7 +158,7 @@ Used to retrieve a `Part` with id `partId`
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part | struct The `Part` struct associated with given `partId` |
+| _0 | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
 
 ### getParts
 
@@ -180,7 +180,7 @@ Used to retrieve multiple parts at the same time.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part[] | struct An array of `Part` structs associated with given `partIds` |
+| _0 | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
 
 ### getType
 
@@ -197,7 +197,7 @@ Used to return the `itemType` of the associated Catalog
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string `itemType` of the associated Catalog |
+| _0 | string | `itemType` of the associated Catalog |
 
 ### isContributor
 
@@ -229,7 +229,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -145,7 +145,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets after this asset has been added |
+| _0 | uint256 | The total number of assets after this asset has been added |
 
 ### approve
 
@@ -153,16 +153,16 @@ Used to add an equippable asset entry.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -187,21 +187,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -240,7 +240,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -288,7 +288,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -311,7 +311,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -333,7 +333,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -372,9 +372,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -412,7 +412,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -434,7 +434,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -442,21 +442,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -478,7 +478,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -527,7 +527,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -550,7 +550,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -574,7 +574,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getLock
 
@@ -591,7 +591,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -613,7 +613,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -630,7 +630,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -647,7 +647,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -655,22 +655,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -693,7 +693,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -717,7 +717,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
@@ -749,7 +749,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -773,7 +773,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
@@ -790,7 +790,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -872,7 +872,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -894,7 +894,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -911,7 +911,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -945,7 +945,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -963,7 +963,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### renounceOwnership
 
@@ -1006,17 +1006,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -1024,18 +1024,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -1043,16 +1043,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1154,7 +1154,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1176,7 +1176,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1193,7 +1193,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1210,7 +1210,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1241,17 +1241,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -65,7 +65,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -91,16 +91,16 @@ Used to add an asset to a token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -125,21 +125,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -194,7 +194,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -216,7 +216,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -224,21 +224,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -260,7 +260,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -283,7 +283,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -306,7 +306,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -323,7 +323,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -345,7 +345,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -362,7 +362,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -379,7 +379,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -387,22 +387,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -425,7 +425,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -457,7 +457,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -481,7 +481,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
@@ -498,7 +498,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### owner
 
@@ -523,21 +523,21 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### pricePerMint
 
@@ -554,7 +554,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -632,17 +632,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -650,18 +650,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -669,16 +669,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -762,7 +762,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -784,7 +784,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -801,7 +801,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -818,7 +818,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 
@@ -826,17 +826,17 @@ Used to retrieve the total supply of the tokens in a collection.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -247,9 +247,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -257,21 +257,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getLock
 
@@ -288,7 +288,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getRoyaltyPercentage
 
@@ -305,7 +305,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -322,7 +322,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -330,22 +330,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
@@ -377,7 +377,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -401,7 +401,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
@@ -418,7 +418,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -500,7 +500,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -522,7 +522,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -539,7 +539,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -556,7 +556,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### renounceOwnership
 
@@ -599,17 +599,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -617,18 +617,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -636,16 +636,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setLock
 
@@ -695,7 +695,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -717,7 +717,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalSupply
 
@@ -734,7 +734,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -765,17 +765,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -128,16 +128,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -162,21 +162,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -215,7 +215,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -238,7 +238,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -261,7 +261,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -283,7 +283,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -322,9 +322,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
@@ -346,7 +346,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -368,7 +368,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -376,21 +376,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -412,7 +412,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -435,7 +435,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -458,7 +458,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -475,7 +475,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -497,7 +497,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -514,7 +514,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -531,7 +531,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -539,22 +539,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -577,7 +577,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -609,7 +609,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -633,7 +633,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
@@ -650,7 +650,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -732,7 +732,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -754,7 +754,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -771,7 +771,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -805,7 +805,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -866,17 +866,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -884,18 +884,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -903,16 +903,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -996,7 +996,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1018,7 +1018,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1035,7 +1035,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1052,7 +1052,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1083,17 +1083,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/erc20Pay/IRMRKErc20Pay.md
+++ b/docs/implementations/erc20Pay/IRMRKErc20Pay.md
@@ -25,7 +25,7 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the ERC20 token&#39;s smart contract |
+| _0 | address | Address of the ERC20 token&#39;s smart contract |
 
 
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -145,7 +145,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets after this asset has been added |
+| _0 | uint256 | The total number of assets after this asset has been added |
 
 ### approve
 
@@ -153,16 +153,16 @@ Used to add an equippable asset entry.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -187,21 +187,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -240,7 +240,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -288,7 +288,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -311,7 +311,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -333,7 +333,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -372,9 +372,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -407,7 +407,7 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the ERC20 token&#39;s smart contract |
+| _0 | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
@@ -429,7 +429,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -451,7 +451,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -459,21 +459,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -495,7 +495,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -544,7 +544,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -567,7 +567,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -591,7 +591,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getLock
 
@@ -608,7 +608,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -630,7 +630,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -647,7 +647,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -664,7 +664,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -672,22 +672,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -710,7 +710,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -734,7 +734,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
@@ -766,7 +766,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -790,7 +790,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -824,7 +824,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -924,7 +924,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -946,7 +946,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -963,7 +963,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -997,7 +997,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -1015,7 +1015,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### renounceOwnership
 
@@ -1058,17 +1058,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -1076,18 +1076,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -1095,16 +1095,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1206,7 +1206,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1228,7 +1228,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1245,7 +1245,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1262,7 +1262,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1293,17 +1293,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/erc20Pay/RMRKErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKErc20Pay.md
@@ -25,7 +25,7 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the ERC20 token&#39;s smart contract |
+| _0 | address | Address of the ERC20 token&#39;s smart contract |
 
 
 

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -65,7 +65,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -91,16 +91,16 @@ Used to add an asset to a token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -125,21 +125,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -189,7 +189,7 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the ERC20 token&#39;s smart contract |
+| _0 | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
@@ -211,7 +211,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -233,7 +233,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -241,21 +241,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -277,7 +277,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -300,7 +300,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -323,7 +323,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -340,7 +340,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -362,7 +362,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -379,7 +379,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -396,7 +396,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -404,22 +404,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -442,7 +442,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -474,7 +474,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -498,7 +498,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -532,7 +532,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### owner
 
@@ -557,21 +557,21 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### pricePerMint
 
@@ -588,7 +588,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -666,17 +666,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -684,18 +684,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -703,16 +703,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -796,7 +796,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -818,7 +818,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -835,7 +835,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -852,7 +852,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 
@@ -860,17 +860,17 @@ Used to retrieve the total supply of the tokens in a collection.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -247,9 +247,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 
@@ -266,7 +266,7 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the ERC20 token&#39;s smart contract |
+| _0 | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getApproved
 
@@ -274,21 +274,21 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getLock
 
@@ -305,7 +305,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getRoyaltyPercentage
 
@@ -322,7 +322,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -339,7 +339,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -347,22 +347,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
@@ -394,7 +394,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -418,7 +418,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -452,7 +452,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -552,7 +552,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -574,7 +574,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -591,7 +591,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -608,7 +608,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### renounceOwnership
 
@@ -651,17 +651,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -669,18 +669,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -688,16 +688,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setLock
 
@@ -747,7 +747,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -769,7 +769,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalSupply
 
@@ -786,7 +786,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -817,17 +817,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -128,16 +128,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -162,21 +162,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -215,7 +215,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -238,7 +238,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -261,7 +261,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -283,7 +283,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -322,9 +322,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 
@@ -341,7 +341,7 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the ERC20 token&#39;s smart contract |
+| _0 | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
@@ -363,7 +363,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -385,7 +385,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -393,21 +393,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -429,7 +429,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -452,7 +452,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -475,7 +475,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -492,7 +492,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -514,7 +514,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -531,7 +531,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -548,7 +548,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -556,22 +556,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -594,7 +594,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -626,7 +626,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -650,7 +650,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -684,7 +684,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -784,7 +784,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -806,7 +806,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -823,7 +823,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -857,7 +857,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -918,17 +918,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -936,18 +936,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -955,16 +955,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1048,7 +1048,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1070,7 +1070,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1087,7 +1087,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1104,7 +1104,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1135,17 +1135,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -145,7 +145,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets after this asset has been added |
+| _0 | uint256 | The total number of assets after this asset has been added |
 
 ### approve
 
@@ -153,16 +153,16 @@ Used to add an equippable asset entry.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -187,21 +187,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -240,7 +240,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -288,7 +288,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -311,7 +311,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -333,7 +333,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -372,9 +372,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -412,7 +412,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -434,7 +434,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -442,21 +442,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -478,7 +478,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -527,7 +527,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -550,7 +550,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -574,7 +574,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getLock
 
@@ -591,7 +591,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -613,7 +613,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -630,7 +630,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -647,7 +647,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -655,22 +655,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -693,7 +693,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -717,7 +717,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
@@ -749,7 +749,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -773,7 +773,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -807,7 +807,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -907,7 +907,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -929,7 +929,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -946,7 +946,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -980,7 +980,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -998,7 +998,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### renounceOwnership
 
@@ -1041,17 +1041,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -1059,18 +1059,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -1078,16 +1078,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1189,7 +1189,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1211,7 +1211,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1228,7 +1228,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1245,7 +1245,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1276,17 +1276,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
@@ -48,7 +48,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -91,7 +91,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets after this asset has been added |
+| _0 | uint256 | The total number of assets after this asset has been added |
 
 ### approveForAssets
 
@@ -133,7 +133,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -171,7 +171,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -193,7 +193,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -215,7 +215,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -264,7 +264,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -287,7 +287,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -311,7 +311,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getLock
 
@@ -328,7 +328,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getNestableAddress
 
@@ -345,7 +345,7 @@ Returns the Equippable contract&#39;s corresponding nestable address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the Nestable module of the external equip composite |
+| _0 | address | Address of the Nestable module of the external equip composite |
 
 ### getPendingAssets
 
@@ -367,7 +367,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -390,7 +390,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -446,7 +446,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -487,7 +487,7 @@ Used to reject all pending assets of a given token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | ID of the token for which we are clearing the pending array. |
-| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from  rejecting assets which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from rejecting assets which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -634,7 +634,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### transferOwnership
 

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -65,7 +65,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -91,16 +91,16 @@ Used to add an asset to a token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -125,21 +125,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -194,7 +194,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -216,7 +216,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -224,21 +224,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -260,7 +260,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -283,7 +283,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -306,7 +306,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -323,7 +323,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -345,7 +345,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -362,7 +362,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -379,7 +379,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -387,22 +387,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -425,7 +425,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -457,7 +457,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -481,7 +481,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -515,7 +515,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### owner
 
@@ -540,21 +540,21 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### pricePerMint
 
@@ -571,7 +571,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -649,17 +649,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -667,18 +667,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -686,16 +686,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -779,7 +779,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -801,7 +801,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -818,7 +818,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -835,7 +835,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 
@@ -843,17 +843,17 @@ Used to retrieve the total supply of the tokens in a collection.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -247,9 +247,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -257,21 +257,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getEquippableAddress
 
@@ -288,7 +288,7 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the `Equippable` smart contract |
+| _0 | address | Address of the `Equippable` smart contract |
 
 ### getLock
 
@@ -305,7 +305,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getRoyaltyPercentage
 
@@ -322,7 +322,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -339,7 +339,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -347,22 +347,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedOrOwner
 
@@ -385,7 +385,7 @@ Used to verify that the specified address is either the owner of the given token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value indicating whether the specified address is the owner of the given token or approved  to manage it |
+| _0 | bool | A boolean value indicating whether the specified address is the owner of the given token or approved to  manage it |
 
 ### isContributor
 
@@ -417,7 +417,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -441,7 +441,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -475,7 +475,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -575,7 +575,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -597,7 +597,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -614,7 +614,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -631,7 +631,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### renounceOwnership
 
@@ -674,17 +674,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -692,18 +692,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -711,16 +711,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setEquippableAddress
 
@@ -786,7 +786,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -808,7 +808,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalSupply
 
@@ -825,7 +825,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -856,17 +856,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -247,9 +247,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -257,21 +257,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getLock
 
@@ -288,7 +288,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getRoyaltyPercentage
 
@@ -305,7 +305,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -322,7 +322,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -330,22 +330,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
@@ -377,7 +377,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -401,7 +401,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -435,7 +435,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -535,7 +535,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -557,7 +557,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -574,7 +574,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -591,7 +591,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### renounceOwnership
 
@@ -634,17 +634,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -652,18 +652,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -671,16 +671,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setLock
 
@@ -730,7 +730,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -752,7 +752,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalSupply
 
@@ -769,7 +769,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -800,17 +800,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -128,16 +128,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -162,21 +162,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -215,7 +215,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -238,7 +238,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -261,7 +261,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -283,7 +283,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -322,9 +322,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
@@ -346,7 +346,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -368,7 +368,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -376,21 +376,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -412,7 +412,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -435,7 +435,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -458,7 +458,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -475,7 +475,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -497,7 +497,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -514,7 +514,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -531,7 +531,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -539,22 +539,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -577,7 +577,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -609,7 +609,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -633,7 +633,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -667,7 +667,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -767,7 +767,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -789,7 +789,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -806,7 +806,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -840,7 +840,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -901,17 +901,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -919,18 +919,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -938,16 +938,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1031,7 +1031,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1053,7 +1053,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1070,7 +1070,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1087,7 +1087,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1118,17 +1118,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -145,7 +145,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets after this asset has been added |
+| _0 | uint256 | The total number of assets after this asset has been added |
 
 ### approve
 
@@ -153,16 +153,16 @@ Used to add an equippable asset entry.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -187,21 +187,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -240,7 +240,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -288,7 +288,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -311,7 +311,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -333,7 +333,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -372,9 +372,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -412,7 +412,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -434,7 +434,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -442,21 +442,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -478,7 +478,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -527,7 +527,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -550,7 +550,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -574,7 +574,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getLock
 
@@ -591,7 +591,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -613,7 +613,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -630,7 +630,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -647,7 +647,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -655,22 +655,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -693,7 +693,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -717,7 +717,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
@@ -749,7 +749,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -773,7 +773,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -807,7 +807,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -907,7 +907,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -929,7 +929,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -946,7 +946,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -980,7 +980,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -998,7 +998,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### renounceOwnership
 
@@ -1041,17 +1041,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -1059,18 +1059,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -1078,16 +1078,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1189,7 +1189,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1211,7 +1211,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1228,7 +1228,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1245,7 +1245,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1276,17 +1276,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -65,7 +65,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -91,16 +91,16 @@ Used to add an asset to a token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -125,21 +125,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -194,7 +194,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -216,7 +216,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -224,21 +224,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -260,7 +260,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -283,7 +283,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -306,7 +306,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -323,7 +323,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -345,7 +345,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -362,7 +362,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -379,7 +379,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -387,22 +387,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -425,7 +425,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -457,7 +457,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -481,7 +481,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -515,7 +515,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### owner
 
@@ -540,21 +540,21 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### pricePerMint
 
@@ -571,7 +571,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -649,17 +649,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -667,18 +667,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -686,16 +686,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -779,7 +779,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -801,7 +801,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -818,7 +818,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -835,7 +835,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 
@@ -843,17 +843,17 @@ Used to retrieve the total supply of the tokens in a collection.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -247,9 +247,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -257,21 +257,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getLock
 
@@ -288,7 +288,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getRoyaltyPercentage
 
@@ -305,7 +305,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -322,7 +322,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -330,22 +330,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
@@ -377,7 +377,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -401,7 +401,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -435,7 +435,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -535,7 +535,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -557,7 +557,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -574,7 +574,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -591,7 +591,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### renounceOwnership
 
@@ -634,17 +634,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -652,18 +652,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -671,16 +671,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setLock
 
@@ -730,7 +730,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -752,7 +752,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalSupply
 
@@ -769,7 +769,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -800,17 +800,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -84,7 +84,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -128,16 +128,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -162,21 +162,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -215,7 +215,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -238,7 +238,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -261,7 +261,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -283,7 +283,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### collectionMetadata
 
@@ -322,9 +322,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
@@ -346,7 +346,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -368,7 +368,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -376,21 +376,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -412,7 +412,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -435,7 +435,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -458,7 +458,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLock
 
@@ -475,7 +475,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getPendingAssets
 
@@ -497,7 +497,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
@@ -514,7 +514,7 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The royalty percentage expressed in the basis points |
+| _0 | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
@@ -531,7 +531,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the recipient of royalties |
+| _0 | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
@@ -539,22 +539,22 @@ Used to retrieve the recipient of royalties.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -577,7 +577,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -609,7 +609,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -633,7 +633,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
@@ -667,7 +667,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -767,7 +767,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -789,7 +789,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
@@ -806,7 +806,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -840,7 +840,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -901,17 +901,17 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -919,18 +919,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -938,16 +938,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1031,7 +1031,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### tokenURI
 
@@ -1053,7 +1053,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Metadata URI of the specified token |
+| _0 | string | Metadata URI of the specified token |
 
 ### totalAssets
 
@@ -1070,7 +1070,7 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The total number of assets |
+| _0 | uint256 | The total number of assets |
 
 ### totalSupply
 
@@ -1087,7 +1087,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferChild
 
@@ -1118,17 +1118,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/mocks/MintingUtilsMock.md
+++ b/docs/mocks/MintingUtilsMock.md
@@ -25,7 +25,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### isContributor
 
@@ -57,7 +57,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -81,7 +81,7 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The maximum supply of tokens in the collection |
+| _0 | uint256 | The maximum supply of tokens in the collection |
 
 ### mockMint
 
@@ -131,7 +131,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The price per mint of a single token expressed in the lowest denomination of a native currency |
+| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### renounceOwnership
 
@@ -198,7 +198,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The number of tokens in a collection |
+| _0 | uint256 | The number of tokens in a collection |
 
 ### transferOwnership
 

--- a/docs/mocks/OwnableLockMock.md
+++ b/docs/mocks/OwnableLockMock.md
@@ -25,7 +25,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the smart contract has been locked |
+| _0 | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### isContributor
 
@@ -57,7 +57,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 

--- a/docs/mocks/RMRKCatalogMock.md
+++ b/docs/mocks/RMRKCatalogMock.md
@@ -80,7 +80,7 @@ Used to check whether the given address is allowed to equip the desired `Part`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
+| _0 | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
 
 ### checkIsEquippableToAll
 
@@ -102,7 +102,7 @@ Used to check if the part is equippable by all addresses.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The status indicating whether the part with `partId` can be equipped by any address or not |
+| _0 | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
 
 ### getMetadataURI
 
@@ -119,7 +119,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Case metadata URI |
+| _0 | string | Case metadata URI |
 
 ### getPart
 
@@ -141,7 +141,7 @@ Used to retrieve a `Part` with id `partId`
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part | struct The `Part` struct associated with given `partId` |
+| _0 | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
 
 ### getParts
 
@@ -163,7 +163,7 @@ Used to retrieve multiple parts at the same time.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part[] | struct An array of `Part` structs associated with given `partIds` |
+| _0 | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
 
 ### getType
 
@@ -180,7 +180,7 @@ Used to return the `itemType` of the associated Catalog
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string `itemType` of the associated Catalog |
+| _0 | string | `itemType` of the associated Catalog |
 
 ### resetEquippableAddresses
 

--- a/docs/mocks/RMRKEquippableMock.md
+++ b/docs/mocks/RMRKEquippableMock.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -126,16 +126,16 @@ function addEquippableAssetEntry(uint64 id, uint64 equippableGroupId, address ca
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -160,21 +160,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -213,7 +213,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -238,7 +238,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -261,7 +261,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -284,7 +284,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -306,7 +306,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -328,9 +328,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -368,7 +368,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -390,7 +390,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -398,21 +398,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -434,7 +434,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -483,7 +483,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -506,7 +506,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -530,7 +530,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
@@ -552,7 +552,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -560,22 +560,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -598,7 +598,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -622,7 +622,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### mint
 
@@ -656,7 +656,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -757,7 +757,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -779,7 +779,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -813,7 +813,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -831,7 +831,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### safeTransferFrom
 
@@ -839,17 +839,17 @@ Rejects a asset from the pending array of given token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -857,18 +857,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -876,16 +876,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -976,7 +976,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -1024,17 +1024,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### unequip
 

--- a/docs/mocks/RMRKExternalEquipMock.md
+++ b/docs/mocks/RMRKExternalEquipMock.md
@@ -106,7 +106,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -144,7 +144,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -166,7 +166,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -188,7 +188,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -237,7 +237,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -260,7 +260,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -284,7 +284,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getNestableAddress
 
@@ -301,7 +301,7 @@ Returns the Equippable contract&#39;s corresponding nestable address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the Nestable module of the external equip composite |
+| _0 | address | Address of the Nestable module of the external equip composite |
 
 ### getPendingAssets
 
@@ -323,7 +323,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -346,7 +346,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -387,7 +387,7 @@ Used to reject all pending assets of a given token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | ID of the token for which we are clearing the pending array. |
-| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from  rejecting assets which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from rejecting assets which  arrive just before this operation. |
 
 ### rejectAsset
 

--- a/docs/mocks/RMRKMultiAssetMock.md
+++ b/docs/mocks/RMRKMultiAssetMock.md
@@ -86,16 +86,16 @@ function addAssetToToken(uint256 tokenId, uint64 assetId, uint64 replacesAssetWi
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -120,21 +120,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -172,7 +172,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -194,7 +194,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -202,21 +202,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -238,7 +238,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -261,7 +261,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -284,7 +284,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -306,7 +306,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -314,22 +314,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -352,7 +352,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 
@@ -386,7 +386,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### ownerOf
 
@@ -394,21 +394,21 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -486,17 +486,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -504,18 +504,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -523,16 +523,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -605,7 +605,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -630,17 +630,17 @@ function transfer(address to, uint256 tokenId) external nonpayable
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/RMRKNestableAutoIndexMock.md
+++ b/docs/mocks/RMRKNestableAutoIndexMock.md
@@ -88,16 +88,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -105,21 +105,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -158,7 +158,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -181,7 +181,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -204,7 +204,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -226,7 +226,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -248,9 +248,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -258,21 +258,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
@@ -280,22 +280,22 @@ function getApproved(uint256 tokenId) external view returns (address)
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### mint
 
@@ -329,7 +329,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -412,7 +412,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -434,7 +434,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -451,7 +451,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeTransferFrom
 
@@ -459,17 +459,17 @@ Used to reject all pending children of a given parent token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -477,18 +477,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -496,16 +496,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -544,7 +544,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferChild
 
@@ -597,17 +597,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/RMRKNestableExternalEquipMock.md
+++ b/docs/mocks/RMRKNestableExternalEquipMock.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -230,9 +230,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -240,21 +240,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getEquippableAddress
 
@@ -271,7 +271,7 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the `Equippable` smart contract |
+| _0 | address | Address of the `Equippable` smart contract |
 
 ### isApprovedForAll
 
@@ -279,22 +279,22 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedOrOwner
 
@@ -317,7 +317,7 @@ Used to verify that the specified address is either the owner of the given token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value indicating whether the specified address is the owner of the given token or approved  to manage it |
+| _0 | bool | A boolean value indicating whether the specified address is the owner of the given token or approved to  manage it |
 
 ### mint
 
@@ -351,7 +351,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -452,7 +452,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -474,7 +474,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -491,7 +491,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeMint
 
@@ -534,17 +534,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -552,18 +552,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -571,16 +571,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setEquippableAddress
 
@@ -635,7 +635,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -683,17 +683,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/RMRKNestableMock.md
+++ b/docs/mocks/RMRKNestableMock.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### balancePerNftOf
 
@@ -163,7 +163,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -186,7 +186,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -209,7 +209,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -231,7 +231,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -253,9 +253,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -263,21 +263,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
@@ -285,22 +285,22 @@ function getApproved(uint256 tokenId) external view returns (address)
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### mint
 
@@ -334,7 +334,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -435,7 +435,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -457,7 +457,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -474,7 +474,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeMint
 
@@ -517,17 +517,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -535,18 +535,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -554,16 +554,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -602,7 +602,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -650,17 +650,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/RMRKNestableMultiAssetMock.md
+++ b/docs/mocks/RMRKNestableMultiAssetMock.md
@@ -123,16 +123,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -157,21 +157,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -210,7 +210,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -233,7 +233,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -256,7 +256,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -278,7 +278,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -300,9 +300,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
@@ -324,7 +324,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -346,7 +346,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -354,21 +354,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -390,7 +390,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -413,7 +413,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -436,7 +436,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -458,7 +458,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -466,22 +466,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -504,7 +504,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 
@@ -538,7 +538,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -639,7 +639,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -661,7 +661,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -695,7 +695,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -756,17 +756,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -774,18 +774,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -793,16 +793,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -875,7 +875,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -923,17 +923,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
+++ b/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### balancePerNftOf
 
@@ -163,7 +163,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -186,7 +186,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -209,7 +209,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -231,7 +231,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -253,9 +253,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -263,21 +263,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
@@ -285,22 +285,22 @@ function getApproved(uint256 tokenId) external view returns (address)
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### mint
 
@@ -334,7 +334,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -435,7 +435,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -457,7 +457,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### reclaimChild
 
@@ -492,7 +492,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeMint
 
@@ -535,17 +535,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -553,18 +553,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -572,16 +572,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -620,7 +620,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -668,17 +668,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
+++ b/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
@@ -51,16 +51,16 @@ Accepts an asset at from the pending array of given token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -85,21 +85,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### emote
 
@@ -139,7 +139,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -161,7 +161,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -169,21 +169,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -205,7 +205,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -228,7 +228,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -251,7 +251,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEmoteCount
 
@@ -296,7 +296,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -304,22 +304,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -342,7 +342,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 
@@ -376,7 +376,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### ownerOf
 
@@ -384,21 +384,21 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -441,17 +441,17 @@ Rejects an asset from the pending array of given token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -459,18 +459,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -478,16 +478,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -560,7 +560,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transferFrom
 
@@ -568,17 +568,17 @@ Used to retrieve the collection symbol.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
@@ -86,16 +86,16 @@ function addAssetToToken(uint256 tokenId, uint64 assetId, uint64 replacesAssetWi
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -120,21 +120,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -172,7 +172,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -194,7 +194,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -202,21 +202,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -238,7 +238,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -261,7 +261,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -284,7 +284,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getLastBlockToTransfer
 
@@ -323,7 +323,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -331,22 +331,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -369,7 +369,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 
@@ -425,7 +425,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### ownerOf
 
@@ -433,21 +433,21 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -525,17 +525,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -543,18 +543,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -562,16 +562,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -644,7 +644,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -669,17 +669,17 @@ function transfer(address to, uint256 tokenId) external nonpayable
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
@@ -86,16 +86,16 @@ function addAssetToToken(uint256 tokenId, uint64 assetId, uint64 replacesAssetWi
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -120,21 +120,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -172,7 +172,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -194,7 +194,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -202,21 +202,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -238,7 +238,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -261,7 +261,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -284,7 +284,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getMaxNumberOfTransfers
 
@@ -323,7 +323,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getTransfersPerToken
 
@@ -353,22 +353,22 @@ Gets the current number of transfer the specified token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -391,7 +391,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 
@@ -447,7 +447,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### ownerOf
 
@@ -455,21 +455,21 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -547,17 +547,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -565,18 +565,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -584,16 +584,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -666,7 +666,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -691,17 +691,17 @@ function transfer(address to, uint256 tokenId) external nonpayable
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -126,16 +126,16 @@ function addEquippableAssetEntry(uint64 id, uint64 equippableGroupId, address ca
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -160,21 +160,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -213,7 +213,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -238,7 +238,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -261,7 +261,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -284,7 +284,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -306,7 +306,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -328,9 +328,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -368,7 +368,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -390,7 +390,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -398,21 +398,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -434,7 +434,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -483,7 +483,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -506,7 +506,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -530,7 +530,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
@@ -552,7 +552,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -560,22 +560,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -598,7 +598,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -622,7 +622,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isSoulbound
 
@@ -678,7 +678,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -779,7 +779,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -801,7 +801,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -835,7 +835,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -853,7 +853,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### safeTransferFrom
 
@@ -861,17 +861,17 @@ Rejects a asset from the pending array of given token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -879,18 +879,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -898,16 +898,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -998,7 +998,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -1046,17 +1046,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### unequip
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
@@ -86,16 +86,16 @@ function addAssetToToken(uint256 tokenId, uint64 assetId, uint64 replacesAssetWi
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -120,21 +120,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -172,7 +172,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -194,7 +194,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -202,21 +202,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -238,7 +238,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -261,7 +261,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -284,7 +284,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -306,7 +306,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -314,22 +314,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -352,7 +352,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 
@@ -408,7 +408,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### ownerOf
 
@@ -416,21 +416,21 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -508,17 +508,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -526,18 +526,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -545,16 +545,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -627,7 +627,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -652,17 +652,17 @@ function transfer(address to, uint256 tokenId) external nonpayable
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -140,7 +140,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -163,7 +163,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -186,7 +186,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -208,7 +208,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -230,9 +230,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -240,21 +240,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getEquippableAddress
 
@@ -271,7 +271,7 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the `Equippable` smart contract |
+| _0 | address | Address of the `Equippable` smart contract |
 
 ### isApprovedForAll
 
@@ -279,22 +279,22 @@ Used to retrieve the `Equippable` smart contract&#39;s address.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedOrOwner
 
@@ -317,7 +317,7 @@ Used to verify that the specified address is either the owner of the given token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value indicating whether the specified address is the owner of the given token or approved  to manage it |
+| _0 | bool | A boolean value indicating whether the specified address is the owner of the given token or approved to  manage it |
 
 ### isSoulbound
 
@@ -373,7 +373,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -474,7 +474,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -496,7 +496,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -513,7 +513,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeMint
 
@@ -556,17 +556,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -574,18 +574,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -593,16 +593,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setEquippableAddress
 
@@ -657,7 +657,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -705,17 +705,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
@@ -70,16 +70,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### balanceOf
 
@@ -87,21 +87,21 @@ function approve(address to, uint256 tokenId) external nonpayable
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### balancePerNftOf
 
@@ -163,7 +163,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -186,7 +186,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -209,7 +209,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -231,7 +231,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -253,9 +253,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
@@ -263,21 +263,21 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
@@ -285,22 +285,22 @@ function getApproved(uint256 tokenId) external view returns (address)
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isSoulbound
 
@@ -356,7 +356,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -457,7 +457,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -479,7 +479,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -496,7 +496,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### safeMint
 
@@ -539,17 +539,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -557,18 +557,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -576,16 +576,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### supportsInterface
 
@@ -624,7 +624,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -672,17 +672,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
@@ -123,16 +123,16 @@ Used to add a child token to a given parent token.
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -157,21 +157,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -210,7 +210,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -233,7 +233,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -256,7 +256,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -278,7 +278,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -300,9 +300,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
@@ -324,7 +324,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -346,7 +346,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -354,21 +354,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -390,7 +390,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -413,7 +413,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -436,7 +436,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -458,7 +458,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -466,22 +466,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -504,7 +504,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 
@@ -560,7 +560,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -661,7 +661,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -683,7 +683,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -717,7 +717,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -778,17 +778,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -796,18 +796,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -815,16 +815,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -897,7 +897,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -945,17 +945,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
@@ -86,16 +86,16 @@ function addAssetToToken(uint256 tokenId, uint64 assetId, uint64 replacesAssetWi
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -120,21 +120,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -172,7 +172,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -194,7 +194,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -202,21 +202,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -238,7 +238,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -261,7 +261,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -284,7 +284,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
@@ -306,7 +306,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -314,22 +314,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -352,7 +352,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -406,7 +406,7 @@ function manageContributor(address contributor, bool grantRole) external nonpaya
 
 Adds or removes a contributor to the smart contract.
 
-*Can only be called by the owner.*
+*Can only be called by the owner.Emits ***ContributorUpdate*** event.*
 
 #### Parameters
 
@@ -447,7 +447,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### owner
 
@@ -472,21 +472,21 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -575,17 +575,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -593,18 +593,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -612,16 +612,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -711,7 +711,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -736,17 +736,17 @@ function transfer(address to, uint256 tokenId) external nonpayable
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### transferOwnership
 

--- a/docs/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.md
+++ b/docs/mocks/extensions/tokenProperties/RMRKTokenPropertiesMock.md
@@ -31,7 +31,7 @@ Used to retrieve the address type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address The value of the address property |
+| _0 | address | The value of the address property |
 
 ### getBoolTokenProperty
 
@@ -54,7 +54,7 @@ Used to retrieve the bool type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The value of the bool property |
+| _0 | bool | The value of the bool property |
 
 ### getBytesTokenProperty
 
@@ -77,7 +77,7 @@ Used to retrieve the bytes type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes | bytes The value of the bytes property |
+| _0 | bytes | The value of the bytes property |
 
 ### getStringTokenProperty
 
@@ -100,7 +100,7 @@ Used to retrieve the string type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The value of the string property |
+| _0 | string | The value of the string property |
 
 ### getUintTokenProperty
 
@@ -123,7 +123,7 @@ Used to retrieve the uint type token properties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 The value of the uint property |
+| _0 | uint256 | The value of the uint property |
 
 ### setAddressProperty
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
@@ -141,16 +141,16 @@ function addTypedAssetEntry(uint64 assetId, string metadataURI, string type_) ex
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -175,21 +175,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -228,7 +228,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### childIsInActive
 
@@ -251,7 +251,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -274,7 +274,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -296,7 +296,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -318,9 +318,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
@@ -342,7 +342,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -364,7 +364,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -372,21 +372,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -408,7 +408,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -431,7 +431,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -454,7 +454,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getAssetType
 
@@ -476,7 +476,7 @@ Used to get the type of the asset.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The type of the asset |
+| _0 | string | The type of the asset |
 
 ### getPendingAssets
 
@@ -498,7 +498,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -506,22 +506,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -544,7 +544,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 
@@ -578,7 +578,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -679,7 +679,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -701,7 +701,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -735,7 +735,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -796,17 +796,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -814,18 +814,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -833,16 +833,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -915,7 +915,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -963,17 +963,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
@@ -43,7 +43,7 @@ Accepts a asset at from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being accepted |
 
 ### acceptChild
 
@@ -147,16 +147,16 @@ function addTypedAssetEntry(uint64 id, uint64 equippableGroupId, address catalog
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -181,21 +181,21 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -234,7 +234,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | uint256 Number of recursively burned children |
+| _0 | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
@@ -259,7 +259,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -282,7 +282,7 @@ Used to verify that the given child tokwn is included in an active array of a to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool A boolean value signifying whether the given child token is included in an active child tokens array  of a token (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the given child token is included in an active child tokens array of a  token (`true`) or not (`false`) |
 
 ### childOf
 
@@ -305,7 +305,7 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containing data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
@@ -327,7 +327,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s active child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -349,9 +349,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the given token&#39;s owner |
-| _1 | uint256 | uint256 The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | bool The boolean value signifying whether the owner is an NFT or not |
+| _0 | address | Address of the given token&#39;s owner |
+| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 
@@ -389,7 +389,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -411,7 +411,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -419,21 +419,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -455,7 +455,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -504,7 +504,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -527,7 +527,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getAssetType
 
@@ -549,7 +549,7 @@ Used to get the type of the asset.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The type of the asset |
+| _0 | string | The type of the asset |
 
 ### getEquipment
 
@@ -573,7 +573,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
@@ -595,7 +595,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
@@ -603,22 +603,22 @@ Used to retrieve IDs of the pending assets of given token.
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -641,7 +641,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -665,7 +665,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
 
 ### mint
 
@@ -699,7 +699,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### nestMint
 
@@ -800,7 +800,7 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child | struct A Child struct containting data about the specified child |
+| _0 | IRMRKNestable.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
@@ -822,7 +822,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKNestable.Child[] | struct[] An array of Child structs containing the parent token&#39;s pending child tokens |
+| _0 | IRMRKNestable.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -856,7 +856,7 @@ Used to reject all pending children of a given parent token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | undefined |
-| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from  rejecting children which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected children to reject, used to prevent from rejecting children which  arrive just before this operation. |
 
 ### rejectAsset
 
@@ -874,7 +874,7 @@ Rejects a asset from the pending array of given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
-| assetId | uint64 | undefined |
+| assetId | uint64 | ID of the asset that is being rejected |
 
 ### safeTransferFrom
 
@@ -882,17 +882,17 @@ Rejects a asset from the pending array of given token.
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -900,18 +900,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -919,16 +919,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -1019,7 +1019,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -1067,17 +1067,17 @@ Used to transfer a child token from a given parent token.
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### unequip
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedExternalEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedExternalEquippableMock.md
@@ -127,7 +127,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean indicating whether the token with the given asset can be equipped into the desired  slot |
+| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -165,7 +165,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -187,7 +187,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
@@ -209,7 +209,7 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the token |
+| _0 | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
@@ -258,7 +258,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -281,7 +281,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getAssetType
 
@@ -303,7 +303,7 @@ Used to get the type of the asset.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The type of the asset |
+| _0 | string | The type of the asset |
 
 ### getEquipment
 
@@ -327,7 +327,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKEquippable.Equipment | struct The `Equipment` struct containing data about the equipped object |
+| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getNestableAddress
 
@@ -344,7 +344,7 @@ Returns the Equippable contract&#39;s corresponding nestable address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the Nestable module of the external equip composite |
+| _0 | address | Address of the Nestable module of the external equip composite |
 
 ### getPendingAssets
 
@@ -366,7 +366,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
@@ -389,7 +389,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -430,7 +430,7 @@ Used to reject all pending assets of a given token.
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | ID of the token for which we are clearing the pending array. |
-| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from  rejecting assets which arrive just before this operation. |
+| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from rejecting assets which  arrive just before this operation. |
 
 ### rejectAsset
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
@@ -104,16 +104,16 @@ function addTypedAssetEntry(uint64 assetId, string metadataURI, string type_) ex
 function approve(address to, uint256 tokenId) external nonpayable
 ```
 
+Used to grant a one-time approval to manage one&#39;s token.
 
-
-*Gives permission to `to` to transfer `tokenId` token to another account. The approval is cleared when the token is transferred. Only a single account can be approved at a time, so approving the zero address clears previous approvals. Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist. Emits an {Approval} event.*
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
 
 ### approveForAssets
 
@@ -138,21 +138,21 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
+Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 
-*Returns the number of tokens in ``owner``&#39;s account.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
+| owner | address | Address of the account being checked |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | undefined |
+| _0 | uint256 | The balance of the given account |
 
 ### burn
 
@@ -190,7 +190,7 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint16[] | uint16[] An array of priorities of the active assets of the given token |
+| _0 | uint16[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
@@ -212,7 +212,7 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of active asset IDs of the given token |
+| _0 | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
@@ -220,21 +220,21 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the account approved to manage given token.
 
-
-*Returns the account approved for `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token to check for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
@@ -256,7 +256,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | address Address of the account that is approved to manage the specified token&#39;s assets |
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
@@ -279,7 +279,7 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
@@ -302,7 +302,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | uint64 ID of the asset which will be replaced |
+| _0 | uint64 | ID of the asset which will be replaced |
 
 ### getAssetType
 
@@ -324,7 +324,7 @@ Used to get the type of the asset.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The type of the asset |
+| _0 | string | The type of the asset |
 
 ### getPendingAssets
 
@@ -346,7 +346,7 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | uint64[] An array of pending asset IDs of the given token |
+| _0 | uint64[] | An array of pending asset IDs of the given token |
 
 ### getTopAssetMetaForTokenWithType
 
@@ -377,22 +377,22 @@ function getTopAssetMetaForTokenWithType(uint256 tokenId, string type_) external
 function isApprovedForAll(address owner, address operator) external view returns (bool)
 ```
 
+Used to check if the given address is allowed to manage the tokens of the specified address.
 
 
-*Returns if the `operator` is allowed to manage all of the assets of `owner`. See {setApprovalForAll}*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | undefined |
-| operator | address | undefined |
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | undefined |
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
@@ -415,7 +415,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | bool The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 
@@ -449,7 +449,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Name of the collection |
+| _0 | string | Name of the collection |
 
 ### ownerOf
 
@@ -457,21 +457,21 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
+Used to retireve the owner of the given token.
 
-
-*Returns the owner of the `tokenId` token. Requirements: - `tokenId` must exist.*
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | undefined |
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -549,17 +549,17 @@ function safeMint(address to, uint256 tokenId) external nonpayable
 function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must have been allowed to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
 
 ### safeTransferFrom
 
@@ -567,18 +567,18 @@ function safeTransferFrom(address from, address to, uint256 tokenId) external no
 function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
 ```
 
+Used to safely transfer a given token token from `from` to `to`.
 
-
-*Safely transfers `tokenId` token from `from` to `to`. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must exist and be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
 
 ### setApprovalForAll
 
@@ -586,16 +586,16 @@ function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
 function setApprovalForAll(address operator, bool approved) external nonpayable
 ```
 
+Used to approve or remove `operator` as an operator for the caller.
 
-
-*Approve or remove `operator` as an operator for the caller. Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller. Requirements: - The `operator` cannot be the caller. Emits an {ApprovalForAll} event.*
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | undefined |
-| approved | bool | undefined |
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
 
 ### setApprovalForAllForAssets
 
@@ -668,7 +668,7 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string Symbol of the collection |
+| _0 | string | Symbol of the collection |
 
 ### transfer
 
@@ -693,17 +693,17 @@ function transfer(address to, uint256 tokenId) external nonpayable
 function transferFrom(address from, address to, uint256 tokenId) external nonpayable
 ```
 
+Transfers a given token from `from` to `to`.
 
-
-*Transfers `tokenId` token from `from` to `to`. WARNING: Note that the caller is responsible to confirm that the recipient is capable of receiving ERC721 or else they may be permanently lost. Usage of {safeTransferFrom} prevents loss, though the caller must understand this adds an external call which potentially creates a reentrancy vulnerability. Requirements: - `from` cannot be the zero address. - `to` cannot be the zero address. - `tokenId` token must be owned by `from`. - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}. Emits a {Transfer} event.*
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | undefined |
-| to | address | undefined |
-| tokenId | uint256 | undefined |
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
 
 
 


### PR DESCRIPTION
# Description

There is a number of `| undefined |` values in our documentation. This PR is an attempt to reduce their number.

# Actions

- Added comments for a few missing parameters and functions.
- Moved away from OpenZeppelin documentation inheritance, as it is not in line with out documentation style.

## Note

The current compiler (`0.8.16`) generates 1385 instances of `| undefined |` and the latest version (`0.8.18`) generates 1263 instances of `| undefined |`. Once we upgrade, we shall get rid of a few additional cases of undefined.

# Checklist

- [N/A] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [N/A] Added tests to fully cover the changes
