### PR TITLE
Removes allowance check on ERC20Pay versions since transfer will fail…

### DIFF
--- a/contracts/implementations/erc20Pay/RMRKErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKErc20Pay.sol
@@ -5,8 +5,6 @@ pragma solidity ^0.8.16;
 import "../../RMRK/utils/IERC20.sol";
 import "./IRMRKErc20Pay.sol";
 
-error RMRKNotEnoughAllowance();
-
 /**
  * @title RMRKNestable
  * @author RMRK team
@@ -34,8 +32,6 @@ abstract contract RMRKErc20Pay is IRMRKErc20Pay {
         address to,
         uint256 value
     ) internal virtual {
-        if (IERC20(_erc20TokenAddress).allowance(from, to) < value)
-            revert RMRKNotEnoughAllowance();
         IERC20(_erc20TokenAddress).transferFrom(from, to, value);
     }
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -2178,17 +2178,6 @@ Attempting to interact with a token without being its owner or having been grant
 *When a token is nested, only the direct owner (NFT parent) can mange it. In that case, approved addresses are  not allowed to manage it, in order to ensure the expected behaviour*
 
 
-### RMRKNotEnoughAllowance
-
-```solidity
-error RMRKNotEnoughAllowance()
-```
-
-
-
-
-
-
 ### RMRKNotEquipped
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -1413,17 +1413,6 @@ Attempting to manage an asset without owning it or having been granted permissio
 
 
 
-### RMRKNotEnoughAllowance
-
-```solidity
-error RMRKNotEnoughAllowance()
-```
-
-
-
-
-
-
 ### RMRKNotOwner
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -1382,17 +1382,6 @@ Attempting to interact with a token without being its owner or having been grant
 *When a token is nested, only the direct owner (NFT parent) can mange it. In that case, approved addresses are  not allowed to manage it, in order to ensure the expected behaviour*
 
 
-### RMRKNotEnoughAllowance
-
-```solidity
-error RMRKNotEnoughAllowance()
-```
-
-
-
-
-
-
 ### RMRKNotOwner
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -1909,17 +1909,6 @@ Attempting to interact with a token without being its owner or having been grant
 *When a token is nested, only the direct owner (NFT parent) can mange it. In that case, approved addresses are  not allowed to manage it, in order to ensure the expected behaviour*
 
 
-### RMRKNotEnoughAllowance
-
-```solidity
-error RMRKNotEnoughAllowance()
-```
-
-
-
-
-
-
 ### RMRKNotOwner
 
 ```solidity

--- a/test/implementations/lazyMintErc20Pay.ts
+++ b/test/implementations/lazyMintErc20Pay.ts
@@ -117,9 +117,8 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
 
     await erc20.mint(addrs[0].address, ONE_ETH);
     await erc20.approve(this.token.address, HALF_ETH);
-    await expect(this.token.mint(addrs[0].address, 1)).to.be.revertedWithCustomError(
-      this.token,
-      'RMRKNotEnoughAllowance',
+    await expect(this.token.mint(addrs[0].address, 1)).to.be.revertedWith(
+      'ERC20: insufficient allowance',
     );
   });
 
@@ -160,9 +159,9 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(10);
     expect(await this.token.balanceOf(addrs[0].address)).to.equal(10);
 
-    await expect(
-      this.token.connect(addrs[0]).mint(addrs[0].address, 1),
-    ).to.be.revertedWithCustomError(this.token, 'RMRKNotEnoughAllowance');
+    await expect(this.token.connect(addrs[0]).mint(addrs[0].address, 1)).to.be.revertedWith(
+      'ERC20: insufficient allowance',
+    );
   });
 
   describe('Nest minting', async () => {


### PR DESCRIPTION
# Description

The transfer call will fail anyway and we save 0.177 in the ERC20Pay implementations

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
