### PR TITLE
Includes toZero parameter on the ChildTransferred event

### DIFF
--- a/contracts/RMRK/nestable/IRMRKNestable.sol
+++ b/contracts/RMRK/nestable/IRMRKNestable.sol
@@ -91,7 +91,7 @@ interface IRMRKNestable is IERC165 {
      * @param childId ID of the child token in the child token's collection smart contract
      * @param fromPending A boolean value signifying whether the token was in the pending child tokens array (`true`) or
      *  in the active child tokens array (`false`)
-     * @param toZero A boolean value signifying whether the token is being transferred to the address zero (`true`) or
+     * @param toZero A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or
      *  not (`false`)
      */
     event ChildTransferred(

--- a/contracts/RMRK/nestable/IRMRKNestable.sol
+++ b/contracts/RMRK/nestable/IRMRKNestable.sol
@@ -91,13 +91,16 @@ interface IRMRKNestable is IERC165 {
      * @param childId ID of the child token in the child token's collection smart contract
      * @param fromPending A boolean value signifying whether the token was in the pending child tokens array (`true`) or
      *  in the active child tokens array (`false`)
+     * @param toZero A boolean value signifying whether the token is being transferred to the address zero (`true`) or
+     *  not (`false`)
      */
     event ChildTransferred(
         uint256 indexed tokenId,
         uint256 childIndex,
         address indexed childAddress,
         uint256 indexed childId,
-        bool fromPending
+        bool fromPending,
+        bool toZero
     );
 
     /**

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -1123,7 +1123,8 @@ contract RMRKNestable is Context, IERC165, IERC721, IRMRKNestable, RMRKCore {
             childIndex,
             childAddress,
             childId,
-            isPending
+            isPending,
+            to == address(0)
         );
         _afterTransferChild(
             tokenId,

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -1188,7 +1188,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1204,6 +1204,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -1188,7 +1188,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1204,6 +1204,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/RMRK/equippable/RMRKNestableExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKNestableExternalEquip.md
@@ -671,7 +671,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -687,6 +687,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### EquippableAddressSet
 

--- a/docs/RMRK/equippable/RMRKNestableExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKNestableExternalEquip.md
@@ -671,7 +671,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -687,6 +687,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### EquippableAddressSet
 

--- a/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
@@ -389,7 +389,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -405,6 +405,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
@@ -389,7 +389,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -405,6 +405,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -671,7 +671,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -687,6 +687,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -671,7 +671,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -687,6 +687,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
+++ b/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
@@ -649,7 +649,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -665,6 +665,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
+++ b/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
@@ -649,7 +649,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -665,6 +665,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/RMRK/nestable/IRMRKNestable.md
+++ b/docs/RMRK/nestable/IRMRKNestable.md
@@ -365,7 +365,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
-| toZero  | bool | A boolean value signifying whether the token is being transferred to the address zero (`true`) or  not (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/RMRK/nestable/IRMRKNestable.md
+++ b/docs/RMRK/nestable/IRMRKNestable.md
@@ -349,7 +349,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -365,6 +365,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the address zero (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/RMRK/nestable/RMRKNestable.md
+++ b/docs/RMRK/nestable/RMRKNestable.md
@@ -631,7 +631,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -647,6 +647,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/RMRK/nestable/RMRKNestable.md
+++ b/docs/RMRK/nestable/RMRKNestable.md
@@ -631,7 +631,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -647,6 +647,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -1013,7 +1013,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1029,6 +1029,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -1013,7 +1013,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1029,6 +1029,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -1580,7 +1580,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1596,6 +1596,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -1580,7 +1580,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1596,6 +1596,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -923,7 +923,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -939,6 +939,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -923,7 +923,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -939,6 +939,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -1362,7 +1362,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1378,6 +1378,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -1362,7 +1362,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1378,6 +1378,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -1632,7 +1632,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1648,6 +1648,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -1632,7 +1632,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1648,6 +1648,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -975,7 +975,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -991,6 +991,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -975,7 +975,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -991,6 +991,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -1414,7 +1414,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1430,6 +1430,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -1414,7 +1414,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1430,6 +1430,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -1615,7 +1615,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1631,6 +1631,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -1615,7 +1615,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1631,6 +1631,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -1014,7 +1014,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1030,6 +1030,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -1014,7 +1014,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1030,6 +1030,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -958,7 +958,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -974,6 +974,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -958,7 +958,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -974,6 +974,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -1397,7 +1397,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1413,6 +1413,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -1397,7 +1397,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1413,6 +1413,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -1615,7 +1615,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1631,6 +1631,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -1615,7 +1615,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1631,6 +1631,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -958,7 +958,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -974,6 +974,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -958,7 +958,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -974,6 +974,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -1397,7 +1397,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1413,6 +1413,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### ContributorUpdate
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -1397,7 +1397,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1413,6 +1413,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### ContributorUpdate
 

--- a/docs/mocks/RMRKEquippableMock.md
+++ b/docs/mocks/RMRKEquippableMock.md
@@ -1314,7 +1314,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1330,6 +1330,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/RMRKEquippableMock.md
+++ b/docs/mocks/RMRKEquippableMock.md
@@ -1314,7 +1314,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1330,6 +1330,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/RMRKNestableAutoIndexMock.md
+++ b/docs/mocks/RMRKNestableAutoIndexMock.md
@@ -706,7 +706,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -722,6 +722,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/RMRKNestableAutoIndexMock.md
+++ b/docs/mocks/RMRKNestableAutoIndexMock.md
@@ -706,7 +706,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -722,6 +722,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/RMRKNestableExternalEquipMock.md
+++ b/docs/mocks/RMRKNestableExternalEquipMock.md
@@ -792,7 +792,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -808,6 +808,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### EquippableAddressSet
 

--- a/docs/mocks/RMRKNestableExternalEquipMock.md
+++ b/docs/mocks/RMRKNestableExternalEquipMock.md
@@ -792,7 +792,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -808,6 +808,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### EquippableAddressSet
 

--- a/docs/mocks/RMRKNestableMock.md
+++ b/docs/mocks/RMRKNestableMock.md
@@ -759,7 +759,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -775,6 +775,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/RMRKNestableMock.md
+++ b/docs/mocks/RMRKNestableMock.md
@@ -759,7 +759,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -775,6 +775,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/RMRKNestableMultiAssetMock.md
+++ b/docs/mocks/RMRKNestableMultiAssetMock.md
@@ -1153,7 +1153,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1169,6 +1169,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/RMRKNestableMultiAssetMock.md
+++ b/docs/mocks/RMRKNestableMultiAssetMock.md
@@ -1153,7 +1153,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1169,6 +1169,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
+++ b/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
@@ -777,7 +777,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -793,6 +793,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
+++ b/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
@@ -777,7 +777,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -793,6 +793,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
@@ -1336,7 +1336,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1352,6 +1352,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
@@ -1336,7 +1336,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1352,6 +1352,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
@@ -814,7 +814,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -830,6 +830,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### EquippableAddressSet
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
@@ -814,7 +814,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -830,6 +830,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### EquippableAddressSet
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
@@ -781,7 +781,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -797,6 +797,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
@@ -781,7 +781,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -797,6 +797,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
@@ -1175,7 +1175,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1191,6 +1191,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
@@ -1175,7 +1175,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1191,6 +1191,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
@@ -1193,7 +1193,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1209,6 +1209,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
@@ -1193,7 +1193,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1209,6 +1209,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
@@ -1357,7 +1357,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1373,6 +1373,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | undefined |
 | childId `indexed` | uint256 | undefined |
 | fromPending  | bool | undefined |
+| toZero  | bool | undefined |
 
 ### NestTransfer
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
@@ -1357,7 +1357,7 @@ Used to notify listeners that a new token has been added to a given token&#39;s 
 ### ChildTransferred
 
 ```solidity
-event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending)
+event ChildTransferred(uint256 indexed tokenId, uint256 childIndex, address indexed childAddress, uint256 indexed childId, bool fromPending, bool toZero)
 ```
 
 Used to notify listeners a child token has been transferred from parent token.
@@ -1373,6 +1373,7 @@ Used to notify listeners a child token has been transferred from parent token.
 | childAddress `indexed` | address | Address of the child token&#39;s collection smart contract |
 | childId `indexed` | uint256 | ID of the child token in the child token&#39;s collection smart contract |
 | fromPending  | bool | A boolean value signifying whether the token was in the pending child tokens array (`true`) or  in the active child tokens array (`false`) |
+| toZero  | bool | A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or  not (`false`) |
 
 ### NestTransfer
 

--- a/test/behavior/nestable.ts
+++ b/test/behavior/nestable.ts
@@ -506,7 +506,7 @@ async function shouldBehaveLikeNestable(
           .transferChild(parentId, tokenOwner.address, 0, 0, child.address, childId, false, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId, false);
+        .withArgs(parentId, 0, child.address, childId, false, false);
 
       await checkChildMovedToRootOwner();
     });
@@ -519,9 +519,22 @@ async function shouldBehaveLikeNestable(
           .transferChild(parentId, toOwnerAddress, 0, 0, child.address, childId, false, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId, false);
+        .withArgs(parentId, 0, child.address, childId, false, false);
 
       await checkChildMovedToRootOwner(toOwnerAddress);
+    });
+
+    it('can transfer child to address zero (remove child)', async function () {
+      const newOwnerAddress = addrs[2].address;
+      const newParentId = await mint(parent, newOwnerAddress);
+      await expect(
+        parent
+          .connect(tokenOwner)
+          .transferChild(parentId, ADDRESS_ZERO, 0, 0, child.address, childId, false, '0x'),
+      )
+        .to.emit(parent, 'ChildTransferred')
+        .withArgs(parentId, 0, child.address, childId, false, true);
+      expect(await parent.childrenOf(parentId)).to.eql([]);
     });
 
     it('can transfer child to another NFT', async function () {
@@ -542,7 +555,7 @@ async function shouldBehaveLikeNestable(
           ),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId, false);
+        .withArgs(parentId, 0, child.address, childId, false, false);
 
       expect(await child.ownerOf(childId)).to.eql(newOwnerAddress);
       expect(await child.directOwnerOf(childId)).to.eql([parent.address, bn(newParentId), true]);
@@ -673,7 +686,7 @@ async function shouldBehaveLikeNestable(
           .transferChild(parentId, tokenOwner.address, 0, 0, child.address, childId, true, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId, true);
+        .withArgs(parentId, 0, child.address, childId, true, false);
 
       await checkChildMovedToRootOwner();
     });
@@ -686,9 +699,20 @@ async function shouldBehaveLikeNestable(
           .transferChild(parentId, toOwnerAddress, 0, 0, child.address, childId, true, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId, true);
+        .withArgs(parentId, 0, child.address, childId, true, false);
 
       await checkChildMovedToRootOwner(toOwnerAddress);
+    });
+
+    it('can transfer child to address zero (reject child)', async function () {
+      await expect(
+        parent
+          .connect(tokenOwner)
+          .transferChild(parentId, ADDRESS_ZERO, 0, 0, child.address, childId, true, '0x'),
+      )
+        .to.emit(parent, 'ChildTransferred')
+        .withArgs(parentId, 0, child.address, childId, true, true);
+      expect(await parent.pendingChildrenOf(parentId)).to.eql([]);
     });
 
     it('can transfer child to another NFT', async function () {
@@ -709,7 +733,7 @@ async function shouldBehaveLikeNestable(
           ),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId, true);
+        .withArgs(parentId, 0, child.address, childId, true, false);
 
       expect(await child.ownerOf(childId)).to.eql(newOwnerAddress);
       expect(await child.directOwnerOf(childId)).to.eql([parent.address, bn(newParentId), true]);


### PR DESCRIPTION
# Description

Includes `toZero` parameter on the `ChildTransferred` event.
This is needed for indexers to identify if a child was removed or rejected, since `NestTransfer` event only emits when address is not 0.

# Actions

- Adds `toZero` on `ChildTransferred` Event
- Updates nestable tests which where checking for the event and args
- Adds test cases for removing and rejecting a child.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
