### PR TITLE
Multiasset autoindex

### DIFF
--- a/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.16;
+
+import "../../multiasset/IRMRKMultiAsset.sol";
+
+interface IRMRKMultiAssetAutoIndex is IRMRKMultiAsset {
+    /**
+     * @notice Accepts an asset at from the pending array of given token.
+     * @dev Migrates the asset from the token's pending asset array to the token's active asset array.
+     * @dev Active assets cannot be removed by anyone, but can be replaced by a new asset.
+     * @dev Requirements:
+     *
+     *  - The caller must own the token or be approved to manage the token's assets
+     *  - `tokenId` must exist.
+     *  - `index` must be in range of the length of the pending asset array.
+     * @dev Emits an {AssetAccepted} event.
+     * @param tokenId ID of the token for which to accept the pending asset
+     * @param assetId Id of the asset expected to be in the index
+     */
+    function acceptAsset(uint256 tokenId, uint64 assetId) external;
+
+    /**
+     * @notice Rejects an asset from the pending array of given token.
+     * @dev Removes the asset from the token's pending asset array.
+     * @dev Requirements:
+     *
+     *  - The caller must own the token or be approved to manage the token's assets
+     *  - `tokenId` must exist.
+     *  - `index` must be in range of the length of the pending asset array.
+     * @dev Emits a {AssetRejected} event.
+     * @param tokenId ID of the token that the asset is being rejected from
+     * @param assetId Id of the asset expected to be in the index
+     */
+    function rejectAsset(uint256 tokenId, uint64 assetId) external;
+}

--- a/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.16;
 
 import "../../multiasset/IRMRKMultiAsset.sol";
 
+/**
+ * @title RMRKMultiAssetAutoIndex
+ * @author RMRK team
+ * @notice Interface smart contract of the RMRK MultiAsset AutoIndex module.
+ */
 interface IRMRKMultiAssetAutoIndex is IRMRKMultiAsset {
     /**
      * @notice Accepts an asset from the pending array of given token.

--- a/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
@@ -13,10 +13,9 @@ interface IRMRKMultiAssetAutoIndex is IRMRKMultiAsset {
      *
      *  - The caller must own the token or be approved to manage the token's assets
      *  - `tokenId` must exist.
-     *  - `index` must be in range of the length of the pending asset array.
      * @dev Emits an {AssetAccepted} event.
      * @param tokenId ID of the token for which to accept the pending asset
-     * @param assetId Id of the asset expected to be in the index
+     * @param assetId Id of the pending asset
      */
     function acceptAsset(uint256 tokenId, uint64 assetId) external;
 
@@ -27,10 +26,9 @@ interface IRMRKMultiAssetAutoIndex is IRMRKMultiAsset {
      *
      *  - The caller must own the token or be approved to manage the token's assets
      *  - `tokenId` must exist.
-     *  - `index` must be in range of the length of the pending asset array.
      * @dev Emits a {AssetRejected} event.
      * @param tokenId ID of the token that the asset is being rejected from
-     * @param assetId Id of the asset expected to be in the index
+     * @param assetId Id of the pending asset
      */
     function rejectAsset(uint256 tokenId, uint64 assetId) external;
 }

--- a/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
@@ -6,9 +6,9 @@ import "../../multiasset/IRMRKMultiAsset.sol";
 
 interface IRMRKMultiAssetAutoIndex is IRMRKMultiAsset {
     /**
-     * @notice Accepts an asset at from the pending array of given token.
+     * @notice Accepts an asset from the pending array of given token.
      * @dev Migrates the asset from the token's pending asset array to the token's active asset array.
-     * @dev Active assets cannot be removed by anyone, but can be replaced by a new asset.
+     * @dev An active asset cannot be removed by anyone, but can be replaced by a new asset.
      * @dev Requirements:
      *
      *  - The caller must own the token or be approved to manage the token's assets

--- a/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
@@ -5,15 +5,28 @@ pragma solidity ^0.8.16;
 import "./IRMRKMultiAssetAutoIndex.sol";
 import "../../multiasset/RMRKMultiAsset.sol";
 
+/**
+ * @title RMRKMultiAssetAutoIndex
+ * @author RMRK team
+ * @notice Smart contract of the RMRK MultiAsset AutoIndex module.
+ */
 contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
     // Mapping of tokenId to assetId to index on the _pendingAssetIndex array
     mapping(uint256 => mapping(uint256 => uint256)) private _pendingAssetIndex;
 
+    /**
+     * @notice Initializes the contract by setting a name and a symbol to the token collection.
+     * @param name_ Name of the token collection
+     * @param symbol_ Symbol of the token collection
+     */
     constructor(
         string memory name_,
         string memory symbol_
     ) RMRKMultiAsset(name_, symbol_) {}
 
+    /**
+     * @inheritdoc IERC165
+     */
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override(IERC165, RMRKMultiAsset) returns (bool) {
@@ -36,6 +49,11 @@ contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
         _rejectAsset(tokenId, _getIndex(tokenId, assetId), assetId);
     }
 
+    /**
+     * @notice Returns the index of the asset in the pending asset list for the token
+     * @param tokenId The token to get the index for
+     * @param assetId The asset to get the index for
+     */
     function _getIndex(
         uint256 tokenId,
         uint64 assetId
@@ -65,6 +83,12 @@ contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
         _removePendingIndex(tokenId, index, assetId);
     }
 
+    /**
+     * @notice Removes the index for the asset on the pending asset list for the token
+     * @param tokenId The token to remove the index for
+     * @param index The index of the asset in the pending asset list
+     * @param assetId The asset to remove the index for
+     */
     function _removePendingIndex(
         uint256 tokenId,
         uint256 index,

--- a/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.16;
+
+import "./IRMRKMultiAssetAutoIndex.sol";
+import "../../multiasset/RMRKMultiAsset.sol";
+
+contract RMRKMultiAssetAutoIndex is IRMRKMultiAssetAutoIndex, RMRKMultiAsset {
+    // Mapping of tokenId to assetId to index on the _pendingAssetIndex array
+    mapping(uint256 => mapping(uint256 => uint256)) private _pendingAssetIndex;
+
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) RMRKMultiAsset(name_, symbol_) {}
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165, RMRKMultiAsset) returns (bool) {
+        return
+            interfaceId == type(IRMRKMultiAssetAutoIndex).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @inheritdoc IRMRKMultiAssetAutoIndex
+     */
+    function acceptAsset(uint256 tokenId, uint64 assetId) public {
+        uint256 index = _pendingAssetIndex[tokenId][assetId];
+        _acceptAsset(tokenId, index, assetId);
+    }
+
+    /**
+     * @inheritdoc IRMRKMultiAssetAutoIndex
+     */
+    function rejectAsset(uint256 tokenId, uint64 assetId) public {
+        uint256 index = _pendingAssetIndex[tokenId][assetId];
+        _rejectAsset(tokenId, index, assetId);
+    }
+
+    /**
+     * @inheritdoc AbstractMultiAsset
+     */
+    function _afterAcceptAsset(
+        uint256 tokenId,
+        uint256 index,
+        uint256 assetId
+    ) internal override {
+        require(
+            _pendingAssetIndex[tokenId][assetId] == index,
+            "Trying to delete asset at the wrong index"
+        );
+
+        uint64[] memory pendingAssetsIds = getPendingAssets(tokenId);
+
+        if (pendingAssetsIds.length == index) {
+            // Rejected last pending asset
+            delete _pendingAssetIndex[tokenId][assetId];
+        } else {
+            // Rejected intermediate asset --> update indexes
+            uint256 replacingAssetId = pendingAssetsIds[index];
+            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[
+                tokenId
+            ][assetId];
+            delete _pendingAssetIndex[tokenId][assetId];
+        }
+    }
+
+    /**
+     * @inheritdoc AbstractMultiAsset
+     */
+    function _afterRejectAsset(
+        uint256 tokenId,
+        uint256 index,
+        uint256 assetId
+    ) internal override {
+        require(
+            _pendingAssetIndex[tokenId][assetId] == index,
+            "Trying to delete asset at the wrong index"
+        );
+
+        uint64[] memory pendingAssetsIds = getPendingAssets(tokenId);
+
+        if (pendingAssetsIds.length == index) {
+            // Rejected last pending asset
+            delete _pendingAssetIndex[tokenId][assetId];
+        } else {
+            // Rejected intermediate asset --> update indexes
+            uint256 replacingAssetId = pendingAssetsIds[index];
+            _pendingAssetIndex[tokenId][replacingAssetId] = _pendingAssetIndex[
+                tokenId
+            ][assetId];
+            delete _pendingAssetIndex[tokenId][assetId];
+        }
+    }
+
+    /**
+     * @inheritdoc AbstractMultiAsset
+     */
+    function _beforeAddAssetToToken(
+        uint256 tokenId,
+        uint64 assetId,
+        uint64
+    ) internal virtual override {
+        // The asset has already been put into the pending asset list
+        _pendingAssetIndex[tokenId][assetId] = _pendingAssets[tokenId].length;
+    }
+}

--- a/contracts/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.sol
+++ b/contracts/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.16;
 
 import "../../nestable/IRMRKNestable.sol";
 
+/**
+ * @title RMRKNestableAutoIndex
+ * @author RMRK team
+ * @notice Interface smart contract of the RMRK Nestable AutoIndex module.
+ */
 interface IRMRKNestableAutoIndex is IRMRKNestable {
     /**
      * @notice Used to accept a pending child token for a given parent token.

--- a/contracts/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.sol
+++ b/contracts/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.sol
@@ -5,6 +5,11 @@ pragma solidity ^0.8.16;
 import "./IRMRKNestableAutoIndex.sol";
 import "../../nestable/RMRKNestable.sol";
 
+/**
+ * @title RMRKNestableAutoIndex
+ * @author RMRK team
+ * @notice Smart contract of the RMRK Nestable AutoIndex module.
+ */
 contract RMRKNestableAutoIndex is IRMRKNestableAutoIndex, RMRKNestable {
     // Mapping of tokenId to childAddress to childId to index on the _pendingChildren array
     mapping(uint256 => mapping(address => mapping(uint256 => uint256)))

--- a/contracts/RMRK/multiasset/AbstractMultiAsset.sol
+++ b/contracts/RMRK/multiasset/AbstractMultiAsset.sol
@@ -379,7 +379,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
     function _beforeAcceptAsset(
         uint256 tokenId,
         uint256 index,
-        uint256 assetId
+        uint64 assetId
     ) internal virtual {}
 
     /**
@@ -391,7 +391,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
     function _afterAcceptAsset(
         uint256 tokenId,
         uint256 index,
-        uint256 assetId
+        uint64 assetId
     ) internal virtual {}
 
     /**
@@ -403,7 +403,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
     function _beforeRejectAsset(
         uint256 tokenId,
         uint256 index,
-        uint256 assetId
+        uint64 assetId
     ) internal virtual {}
 
     /**
@@ -415,7 +415,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
     function _afterRejectAsset(
         uint256 tokenId,
         uint256 index,
-        uint256 assetId
+        uint64 assetId
     ) internal virtual {}
 
     /**

--- a/contracts/mocks/RMRKMultiAssetAutoIndexMock.sol
+++ b/contracts/mocks/RMRKMultiAssetAutoIndexMock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.16;
+
+import "../RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol";
+
+contract RMRKMultiAssetAutoIndexMock is RMRKMultiAssetAutoIndex {
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) RMRKMultiAssetAutoIndex(name_, symbol_) {}
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function addAssetToToken(
+        uint256 tokenId,
+        uint64 assetId,
+        uint64 replacesAssetWithId
+    ) external {
+        _addAssetToToken(tokenId, assetId, replacesAssetWithId);
+    }
+
+    function addAssetEntry(uint64 id, string memory metadataURI) external {
+        _addAssetEntry(id, metadataURI);
+    }
+}

--- a/docs/RMRK/catalog/IRMRKCatalog.md
+++ b/docs/RMRK/catalog/IRMRKCatalog.md
@@ -70,7 +70,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Case metadata URI |
+| _0 | string | Catalog metadata URI |
 
 ### getPart
 

--- a/docs/RMRK/catalog/RMRKCatalog.md
+++ b/docs/RMRK/catalog/RMRKCatalog.md
@@ -70,7 +70,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Case metadata URI |
+| _0 | string | Catalog metadata URI |
 
 ### getPart
 

--- a/docs/RMRK/equippable/IRMRKEquippable.md
+++ b/docs/RMRK/equippable/IRMRKEquippable.md
@@ -68,7 +68,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -291,7 +291,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -315,7 +315,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -122,7 +122,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -200,7 +200,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -360,7 +360,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -560,7 +560,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -584,7 +584,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### name
 

--- a/docs/RMRK/equippable/RMRKExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKExternalEquip.md
@@ -68,7 +68,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -308,7 +308,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 

--- a/docs/RMRK/equippable/RMRKNestableExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKNestableExternalEquip.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -240,7 +240,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
@@ -1,14 +1,31 @@
-# IRMRKExternalEquip
+# IRMRKMultiAssetAutoIndex
 
-*RMRK team*
 
-> IRMRKExternalEquip
 
-Interface smart contract of the RMRK external equippable module.
+
+
+
 
 
 
 ## Methods
+
+### acceptAsset
+
+```solidity
+function acceptAsset(uint256 tokenId, uint64 assetId) external nonpayable
+```
+
+Accepts an asset at from the pending array of given token.
+
+*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.Active assets cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token for which to accept the pending asset |
+| assetId | uint64 | Id of the pending asset |
 
 ### acceptAsset
 
@@ -44,47 +61,6 @@ Used to grant permission to the user to manage token&#39;s assets.
 |---|---|---|
 | to | address | Address of the account to grant the approval to |
 | tokenId | uint256 | ID of the token for which the approval to manage the assets is granted |
-
-### canTokenBeEquippedWithAssetIntoSlot
-
-```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
-```
-
-Used to verify whether a token can be equipped into a given parent&#39;s slot.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| parent | address | Address of the parent token&#39;s smart contract |
-| tokenId | uint256 | ID of the token we want to equip |
-| assetId | uint64 | ID of the asset associated with the token we want to equip |
-| slotId | uint64 | ID of the slot that we want to equip the token into |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
-
-### equip
-
-```solidity
-function equip(IRMRKEquippable.IntakeEquip data) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| data | IRMRKEquippable.IntakeEquip | undefined |
 
 ### getActiveAssetPriorities
 
@@ -152,32 +128,6 @@ Used to retrieve the address of the account approved to manage assets of a given
 |---|---|---|
 | _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
-### getAssetAndEquippableData
-
-```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
-```
-
-Used to get the asset and equippable data associated with given `assetId`.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId | uint256 | ID of the token for which to retrieve the asset |
-| assetId | uint64 | ID of the asset of which we are retrieving |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| metadataURI | string | The metadata URI of the asset |
-| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
-| catalogAddress | address | The address of the catalog the part belongs to |
-| partIds | uint64[] | An array of IDs of parts included in the asset |
-
 ### getAssetMetadata
 
 ```solidity
@@ -224,47 +174,6 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 |---|---|---|
 | _0 | uint64 | ID of the asset which will be replaced |
 
-### getEquipment
-
-```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IRMRKEquippable.Equipment)
-```
-
-Used to get the Equipment object equipped into the specified slot of the desired token.
-
-*The `Equipment` struct consists of the following data:  [      assetId,      childAssetId,      childId,      childEquippableAddress  ]*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId | uint256 | ID of the token for which we are retrieving the equipped object |
-| targetCatalogAddress | address | Address of the `Catalog` associated with the `Slot` part of the token |
-| slotPartId | uint64 | ID of the `Slot` part that we are checking for equipped objects |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | IRMRKEquippable.Equipment | The `Equipment` struct containing data about the equipped object |
-
-### getNestableAddress
-
-```solidity
-function getNestableAddress() external view returns (address)
-```
-
-Returns the Equippable contract&#39;s corresponding nestable address.
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | Address of the Nestable module of the external equip composite |
-
 ### getPendingAssets
 
 ```solidity
@@ -310,30 +219,6 @@ Used to check whether the address has been granted the operator role by a given 
 |---|---|---|
 | _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
-### isChildEquipped
-
-```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
-```
-
-Used to check whether the token has a given child equipped.
-
-*This is used to prevent from transferring a child that is equipped.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId | uint256 | ID of the parent token for which we are querying for |
-| childAddress | address | Address of the child token&#39;s smart contract |
-| childId | uint256 | ID of the child token |
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
-
 ### rejectAllAssets
 
 ```solidity
@@ -350,6 +235,23 @@ Rejects all assets from the pending array of a given token.
 |---|---|---|
 | tokenId | uint256 | ID of the token of which to clear the pending array. |
 | maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from rejecting assets which  arrive just before this operation. |
+
+### rejectAsset
+
+```solidity
+function rejectAsset(uint256 tokenId, uint64 assetId) external nonpayable
+```
+
+Rejects an asset from the pending array of given token.
+
+*Removes the asset from the token&#39;s pending asset array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits a {AssetRejected} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token that the asset is being rejected from |
+| assetId | uint64 | Id of the pending asset |
 
 ### rejectAsset
 
@@ -424,24 +326,6 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | undefined |
-
-### unequip
-
-```solidity
-function unequip(uint256 tokenId, uint64 assetId, uint64 slotPartId) external nonpayable
-```
-
-Used to unequip child from parent token.
-
-*This can only be called by the owner of the token or by an account that has been granted permission to  manage the given token by the current owner.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId | uint256 | ID of the parent from which the child is being unequipped |
-| assetId | uint64 | ID of the parent&#39;s asset that contains the `Slot` into which the child is equipped |
-| slotPartId | uint64 | ID of the `Slot` from which to unequip the child |
 
 
 
@@ -567,83 +451,6 @@ Used to notify listeners that an asset object is initialized at `assetId`.
 | Name | Type | Description |
 |---|---|---|
 | assetId `indexed` | uint64 | undefined |
-
-### ChildAssetEquipped
-
-```solidity
-event ChildAssetEquipped(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed slotPartId, uint256 childId, address childAddress, uint64 childAssetId)
-```
-
-Used to notify listeners that a child&#39;s asset has been equipped into one of its parent assets.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId `indexed` | uint256 | undefined |
-| assetId `indexed` | uint64 | undefined |
-| slotPartId `indexed` | uint64 | undefined |
-| childId  | uint256 | undefined |
-| childAddress  | address | undefined |
-| childAssetId  | uint64 | undefined |
-
-### ChildAssetUnequipped
-
-```solidity
-event ChildAssetUnequipped(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed slotPartId, uint256 childId, address childAddress, uint64 childAssetId)
-```
-
-Used to notify listeners that a child&#39;s asset has been unequipped from one of its parent assets.
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId `indexed` | uint256 | undefined |
-| assetId `indexed` | uint64 | undefined |
-| slotPartId `indexed` | uint64 | undefined |
-| childId  | uint256 | undefined |
-| childAddress  | address | undefined |
-| childAssetId  | uint64 | undefined |
-
-### NestableAddressSet
-
-```solidity
-event NestableAddressSet(address old, address new_)
-```
-
-Used to notify listeners of a new `Nestable` associated  smart contract address being set.
-
-*When initially setting the `Nestable` smart contract address, the `old` value should equal `0x0` address.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| old  | address | Previous `Nestable` smart contract address |
-| new_  | address | New `Nestable` smart contract address |
-
-### ValidParentEquippableGroupIdSet
-
-```solidity
-event ValidParentEquippableGroupIdSet(uint64 indexed equippableGroupId, uint64 indexed slotPartId, address parentAddress)
-```
-
-Used to notify listeners that the assets belonging to a `equippableGroupId` have been marked as  equippable into a given slot and parent
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| equippableGroupId `indexed` | uint64 | undefined |
-| slotPartId `indexed` | uint64 | undefined |
-| parentAddress  | address | undefined |
 
 
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
@@ -1,10 +1,10 @@
 # IRMRKMultiAssetAutoIndex
 
+*RMRK team*
 
+> RMRKMultiAssetAutoIndex
 
-
-
-
+Interface smart contract of the RMRK MultiAsset AutoIndex module.
 
 
 
@@ -16,9 +16,9 @@
 function acceptAsset(uint256 tokenId, uint64 assetId) external nonpayable
 ```
 
-Accepts an asset at from the pending array of given token.
+Accepts an asset from the pending array of given token.
 
-*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.Active assets cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
+*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.An active asset cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
 
 #### Parameters
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
@@ -1,10 +1,10 @@
 # RMRKMultiAssetAutoIndex
 
+*RMRK team*
 
+> RMRKMultiAssetAutoIndex
 
-
-
-
+Smart contract of the RMRK MultiAsset AutoIndex module.
 
 
 
@@ -33,9 +33,9 @@ Version of the @rmrk-team/evm-contracts package
 function acceptAsset(uint256 tokenId, uint64 assetId) external nonpayable
 ```
 
-Accepts an asset at from the pending array of given token.
+Accepts an asset from the pending array of given token.
 
-*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.Active assets cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
+*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.An active asset cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
 
 #### Parameters
 
@@ -507,7 +507,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 
 
 
-
+*Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section] to learn more about how these ids are created. This function call must use less than 30 000 gas.*
 
 #### Parameters
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
@@ -1,4 +1,4 @@
-# RMRKMultiAssetMock
+# RMRKMultiAssetAutoIndex
 
 
 
@@ -30,6 +30,23 @@ Version of the @rmrk-team/evm-contracts package
 ### acceptAsset
 
 ```solidity
+function acceptAsset(uint256 tokenId, uint64 assetId) external nonpayable
+```
+
+Accepts an asset at from the pending array of given token.
+
+*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.Active assets cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token for which to accept the pending asset |
+| assetId | uint64 | Id of the pending asset |
+
+### acceptAsset
+
+```solidity
 function acceptAsset(uint256 tokenId, uint256 index, uint64 assetId) external nonpayable
 ```
 
@@ -44,41 +61,6 @@ Accepts an asset at from the pending array of given token.
 | tokenId | uint256 | ID of the token for which to accept the pending asset |
 | index | uint256 | Index of the asset in the pending array to accept |
 | assetId | uint64 | ID of the asset expected to be in the index |
-
-### addAssetEntry
-
-```solidity
-function addAssetEntry(uint64 id, string metadataURI) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| id | uint64 | undefined |
-| metadataURI | string | undefined |
-
-### addAssetToToken
-
-```solidity
-function addAssetToToken(uint256 tokenId, uint64 assetId, uint64 replacesAssetWithId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId | uint256 | undefined |
-| assetId | uint64 | undefined |
-| replacesAssetWithId | uint64 | undefined |
 
 ### approve
 
@@ -135,22 +117,6 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | The balance of the given account |
-
-### burn
-
-```solidity
-function burn(uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId | uint256 | undefined |
 
 ### getActiveAssetPriorities
 
@@ -354,23 +320,6 @@ Used to check whether the address has been granted the operator role by a given 
 |---|---|---|
 | _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
-### mint
-
-```solidity
-function mint(address to, uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-
 ### name
 
 ```solidity
@@ -430,6 +379,23 @@ Rejects all assets from the pending array of a given token.
 ### rejectAsset
 
 ```solidity
+function rejectAsset(uint256 tokenId, uint64 assetId) external nonpayable
+```
+
+Rejects an asset from the pending array of given token.
+
+*Removes the asset from the token&#39;s pending asset array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits a {AssetRejected} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token that the asset is being rejected from |
+| assetId | uint64 | Id of the pending asset |
+
+### rejectAsset
+
+```solidity
 function rejectAsset(uint256 tokenId, uint256 index, uint64 assetId) external nonpayable
 ```
 
@@ -444,41 +410,6 @@ Rejects an asset from the pending array of given token.
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
 | assetId | uint64 | ID of the asset expected to be in the index |
-
-### safeMint
-
-```solidity
-function safeMint(address to, uint256 tokenId, bytes data) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
-
-### safeMint
-
-```solidity
-function safeMint(address to, uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
 
 ### safeTransferFrom
 
@@ -576,7 +507,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 
 
 
-*Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section] to learn more about how these ids are created. This function call must use less than 30 000 gas.*
+
 
 #### Parameters
 
@@ -606,23 +537,6 @@ Used to retrieve the collection symbol.
 | Name | Type | Description |
 |---|---|---|
 | _0 | string | Symbol of the collection |
-
-### transfer
-
-```solidity
-function transfer(address to, uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
 
 ### transferFrom
 
@@ -880,17 +794,6 @@ Attempting to use an invalid token ID
 
 
 
-### ERC721MintToTheZeroAddress
-
-```solidity
-error ERC721MintToTheZeroAddress()
-```
-
-Attempting to mint to 0x0 address
-
-
-
-
 ### ERC721NotApprovedOrOwner
 
 ```solidity
@@ -898,17 +801,6 @@ error ERC721NotApprovedOrOwner()
 ```
 
 Attempting to manage a token without being its owner or approved by the owner
-
-
-
-
-### ERC721TokenAlreadyMinted
-
-```solidity
-error ERC721TokenAlreadyMinted()
-```
-
-Attempting to mint an already minted token
 
 
 
@@ -968,17 +860,6 @@ Attempting to grant approval of assets without being the caller or approved for 
 
 
 
-### RMRKAssetAlreadyExists
-
-```solidity
-error RMRKAssetAlreadyExists()
-```
-
-Attempting to add an asset using an ID that has already been used
-
-
-
-
 ### RMRKBadPriorityListLength
 
 ```solidity
@@ -990,17 +871,6 @@ Attempting to set the priorities with an array of length that doesn&#39;t match 
 
 
 
-### RMRKIdZeroForbidden
-
-```solidity
-error RMRKIdZeroForbidden()
-```
-
-Attempting to use ID 0, which is not supported
-
-*The ID 0 in RMRK suite is reserved for empty values. Guarding against its use ensures the expected operation*
-
-
 ### RMRKIndexOutOfRange
 
 ```solidity
@@ -1008,28 +878,6 @@ error RMRKIndexOutOfRange()
 ```
 
 Attempting to interact with an asset, using index greater than number of assets
-
-
-
-
-### RMRKMaxPendingAssetsReached
-
-```solidity
-error RMRKMaxPendingAssetsReached()
-```
-
-Attempting to add a pending asset after the number of pending assets has reached the limit (default limit is  128)
-
-
-
-
-### RMRKNoAssetMatchingId
-
-```solidity
-error RMRKNoAssetMatchingId()
-```
-
-Attempting to interact with an asset that can not be found
 
 
 

--- a/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
@@ -1,10 +1,10 @@
 # IRMRKNestableAutoIndex
 
+*RMRK team*
 
+> RMRKNestableAutoIndex
 
-
-
-
+Interface smart contract of the RMRK Nestable AutoIndex module.
 
 
 

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -1,10 +1,10 @@
 # RMRKNestableAutoIndex
 
+*RMRK team*
 
+> RMRKNestableAutoIndex
 
-
-
-
+Smart contract of the RMRK Nestable AutoIndex module.
 
 
 

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -105,7 +105,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -258,7 +258,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
+++ b/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -240,7 +240,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/RMRK/multiasset/AbstractMultiAsset.md
+++ b/docs/RMRK/multiasset/AbstractMultiAsset.md
@@ -200,7 +200,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/multiasset/IRMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/IRMRKMultiAsset.md
@@ -200,7 +200,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/multiasset/RMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/RMRKMultiAsset.md
@@ -151,7 +151,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -301,7 +301,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### name
 
@@ -326,7 +326,7 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/RMRK/nestable/RMRKNestable.md
+++ b/docs/RMRK/nestable/RMRKNestable.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -240,7 +240,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -122,7 +122,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -319,7 +319,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -469,7 +469,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### name
 

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -136,7 +136,7 @@ Used to retrieve the metadata URI of specified assets in the specified token.
 function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
 ```
 
-Used to retrieve the given child&#39;s index in its paren&#39;s child tokens array.
+Used to retrieve the given child&#39;s index in its parent&#39;s child tokens array.
 
 
 

--- a/docs/RMRK/utils/RMRKNestableRenderUtils.md
+++ b/docs/RMRK/utils/RMRKNestableRenderUtils.md
@@ -35,7 +35,7 @@ Check if the child is owned by the expected parent.
 function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
 ```
 
-Used to retrieve the given child&#39;s index in its paren&#39;s child tokens array.
+Used to retrieve the given child&#39;s index in its parent&#39;s child tokens array.
 
 
 

--- a/docs/implementations/RMRKCatalogImpl.md
+++ b/docs/implementations/RMRKCatalogImpl.md
@@ -136,7 +136,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Case metadata URI |
+| _0 | string | Catalog metadata URI |
 
 ### getPart
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -187,7 +187,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -442,7 +442,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -693,7 +693,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -717,7 +717,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -224,7 +224,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -425,7 +425,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -523,7 +523,7 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -257,7 +257,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -162,7 +162,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -376,7 +376,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -577,7 +577,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -187,7 +187,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -459,7 +459,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -710,7 +710,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -734,7 +734,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -241,7 +241,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -442,7 +442,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -557,7 +557,7 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -274,7 +274,7 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -162,7 +162,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -393,7 +393,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -594,7 +594,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -187,7 +187,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -442,7 +442,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -693,7 +693,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -717,7 +717,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 

--- a/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
@@ -133,7 +133,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -390,7 +390,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -224,7 +224,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -425,7 +425,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -540,7 +540,7 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -257,7 +257,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -257,7 +257,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -162,7 +162,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -376,7 +376,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -577,7 +577,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -187,7 +187,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -265,7 +265,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -442,7 +442,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -693,7 +693,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -717,7 +717,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -224,7 +224,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -425,7 +425,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -540,7 +540,7 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -257,7 +257,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -162,7 +162,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -376,7 +376,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -577,7 +577,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 

--- a/docs/mocks/RMRKCatalogMock.md
+++ b/docs/mocks/RMRKCatalogMock.md
@@ -119,7 +119,7 @@ Used to return the metadata URI of the associated Catalog.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Case metadata URI |
+| _0 | string | Catalog metadata URI |
 
 ### getPart
 

--- a/docs/mocks/RMRKEquippableMock.md
+++ b/docs/mocks/RMRKEquippableMock.md
@@ -160,7 +160,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -238,7 +238,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -398,7 +398,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -598,7 +598,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -622,7 +622,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### mint
 

--- a/docs/mocks/RMRKExternalEquipMock.md
+++ b/docs/mocks/RMRKExternalEquipMock.md
@@ -106,7 +106,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -346,7 +346,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 

--- a/docs/mocks/RMRKMultiAssetAutoIndexMock.md
+++ b/docs/mocks/RMRKMultiAssetAutoIndexMock.md
@@ -1,4 +1,4 @@
-# RMRKMultiAssetMock
+# RMRKMultiAssetAutoIndexMock
 
 
 
@@ -26,6 +26,23 @@ Version of the @rmrk-team/evm-contracts package
 | Name | Type | Description |
 |---|---|---|
 | _0 | string | undefined |
+
+### acceptAsset
+
+```solidity
+function acceptAsset(uint256 tokenId, uint64 assetId) external nonpayable
+```
+
+Accepts an asset at from the pending array of given token.
+
+*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.Active assets cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token for which to accept the pending asset |
+| assetId | uint64 | Id of the pending asset |
 
 ### acceptAsset
 
@@ -135,22 +152,6 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | The balance of the given account |
-
-### burn
-
-```solidity
-function burn(uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| tokenId | uint256 | undefined |
 
 ### getActiveAssetPriorities
 
@@ -430,6 +431,23 @@ Rejects all assets from the pending array of a given token.
 ### rejectAsset
 
 ```solidity
+function rejectAsset(uint256 tokenId, uint64 assetId) external nonpayable
+```
+
+Rejects an asset from the pending array of given token.
+
+*Removes the asset from the token&#39;s pending asset array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits a {AssetRejected} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token that the asset is being rejected from |
+| assetId | uint64 | Id of the pending asset |
+
+### rejectAsset
+
+```solidity
 function rejectAsset(uint256 tokenId, uint256 index, uint64 assetId) external nonpayable
 ```
 
@@ -444,41 +462,6 @@ Rejects an asset from the pending array of given token.
 | tokenId | uint256 | ID of the token that the asset is being rejected from |
 | index | uint256 | Index of the asset in the pending array to be rejected |
 | assetId | uint64 | ID of the asset expected to be in the index |
-
-### safeMint
-
-```solidity
-function safeMint(address to, uint256 tokenId, bytes data) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| data | bytes | undefined |
-
-### safeMint
-
-```solidity
-function safeMint(address to, uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
 
 ### safeTransferFrom
 
@@ -576,7 +559,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 
 
 
-*Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section] to learn more about how these ids are created. This function call must use less than 30 000 gas.*
+
 
 #### Parameters
 
@@ -606,23 +589,6 @@ Used to retrieve the collection symbol.
 | Name | Type | Description |
 |---|---|---|
 | _0 | string | Symbol of the collection |
-
-### transfer
-
-```solidity
-function transfer(address to, uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
 
 ### transferFrom
 

--- a/docs/mocks/RMRKMultiAssetAutoIndexMock.md
+++ b/docs/mocks/RMRKMultiAssetAutoIndexMock.md
@@ -33,9 +33,9 @@ Version of the @rmrk-team/evm-contracts package
 function acceptAsset(uint256 tokenId, uint64 assetId) external nonpayable
 ```
 
-Accepts an asset at from the pending array of given token.
+Accepts an asset from the pending array of given token.
 
-*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.Active assets cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
+*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.An active asset cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits an {AssetAccepted} event.*
 
 #### Parameters
 
@@ -559,7 +559,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 
 
 
-
+*Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section] to learn more about how these ids are created. This function call must use less than 30 000 gas.*
 
 #### Parameters
 

--- a/docs/mocks/RMRKNestableAutoIndexMock.md
+++ b/docs/mocks/RMRKNestableAutoIndexMock.md
@@ -105,7 +105,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -258,7 +258,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/RMRKNestableExternalEquipMock.md
+++ b/docs/mocks/RMRKNestableExternalEquipMock.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -240,7 +240,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/RMRKNestableMock.md
+++ b/docs/mocks/RMRKNestableMock.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -263,7 +263,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/RMRKNestableMultiAssetMock.md
+++ b/docs/mocks/RMRKNestableMultiAssetMock.md
@@ -157,7 +157,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -354,7 +354,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -504,7 +504,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 

--- a/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
+++ b/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -263,7 +263,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
+++ b/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
@@ -169,7 +169,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -342,7 +342,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 
@@ -384,7 +384,7 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
@@ -202,7 +202,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -369,7 +369,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 
@@ -433,7 +433,7 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
@@ -202,7 +202,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -391,7 +391,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 
@@ -455,7 +455,7 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
@@ -160,7 +160,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -238,7 +238,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -398,7 +398,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -598,7 +598,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -622,7 +622,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isSoulbound
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
@@ -202,7 +202,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -352,7 +352,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 
@@ -416,7 +416,7 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -240,7 +240,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
@@ -87,7 +87,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -263,7 +263,7 @@ Used to retrieve the immediate owner of the given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
@@ -157,7 +157,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -354,7 +354,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -504,7 +504,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isSoulbound
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
@@ -202,7 +202,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -352,7 +352,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isContributor
 
@@ -472,7 +472,7 @@ Returns the address of the current owner.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
@@ -175,7 +175,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -372,7 +372,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -544,7 +544,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
@@ -181,7 +181,7 @@ Used to grant approvals for specific tokens to a specified address.
 function balanceOf(address owner) external view returns (uint256)
 ```
 
-Used to retrieve the number of tokens in ``owner``&#39;s account.
+Used to retrieve the number of tokens in `owner`&#39;s account.
 
 
 
@@ -259,7 +259,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childIsInActive
 
@@ -419,7 +419,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -641,7 +641,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -665,7 +665,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating whether the child token is equipped into the given token or not |
+| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### mint
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedExternalEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedExternalEquippableMock.md
@@ -127,7 +127,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -389,7 +389,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
@@ -220,7 +220,7 @@ Used to retrieve IDs of the active assets of given token.
 function getApproved(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the account approved to manage given token.
+Used to retrieve the account approved to manage given token.
 
 *Requirements:  - `tokenId` must exist.*
 
@@ -415,7 +415,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The boolean value indicating wehter the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### mint
 
@@ -457,7 +457,7 @@ Used to retrieve the collection name.
 function ownerOf(uint256 tokenId) external view returns (address)
 ```
 
-Used to retireve the owner of the given token.
+Used to retrieve the owner of the given token.
 
 *Requirements:  - `tokenId` must exist.*
 

--- a/test/extensions/multiAssetAutoIndex.ts
+++ b/test/extensions/multiAssetAutoIndex.ts
@@ -16,7 +16,7 @@ async function multiAssetAutoIndexFixture() {
   return token;
 }
 
-describe('RMRKMultiAssetAutoIndexMock', async function () {
+describe.only('RMRKMultiAssetAutoIndexMock', async function () {
   let token: RMRKMultiAssetAutoIndexMock;
   let owner: SignerWithAddress;
   let user: SignerWithAddress;

--- a/test/extensions/multiAssetAutoIndex.ts
+++ b/test/extensions/multiAssetAutoIndex.ts
@@ -16,7 +16,7 @@ async function multiAssetAutoIndexFixture() {
   return token;
 }
 
-describe.only('RMRKMultiAssetAutoIndexMock', async function () {
+describe('RMRKMultiAssetAutoIndexMock', async function () {
   let token: RMRKMultiAssetAutoIndexMock;
   let owner: SignerWithAddress;
   let user: SignerWithAddress;

--- a/test/extensions/multiAssetAutoIndex.ts
+++ b/test/extensions/multiAssetAutoIndex.ts
@@ -1,0 +1,145 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { bn } from '../utils';
+import { IERC165, IRMRKMultiAsset, IRMRKMultiAssetAutoIndex, IOtherInterface } from '../interfaces';
+import { RMRKMultiAssetAutoIndexMock } from '../../typechain-types';
+
+// --------------- FIXTURES -----------------------
+
+async function multiAssetAutoIndexFixture() {
+  const factory = await ethers.getContractFactory('RMRKMultiAssetAutoIndexMock');
+  const token = await factory.deploy('Chunky', 'CHNK');
+  await token.deployed();
+
+  return token;
+}
+
+describe('RMRKMultiAssetAutoIndexMock', async function () {
+  let token: RMRKMultiAssetAutoIndexMock;
+  let owner: SignerWithAddress;
+  let user: SignerWithAddress;
+  let tokenId = bn(1);
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+    token = await loadFixture(multiAssetAutoIndexFixture);
+  });
+
+  it('can support IERC165', async function () {
+    expect(await token.supportsInterface(IERC165)).to.equal(true);
+  });
+
+  it('can support IRMRKMultiAsset', async function () {
+    expect(await token.supportsInterface(IRMRKMultiAsset)).to.equal(true);
+  });
+
+  it('can support IRMRKMultiAssetAutoIndex', async function () {
+    expect(await token.supportsInterface(IRMRKMultiAssetAutoIndex)).to.equal(true);
+  });
+
+  it('does not support other interfaces', async function () {
+    expect(await token.supportsInterface(IOtherInterface)).to.equal(false);
+  });
+
+  describe('With minted tokens', async function () {
+    const assetId = bn(1);
+
+    beforeEach(async function () {
+      await token.mint(user.address, tokenId);
+      await token.addAssetEntry(assetId, 'ipfs/something.json');
+      await token.addAssetToToken(tokenId, assetId, 0);
+    });
+
+    it('can accept an asset', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([assetId]);
+    });
+
+    it('can reject an asset', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+  });
+
+  describe('With multiple assets in the pending list', async function () {
+    const asseOneId = bn(1);
+    const assetTwoId = bn(2);
+    const assetThreeId = bn(3);
+
+    beforeEach(async function () {
+      await token.connect(owner).addAssetEntry(asseOneId, 'ipfs/asset1.json');
+      await token.connect(owner).addAssetToToken(tokenId, asseOneId, 0);
+      await token.connect(owner).addAssetEntry(assetTwoId, 'ipfs/asset2.json');
+      await token.addAssetToToken(tokenId, assetTwoId, 0);
+      await token.connect(owner).addAssetEntry(assetThreeId, 'ipfs/asset3.json');
+      await token.addAssetToToken(tokenId, assetThreeId, 0);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([bn(1), bn(2), bn(3)]);
+    });
+
+    it('can reject a middle asset in the pending list', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([bn(1), bn(3)]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+
+    it('can accept a middle asset in the pending list', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([asseOneId, assetThreeId]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([assetTwoId]);
+    });
+
+    it('can reject first asset in the pending list', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, asseOneId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([assetThreeId, assetTwoId]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+
+    it('can accept first asset in the pending list', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, asseOneId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([assetThreeId, assetTwoId]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([asseOneId]);
+    });
+
+    it('can reject all assets in the pending list', async function () {
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, asseOneId);
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetThreeId);
+      await token.connect(user)['rejectAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([]);
+    });
+
+    it('can accept all assets in the pending list', async function () {
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, asseOneId);
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetThreeId);
+      await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
+      expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+      expect(await token.getActiveAssets(tokenId)).to.be.eql([asseOneId, assetThreeId, assetTwoId]);
+    });
+
+    describe('With multiple assets in the active list', async function () {
+      const assetFourId = bn(4);
+
+      beforeEach(async function () {
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, asseOneId);
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetThreeId);
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetTwoId);
+      });
+
+      it('can replace the first active asset', async function () {
+        await token.connect(owner).addAssetEntry(assetFourId, 'ipfs/asset4.json');
+        await token.connect(owner).addAssetToToken(tokenId, assetFourId, asseOneId);
+        await token.connect(user)['acceptAsset(uint256,uint64)'](tokenId, assetFourId);
+        expect(await token.getPendingAssets(tokenId)).to.be.eql([]);
+        expect(await token.getActiveAssets(tokenId)).to.be.eql([
+          assetFourId,
+          assetThreeId,
+          assetTwoId,
+        ]);
+      });
+    });
+  });
+});

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -10,6 +10,7 @@ const IRMRKExternalEquip = '0x289dfee5';
 const IRMRKMultiAsset = '0xd1526708';
 const IRMRKNestable = '0x42b0e56f';
 const IRMRKNestableAutoIndex = '0x1884d52d';
+const IRMRKMultiAssetAutoIndex = '0x1cf132fe';
 const IRMRKNestableExternalEquip = '0x8b7f3e99';
 const IRMRKReclaimableChild = '0x2fb59acf';
 const IRMRKSoulbound = '0x911ec470';
@@ -29,6 +30,7 @@ export {
   IRMRKMultiAsset,
   IRMRKNestable,
   IRMRKNestableAutoIndex,
+  IRMRKMultiAssetAutoIndex,
   IRMRKNestableExternalEquip,
   IRMRKReclaimableChild,
   IRMRKSoulbound,


### PR DESCRIPTION
# Description

Implements MultiAsset AutoIndex extension. Recreates docs and fixes bug on MultiAsset hooks. Some where calling using `uint256` for assetId instead of `uint64`

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
