### PR TITLE
Implements BulkWriterPerCollection contract.

### DIFF
--- a/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
@@ -3,6 +3,10 @@
 pragma solidity ^0.8.18;
 
 import "../equippable/IRMRKEquippable.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+error RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
+error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
 
 /**
  * @title RMRKBulkWriterPerCollection
@@ -14,18 +18,24 @@ contract RMRKBulkWriterPerCollection {
     /**
      * @notice Used to provide a struct for inputing unequip data.
      * @dev Only used for input and not storage of data
-     * @return tokenId ID of the token we are managing
      * @return assetId ID of the asset that we are equipping into
      * @return slotPartId ID of the slot part that we are using to unequip
      */
     struct IntakeUnequip {
-        uint256 tokenId;
         uint64 assetId;
         uint64 slotPartId;
     }
 
     /// Address of the collection that this contract is managing
     address private _collection;
+
+    /**
+     * @notice Reverts if the caller is not the owner of the token
+     */
+    modifier onlyTokenOwner(uint256 tokenId) {
+        _checkTokenOwner(tokenId);
+        _;
+    }
 
     /**
      * @notice Initializes the contract by setting the collection
@@ -39,7 +49,7 @@ contract RMRKBulkWriterPerCollection {
      * @notice Returns the address of the collection that this contract is managing
      * @return Address of the collection that this contract is managing
      */
-    function getCollection() external view returns (address) {
+    function getCollection() public view returns (address) {
         return _collection;
     }
 
@@ -55,7 +65,9 @@ contract RMRKBulkWriterPerCollection {
      *  ]
      * @param data An `IntakeEquip` struct specifying the equip data.
      */
-    function replaceEquip(IRMRKEquippable.IntakeEquip memory data) external {
+    function replaceEquip(
+        IRMRKEquippable.IntakeEquip memory data
+    ) public onlyTokenOwner(data.tokenId) {
         IRMRKEquippable(_collection).unequip(
             data.tokenId,
             data.assetId,
@@ -65,11 +77,12 @@ contract RMRKBulkWriterPerCollection {
     }
 
     /**
-     * @notice Permorms multiple unequip and equip operations
+     * @notice Performs multiple unequip and equip operations
      * @dev Unequip operations must run first
-     * @dev The `IntakeUnquip` stuct contains the following data:
+     * @dev tokenId is included as a parameter to be able to do a single check for ownership
+     * @dev Every tokenId in the `IntakeEquip` structs must match the tokenId passed in
+     * @dev The `IntakeUnequip` stuct contains the following data:
      *  [
-     *      tokenId,
      *      assetId,
      *      slotPartId,
      *  ]
@@ -81,24 +94,41 @@ contract RMRKBulkWriterPerCollection {
      *      slotPartId,
      *      childAssetId
      *  ]
+     * @param tokenId ID of the token we are managing.
      * @param unequips[] An array of `IntakeUnequip` structs specifying the slots to unequip.
      * @param equips[] An array of `IntakeEquip` structs specifying the slots to equip.
      */
     function bulkEquip(
+        uint256 tokenId,
         IntakeUnequip[] memory unequips,
         IRMRKEquippable.IntakeEquip[] memory equips
-    ) external {
+    ) public onlyTokenOwner(tokenId) {
         uint256 length = unequips.length;
         for (uint256 i = 0; i < length; i++) {
             IRMRKEquippable(_collection).unequip(
-                unequips[i].tokenId,
+                tokenId,
                 unequips[i].assetId,
                 unequips[i].slotPartId
             );
         }
         length = equips.length;
         for (uint256 i = 0; i < length; i++) {
+            if (equips[i].tokenId != tokenId) {
+                revert RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
+            }
             IRMRKEquippable(_collection).equip(equips[i]);
+        }
+    }
+
+    /**
+     * @notice Checks if the caller is the owner of the token
+     * @dev Reverts if the caller is not the owner of the token
+     * @param tokenId ID of the token we are managing.
+     */
+    function _checkTokenOwner(uint256 tokenId) internal view {
+        address tokenOwner = IERC721(_collection).ownerOf(tokenId);
+        if (tokenOwner != msg.sender) {
+            revert RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
         }
     }
 }

--- a/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.18;
+
+import "../equippable/IRMRKEquippable.sol";
+
+/**
+ * @title RMRKBulkWriterPerCollection
+ * @author RMRK team
+ * @notice Smart contract of the RMRK Bulk Writer per collection module.
+ * @dev Extra utility functions for RMRK contracts.
+ */
+contract RMRKBulkWriterPerCollection {
+    /**
+     * @notice Used to provide a struct for inputing unequip data.
+     * @dev Only used for input and not storage of data
+     * @return tokenId ID of the token we are managing
+     * @return assetId ID of the asset that we are equipping into
+     * @return slotPartId ID of the slot part that we are using to unequip
+     */
+    struct IntakeUnequip {
+        uint256 tokenId;
+        uint64 assetId;
+        uint64 slotPartId;
+    }
+
+    /// Address of the collection that this contract is managing
+    address private _collection;
+
+    /**
+     * @notice Initializes the contract by setting the collection
+     * @param collection Address of the collection that this contract is managing.
+     */
+    constructor(address collection) {
+        _collection = collection;
+    }
+
+    /**
+     * @notice Returns the address of the collection that this contract is managing
+     * @return Address of the collection that this contract is managing
+     */
+    function getCollection() external view returns (address) {
+        return _collection;
+    }
+
+    /**
+     * @notice Replaces the current equipped child on the asset and slot combination with the given one
+     * @dev The `IntakeEquip` stuct contains the following data:
+     *  [
+     *      tokenId,
+     *      childIndex,
+     *      assetId,
+     *      slotPartId,
+     *      childAssetId
+     *  ]
+     * @param data An `IntakeEquip` struct specifying the equip data.
+     */
+    function replaceEquip(IRMRKEquippable.IntakeEquip memory data) external {
+        IRMRKEquippable(_collection).unequip(
+            data.tokenId,
+            data.assetId,
+            data.slotPartId
+        );
+        IRMRKEquippable(_collection).equip(data);
+    }
+
+    /**
+     * @notice Permorms multiple unequip and equip operations
+     * @dev Unequip operations must run first
+     * @dev The `IntakeUnquip` stuct contains the following data:
+     *  [
+     *      tokenId,
+     *      assetId,
+     *      slotPartId,
+     *  ]
+     * @dev The `IntakeEquip` stuct contains the following data:
+     *  [
+     *      tokenId,
+     *      childIndex,
+     *      assetId,
+     *      slotPartId,
+     *      childAssetId
+     *  ]
+     * @param unequips[] An array of `IntakeUnequip` structs specifying the slots to unequip.
+     * @param equips[] An array of `IntakeEquip` structs specifying the slots to equip.
+     */
+    function bulkEquip(
+        IntakeUnequip[] memory unequips,
+        IRMRKEquippable.IntakeEquip[] memory equips
+    ) external {
+        uint256 length = unequips.length;
+        for (uint256 i = 0; i < length; i++) {
+            IRMRKEquippable(_collection).unequip(
+                unequips[i].tokenId,
+                unequips[i].assetId,
+                unequips[i].slotPartId
+            );
+        }
+        length = equips.length;
+        for (uint256 i = 0; i < length; i++) {
+            IRMRKEquippable(_collection).equip(equips[i]);
+        }
+    }
+}

--- a/docs/RMRK/utils/RMRKBulkWriterPerCollection.md
+++ b/docs/RMRK/utils/RMRKBulkWriterPerCollection.md
@@ -13,7 +13,7 @@ Smart contract of the RMRK Bulk Writer per collection module.
 ### bulkEquip
 
 ```solidity
-function bulkEquip(RMRKBulkWriterPerCollection.IntakeUnequip[] unequips, IRMRKEquippable.IntakeEquip[] equips) external nonpayable
+function bulkEquip(uint256 tokenId, RMRKBulkWriterPerCollection.IntakeUnequip[] unequips, IRMRKEquippable.IntakeEquip[] equips) external nonpayable
 ```
 
 
@@ -24,6 +24,7 @@ function bulkEquip(RMRKBulkWriterPerCollection.IntakeUnequip[] unequips, IRMRKEq
 
 | Name | Type | Description |
 |---|---|---|
+| tokenId | uint256 | undefined |
 | unequips | RMRKBulkWriterPerCollection.IntakeUnequip[] | undefined |
 | equips | IRMRKEquippable.IntakeEquip[] | undefined |
 
@@ -59,6 +60,31 @@ function replaceEquip(IRMRKEquippable.IntakeEquip data) external nonpayable
 | Name | Type | Description |
 |---|---|---|
 | data | IRMRKEquippable.IntakeEquip | undefined |
+
+
+
+
+## Errors
+
+### RMRKCanOnlyDoBulkOperationsOnOwnedTokens
+
+```solidity
+error RMRKCanOnlyDoBulkOperationsOnOwnedTokens()
+```
+
+
+
+
+
+
+### RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime
+
+```solidity
+error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime()
+```
+
+
+
 
 
 

--- a/docs/RMRK/utils/RMRKBulkWriterPerCollection.md
+++ b/docs/RMRK/utils/RMRKBulkWriterPerCollection.md
@@ -1,0 +1,65 @@
+# RMRKBulkWriterPerCollection
+
+*RMRK team*
+
+> RMRKBulkWriterPerCollection
+
+Smart contract of the RMRK Bulk Writer per collection module.
+
+*Extra utility functions for RMRK contracts.*
+
+## Methods
+
+### bulkEquip
+
+```solidity
+function bulkEquip(RMRKBulkWriterPerCollection.IntakeUnequip[] unequips, IRMRKEquippable.IntakeEquip[] equips) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| unequips | RMRKBulkWriterPerCollection.IntakeUnequip[] | undefined |
+| equips | IRMRKEquippable.IntakeEquip[] | undefined |
+
+### getCollection
+
+```solidity
+function getCollection() external view returns (address)
+```
+
+Returns the address of the collection that this contract is managing
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | Address of the collection that this contract is managing |
+
+### replaceEquip
+
+```solidity
+function replaceEquip(IRMRKEquippable.IntakeEquip data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| data | IRMRKEquippable.IntakeEquip | undefined |
+
+
+
+

--- a/test/bulkWriter.ts
+++ b/test/bulkWriter.ts
@@ -1,0 +1,254 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { ADDRESS_ZERO, bn, mintFromMock, nestMintFromMock } from './utils';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import {
+  RMRKCatalogMock,
+  RMRKEquippableMock,
+  RMRKBulkWriterPerCollection,
+} from '../typechain-types';
+import {
+  assetForGemAFull,
+  assetForGemALeft,
+  assetForGemAMid,
+  assetForGemARight,
+  assetForGemBFull,
+  assetForGemBLeft,
+  assetForGemBMid,
+  assetForGemBRight,
+  assetForKanariaFull,
+  slotIdGemLeft,
+  slotIdGemMid,
+  slotIdGemRight,
+  setUpCatalog,
+  setUpKanariaAsset,
+  setUpGemAssets,
+} from './kanariaUtils';
+
+// --------------- FIXTURES -----------------------
+
+async function bulkWriterFixture() {
+  const catalogFactory = await ethers.getContractFactory('RMRKCatalogMock');
+  const equipFactory = await ethers.getContractFactory('RMRKEquippableMock');
+  const bulkWriterFactory = await ethers.getContractFactory('RMRKBulkWriterPerCollection');
+
+  const catalog = <RMRKCatalogMock>await catalogFactory.deploy('ipfs://catalog.json', 'misc');
+
+  const kanaria = <RMRKEquippableMock>await equipFactory.deploy('Kanaria', 'KAN');
+  kanaria.deployed();
+
+  const gem = <RMRKEquippableMock>await equipFactory.deploy('Kanaria Gem', 'KGEM');
+  gem.deployed();
+
+  const bulkWriter = <RMRKBulkWriterPerCollection>await bulkWriterFactory.deploy(kanaria.address);
+  await bulkWriter.deployed();
+
+  return { catalog, kanaria, gem, bulkWriter };
+}
+
+describe('Advanced Equip Render Utils', async function () {
+  let owner: SignerWithAddress;
+  let catalog: RMRKCatalogMock;
+  let kanaria: RMRKEquippableMock;
+  let gem: RMRKEquippableMock;
+  let bulkWriter: RMRKBulkWriterPerCollection;
+  let kanariaId: number;
+  let gemId1: number;
+  let gemId2: number;
+  let gemId3: number;
+
+  beforeEach(async function () {
+    ({ catalog, kanaria, gem, bulkWriter } = await loadFixture(bulkWriterFixture));
+    [owner] = await ethers.getSigners();
+
+    kanariaId = await mintFromMock(kanaria, owner.address);
+    gemId1 = await nestMintFromMock(gem, kanaria.address, kanariaId);
+    gemId2 = await nestMintFromMock(gem, kanaria.address, kanariaId);
+    gemId3 = await nestMintFromMock(gem, kanaria.address, kanariaId);
+    await kanaria.acceptChild(kanariaId, 0, gem.address, gemId1);
+    await kanaria.acceptChild(kanariaId, 1, gem.address, gemId2);
+    await kanaria.acceptChild(kanariaId, 0, gem.address, gemId3);
+    await kanaria.setApprovalForAll(bulkWriter.address, true);
+
+    await setUpCatalog(catalog, gem.address);
+    await setUpKanariaAsset(kanaria, kanariaId, catalog.address);
+    await setUpGemAssets(gem, gemId1, gemId2, gemId3, kanaria.address, catalog.address);
+
+    await kanaria.equip({
+      tokenId: kanariaId,
+      childIndex: 0,
+      assetId: assetForKanariaFull,
+      slotPartId: slotIdGemLeft,
+      childAssetId: assetForGemALeft,
+    });
+  });
+
+  it('can get managed collection', async function () {
+    expect(await bulkWriter.getCollection()).to.equal(kanaria.address);
+  });
+
+  it('can replace equip', async function () {
+    await bulkWriter.replaceEquip({
+      tokenId: kanariaId,
+      childIndex: 1,
+      assetId: assetForKanariaFull,
+      slotPartId: slotIdGemLeft,
+      childAssetId: assetForGemALeft,
+    });
+
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemLeft)).to.eql([
+      bn(assetForKanariaFull),
+      bn(assetForGemALeft),
+      bn(gemId2),
+      gem.address,
+    ]);
+  });
+
+  it('can unequip and equip in bulk', async function () {
+    // On a single call we remove the gem from the first slot and add 2 gems on the other 2 slots
+    await bulkWriter.bulkEquip(
+      [
+        {
+          tokenId: kanariaId,
+          assetId: assetForKanariaFull,
+          slotPartId: slotIdGemLeft,
+        },
+      ],
+      [
+        {
+          tokenId: kanariaId,
+          childIndex: 1,
+          assetId: assetForKanariaFull,
+          slotPartId: slotIdGemMid,
+          childAssetId: assetForGemAMid,
+        },
+        {
+          tokenId: kanariaId,
+          childIndex: 2,
+          assetId: assetForKanariaFull,
+          slotPartId: slotIdGemRight,
+          childAssetId: assetForGemBRight,
+        },
+      ],
+    );
+
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemLeft)).to.eql([
+      bn(0),
+      bn(0),
+      bn(0),
+      ADDRESS_ZERO,
+    ]);
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemMid)).to.eql([
+      bn(assetForKanariaFull),
+      bn(assetForGemAMid),
+      bn(gemId2),
+      gem.address,
+    ]);
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemRight)).to.eql([
+      bn(assetForKanariaFull),
+      bn(assetForGemBRight),
+      bn(gemId3),
+      gem.address,
+    ]);
+  });
+
+  it('can use bulk with only unequip operations', async function () {
+    // On a single call we remove the gem from the first slot and add 2 gems on the other 2 slots
+    await bulkWriter.bulkEquip(
+      [
+        {
+          tokenId: kanariaId,
+          assetId: assetForKanariaFull,
+          slotPartId: slotIdGemLeft,
+        },
+      ],
+      [],
+    );
+
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemLeft)).to.eql([
+      bn(0),
+      bn(0),
+      bn(0),
+      ADDRESS_ZERO,
+    ]);
+  });
+
+  it('can use bulk with only equip operations', async function () {
+    // On a single call we remove the gem from the first slot and add 2 gems on the other 2 slots
+    await bulkWriter.bulkEquip(
+      [],
+      [
+        {
+          tokenId: kanariaId,
+          childIndex: 1,
+          assetId: assetForKanariaFull,
+          slotPartId: slotIdGemMid,
+          childAssetId: assetForGemAMid,
+        },
+        {
+          tokenId: kanariaId,
+          childIndex: 2,
+          assetId: assetForKanariaFull,
+          slotPartId: slotIdGemRight,
+          childAssetId: assetForGemBRight,
+        },
+      ],
+    );
+
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemLeft)).to.eql([
+      bn(assetForKanariaFull),
+      bn(assetForGemALeft),
+      bn(gemId1),
+      gem.address,
+    ]);
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemMid)).to.eql([
+      bn(assetForKanariaFull),
+      bn(assetForGemAMid),
+      bn(gemId2),
+      gem.address,
+    ]);
+    expect(await kanaria.getEquipment(kanariaId, catalog.address, slotIdGemRight)).to.eql([
+      bn(assetForKanariaFull),
+      bn(assetForGemBRight),
+      bn(gemId3),
+      gem.address,
+    ]);
+  });
+
+  it('cannot do operations if not writer is not approved', async function () {
+    await kanaria.setApprovalForAll(bulkWriter.address, false);
+
+    // On a single call we remove the gem from the first slot and add 2 gems on the other 2 slots
+    await expect(
+      bulkWriter.bulkEquip(
+        [
+          {
+            tokenId: kanariaId,
+            assetId: assetForKanariaFull,
+            slotPartId: slotIdGemLeft,
+          },
+        ],
+        [
+          {
+            tokenId: kanariaId,
+            childIndex: 1,
+            assetId: assetForKanariaFull,
+            slotPartId: slotIdGemMid,
+            childAssetId: assetForGemAMid,
+          },
+        ],
+      ),
+    ).to.be.revertedWithCustomError(kanaria, 'ERC721NotApprovedOrOwner');
+
+    await expect(
+      bulkWriter.replaceEquip({
+        tokenId: kanariaId,
+        childIndex: 1,
+        assetId: assetForKanariaFull,
+        slotPartId: slotIdGemLeft,
+        childAssetId: assetForGemALeft,
+      }),
+    ).to.be.revertedWithCustomError(kanaria, 'ERC721NotApprovedOrOwner');
+  });
+});

--- a/test/kanariaUtils.ts
+++ b/test/kanariaUtils.ts
@@ -1,0 +1,199 @@
+import { ethers } from 'hardhat';
+import { RMRKCatalogMock, RMRKEquippableMock } from '../typechain-types';
+
+// These refIds are used from the child's perspective, to group assets that can be equipped into a parent
+// With it, we avoid the need to do set it asset by asset
+const noEquippableGroup = 0;
+const equippableRefIdLeftGem = 1;
+const equippableRefIdMidGem = 2;
+const equippableRefIdRightGem = 3;
+
+const assetForGemAFull = 1;
+const assetForGemALeft = 2;
+const assetForGemAMid = 3;
+const assetForGemARight = 4;
+const assetForGemBFull = 5;
+const assetForGemBLeft = 6;
+const assetForGemBMid = 7;
+const assetForGemBRight = 8;
+const assetForKanariaFull = 9;
+
+const slotIdGemLeft = 1;
+const slotIdGemMid = 2;
+const slotIdGemRight = 3;
+
+async function setUpCatalog(catalog: RMRKCatalogMock, gemAddress: string): Promise<void> {
+  await catalog.addPartList([
+    {
+      // Gems slot 1
+      partId: slotIdGemLeft,
+      part: {
+        itemType: 1, // Slot
+        z: 4,
+        equippable: [gemAddress], // Only gems tokens can be equipped here
+        metadataURI: 'ipfs://metadataSlotGemLeft',
+      },
+    },
+    {
+      // Gems slot 2
+      partId: slotIdGemMid,
+      part: {
+        itemType: 1, // Slot
+        z: 4,
+        equippable: [gemAddress], // Only gems tokens can be equipped here
+        metadataURI: 'ipfs://metadataSlotGemMid',
+      },
+    },
+    {
+      // Gems slot 3
+      partId: slotIdGemRight,
+      part: {
+        itemType: 1, // Slot
+        z: 4,
+        equippable: [gemAddress], // Only gems tokens can be equipped here
+        metadataURI: 'ipfs://metadataSlotGemRight',
+      },
+    },
+  ]);
+}
+
+async function setUpKanariaAsset(
+  kanaria: RMRKEquippableMock,
+  kanariaId: number,
+  catalogAddress: string,
+): Promise<void> {
+  await kanaria.addEquippableAssetEntry(
+    assetForKanariaFull,
+    noEquippableGroup,
+    catalogAddress,
+    `ipfs://kanaria/full.svg`,
+    [slotIdGemLeft, slotIdGemMid, slotIdGemRight],
+  );
+  await kanaria.addAssetToToken(kanariaId, assetForKanariaFull, 0);
+  await kanaria.acceptAsset(kanariaId, 0, assetForKanariaFull);
+}
+
+async function setUpGemAssets(
+  gem: RMRKEquippableMock,
+  gemId1: number,
+  gemId2: number,
+  gemId3: number,
+  kanariaAddress: string,
+  catalogAddress: string,
+): Promise<void> {
+  const [owner] = await ethers.getSigners();
+  // We'll add 4 assets for each gem, a full version and 3 versions matching each slot.
+  // We will have only 2 types of gems -> 4x2: 8 assets.
+  // This is not composed by others, so fixed and slot parts are never used.
+  await gem.addEquippableAssetEntry(
+    assetForGemAFull,
+    noEquippableGroup,
+    catalogAddress,
+    `ipfs://gems/typeA/full.svg`,
+    [],
+  );
+  await gem.addEquippableAssetEntry(
+    assetForGemALeft,
+    equippableRefIdLeftGem,
+    catalogAddress,
+    `ipfs://gems/typeA/left.svg`,
+    [],
+  );
+  await gem.addEquippableAssetEntry(
+    assetForGemAMid,
+    equippableRefIdMidGem,
+    catalogAddress,
+    `ipfs://gems/typeA/mid.svg`,
+    [],
+  );
+  await gem.addEquippableAssetEntry(
+    assetForGemARight,
+    equippableRefIdRightGem,
+    catalogAddress,
+    `ipfs://gems/typeA/right.svg`,
+    [],
+  );
+  await gem.addEquippableAssetEntry(
+    assetForGemBFull,
+    noEquippableGroup,
+    catalogAddress,
+    `ipfs://gems/typeB/full.svg`,
+    [],
+  );
+  await gem.addEquippableAssetEntry(
+    assetForGemBLeft,
+    equippableRefIdLeftGem,
+    catalogAddress,
+    `ipfs://gems/typeB/left.svg`,
+    [],
+  );
+  await gem.addEquippableAssetEntry(
+    assetForGemBMid,
+    equippableRefIdMidGem,
+    catalogAddress,
+    `ipfs://gems/typeB/mid.svg`,
+    [],
+  );
+  await gem.addEquippableAssetEntry(
+    assetForGemBRight,
+    equippableRefIdRightGem,
+    catalogAddress,
+    `ipfs://gems/typeB/right.svg`,
+    [],
+  );
+
+  await gem.setValidParentForEquippableGroup(equippableRefIdLeftGem, kanariaAddress, slotIdGemLeft);
+  await gem.setValidParentForEquippableGroup(equippableRefIdMidGem, kanariaAddress, slotIdGemMid);
+  await gem.setValidParentForEquippableGroup(
+    equippableRefIdRightGem,
+    kanariaAddress,
+    slotIdGemRight,
+  );
+
+  // We add assets of type A to gem 1 and 2, and type Bto gem 3. Both are nested into the first kanaria
+  // This means gems 1 and 2 will have the same asset, which is totally valid.
+  await gem.addAssetToToken(gemId1, assetForGemAFull, 0);
+  await gem.addAssetToToken(gemId1, assetForGemALeft, 0);
+  await gem.addAssetToToken(gemId1, assetForGemAMid, 0);
+  await gem.addAssetToToken(gemId1, assetForGemARight, 0);
+  await gem.addAssetToToken(gemId2, assetForGemAFull, 0);
+  await gem.addAssetToToken(gemId2, assetForGemALeft, 0);
+  await gem.addAssetToToken(gemId2, assetForGemAMid, 0);
+  await gem.addAssetToToken(gemId2, assetForGemARight, 0);
+  await gem.addAssetToToken(gemId3, assetForGemBFull, 0);
+  await gem.addAssetToToken(gemId3, assetForGemBLeft, 0);
+  await gem.addAssetToToken(gemId3, assetForGemBMid, 0);
+  await gem.addAssetToToken(gemId3, assetForGemBRight, 0);
+
+  // We accept them backwards to easily know the right indices
+  await gem.acceptAsset(gemId1, 3, assetForGemARight);
+  await gem.acceptAsset(gemId1, 2, assetForGemAMid);
+  await gem.acceptAsset(gemId1, 1, assetForGemALeft);
+  await gem.acceptAsset(gemId1, 0, assetForGemAFull);
+  await gem.acceptAsset(gemId2, 3, assetForGemARight);
+  await gem.acceptAsset(gemId2, 2, assetForGemAMid);
+  await gem.acceptAsset(gemId2, 1, assetForGemALeft);
+  await gem.acceptAsset(gemId2, 0, assetForGemAFull);
+  await gem.acceptAsset(gemId3, 3, assetForGemBRight);
+  await gem.acceptAsset(gemId3, 2, assetForGemBMid);
+  await gem.acceptAsset(gemId3, 1, assetForGemBLeft);
+  await gem.acceptAsset(gemId3, 0, assetForGemBFull);
+}
+
+export {
+  assetForGemAFull,
+  assetForGemALeft,
+  assetForGemAMid,
+  assetForGemARight,
+  assetForGemBFull,
+  assetForGemBLeft,
+  assetForGemBMid,
+  assetForGemBRight,
+  assetForKanariaFull,
+  slotIdGemLeft,
+  slotIdGemMid,
+  slotIdGemRight,
+  setUpCatalog,
+  setUpKanariaAsset,
+  setUpGemAssets,
+};

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -10,12 +10,28 @@ import {
   RMRKEquipRenderUtils,
   RMRKMultiAssetRenderUtils,
 } from '../typechain-types';
-import { RMRKMultiAssetMock } from '../typechain-types';
-import { RMRKNestableMock } from '../typechain-types';
-import { RMRKNestableMultiAssetMock } from '../typechain-types';
-import { RMRKSoulboundNestableMock } from '../typechain-types';
-import { RMRKMultiAssetImplPreMint } from '../typechain-types';
-import { connected } from 'process';
+import {
+  RMRKMultiAssetMock,
+  RMRKNestableMock,
+  RMRKNestableMultiAssetMock,
+  RMRKSoulboundNestableMock,
+  RMRKMultiAssetImplPreMint,
+} from '../typechain-types';
+import {
+  assetForGemALeft,
+  assetForGemAMid,
+  assetForGemARight,
+  assetForGemBLeft,
+  assetForGemBMid,
+  assetForGemBRight,
+  assetForKanariaFull,
+  slotIdGemLeft,
+  slotIdGemMid,
+  slotIdGemRight,
+  setUpCatalog,
+  setUpKanariaAsset,
+  setUpGemAssets,
+} from './kanariaUtils';
 
 // --------------- FIXTURES -----------------------
 
@@ -265,27 +281,6 @@ describe('MultiAsset and Equip Render Utils', async function () {
     });
   });
 });
-
-// These refIds are used from the child's perspective, to group assets that can be equipped into a parent
-// With it, we avoid the need to do set it asset by asset
-const noEquippableGroup = 0;
-const equippableRefIdLeftGem = 1;
-const equippableRefIdMidGem = 2;
-const equippableRefIdRightGem = 3;
-
-const assetForGemAFull = 1;
-const assetForGemALeft = 2;
-const assetForGemAMid = 3;
-const assetForGemARight = 4;
-const assetForGemBFull = 5;
-const assetForGemBLeft = 6;
-const assetForGemBMid = 7;
-const assetForGemBRight = 8;
-const assetForKanariaFull = 9;
-
-const slotIdGemLeft = 1;
-const slotIdGemMid = 2;
-const slotIdGemRight = 3;
 
 describe('Advanced Equip Render Utils', async function () {
   let owner: SignerWithAddress;
@@ -794,164 +789,6 @@ describe('Extended NFT render utils', function () {
     expect(data.hasEquippableInterface).to.be.true;
   });
 });
-
-async function setUpCatalog(catalog: RMRKCatalogMock, gemAddress: string): Promise<void> {
-  await catalog.addPartList([
-    {
-      // Gems slot 1
-      partId: slotIdGemLeft,
-      part: {
-        itemType: 1, // Slot
-        z: 4,
-        equippable: [gemAddress], // Only gems tokens can be equipped here
-        metadataURI: 'ipfs://metadataSlotGemLeft',
-      },
-    },
-    {
-      // Gems slot 2
-      partId: slotIdGemMid,
-      part: {
-        itemType: 1, // Slot
-        z: 4,
-        equippable: [gemAddress], // Only gems tokens can be equipped here
-        metadataURI: 'ipfs://metadataSlotGemMid',
-      },
-    },
-    {
-      // Gems slot 3
-      partId: slotIdGemRight,
-      part: {
-        itemType: 1, // Slot
-        z: 4,
-        equippable: [gemAddress], // Only gems tokens can be equipped here
-        metadataURI: 'ipfs://metadataSlotGemRight',
-      },
-    },
-  ]);
-}
-
-async function setUpKanariaAsset(
-  kanaria: RMRKEquippableMock,
-  kanariaId: number,
-  catalogAddress: string,
-): Promise<void> {
-  await kanaria.addEquippableAssetEntry(
-    assetForKanariaFull,
-    noEquippableGroup,
-    catalogAddress,
-    `ipfs://kanaria/full.svg`,
-    [slotIdGemLeft, slotIdGemMid, slotIdGemRight],
-  );
-  await kanaria.addAssetToToken(kanariaId, assetForKanariaFull, 0);
-  await kanaria.acceptAsset(kanariaId, 0, assetForKanariaFull);
-}
-
-async function setUpGemAssets(
-  gem: RMRKEquippableMock,
-  gemId1: number,
-  gemId2: number,
-  gemId3: number,
-  kanariaAddress: string,
-  catalogAddress: string,
-): Promise<void> {
-  const [owner] = await ethers.getSigners();
-  // We'll add 4 assets for each gem, a full version and 3 versions matching each slot.
-  // We will have only 2 types of gems -> 4x2: 8 assets.
-  // This is not composed by others, so fixed and slot parts are never used.
-  await gem.addEquippableAssetEntry(
-    assetForGemAFull,
-    noEquippableGroup,
-    catalogAddress,
-    `ipfs://gems/typeA/full.svg`,
-    [],
-  );
-  await gem.addEquippableAssetEntry(
-    assetForGemALeft,
-    equippableRefIdLeftGem,
-    catalogAddress,
-    `ipfs://gems/typeA/left.svg`,
-    [],
-  );
-  await gem.addEquippableAssetEntry(
-    assetForGemAMid,
-    equippableRefIdMidGem,
-    catalogAddress,
-    `ipfs://gems/typeA/mid.svg`,
-    [],
-  );
-  await gem.addEquippableAssetEntry(
-    assetForGemARight,
-    equippableRefIdRightGem,
-    catalogAddress,
-    `ipfs://gems/typeA/right.svg`,
-    [],
-  );
-  await gem.addEquippableAssetEntry(
-    assetForGemBFull,
-    noEquippableGroup,
-    catalogAddress,
-    `ipfs://gems/typeB/full.svg`,
-    [],
-  );
-  await gem.addEquippableAssetEntry(
-    assetForGemBLeft,
-    equippableRefIdLeftGem,
-    catalogAddress,
-    `ipfs://gems/typeB/left.svg`,
-    [],
-  );
-  await gem.addEquippableAssetEntry(
-    assetForGemBMid,
-    equippableRefIdMidGem,
-    catalogAddress,
-    `ipfs://gems/typeB/mid.svg`,
-    [],
-  );
-  await gem.addEquippableAssetEntry(
-    assetForGemBRight,
-    equippableRefIdRightGem,
-    catalogAddress,
-    `ipfs://gems/typeB/right.svg`,
-    [],
-  );
-
-  await gem.setValidParentForEquippableGroup(equippableRefIdLeftGem, kanariaAddress, slotIdGemLeft);
-  await gem.setValidParentForEquippableGroup(equippableRefIdMidGem, kanariaAddress, slotIdGemMid);
-  await gem.setValidParentForEquippableGroup(
-    equippableRefIdRightGem,
-    kanariaAddress,
-    slotIdGemRight,
-  );
-
-  // We add assets of type A to gem 1 and 2, and type Bto gem 3. Both are nested into the first kanaria
-  // This means gems 1 and 2 will have the same asset, which is totally valid.
-  await gem.addAssetToToken(gemId1, assetForGemAFull, 0);
-  await gem.addAssetToToken(gemId1, assetForGemALeft, 0);
-  await gem.addAssetToToken(gemId1, assetForGemAMid, 0);
-  await gem.addAssetToToken(gemId1, assetForGemARight, 0);
-  await gem.addAssetToToken(gemId2, assetForGemAFull, 0);
-  await gem.addAssetToToken(gemId2, assetForGemALeft, 0);
-  await gem.addAssetToToken(gemId2, assetForGemAMid, 0);
-  await gem.addAssetToToken(gemId2, assetForGemARight, 0);
-  await gem.addAssetToToken(gemId3, assetForGemBFull, 0);
-  await gem.addAssetToToken(gemId3, assetForGemBLeft, 0);
-  await gem.addAssetToToken(gemId3, assetForGemBMid, 0);
-  await gem.addAssetToToken(gemId3, assetForGemBRight, 0);
-
-  // We accept them backwards to easily know the right indices
-  await gem.acceptAsset(gemId1, 3, assetForGemARight);
-  await gem.acceptAsset(gemId1, 2, assetForGemAMid);
-  await gem.acceptAsset(gemId1, 1, assetForGemALeft);
-  await gem.acceptAsset(gemId1, 0, assetForGemAFull);
-  await gem.acceptAsset(gemId2, 3, assetForGemARight);
-  await gem.acceptAsset(gemId2, 2, assetForGemAMid);
-  await gem.acceptAsset(gemId2, 1, assetForGemALeft);
-  await gem.acceptAsset(gemId2, 0, assetForGemAFull);
-  await gem.acceptAsset(gemId3, 3, assetForGemBRight);
-  await gem.acceptAsset(gemId3, 2, assetForGemBMid);
-  await gem.acceptAsset(gemId3, 1, assetForGemBLeft);
-  await gem.acceptAsset(gemId3, 0, assetForGemBFull);
-}
 
 describe('Render Utils', async function () {
   let owner: SignerWithAddress;


### PR DESCRIPTION
# Description

This contract is meant to exist 1 per NFT collection, the idea is to limit danger if the contract is somehow compromised. That however makes UX worse, since we need to deploy one per collection and users need to approve it too.

It's up for discussion

# Actions

- Implements replace equip
- Implements bulk equip

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
