### PR TITLE
Allows to set multiple tokenIds in AssetAddedToToken event

### DIFF
--- a/contracts/RMRK/multiasset/AbstractMultiAsset.sol
+++ b/contracts/RMRK/multiasset/AbstractMultiAsset.sol
@@ -320,7 +320,9 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
             _assetReplacements[tokenId][assetId] = replacesAssetWithId;
         }
 
-        emit AssetAddedToToken(tokenId, assetId, replacesAssetWithId);
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = tokenId;
+        emit AssetAddedToToken(tokenIds, assetId, replacesAssetWithId);
         _afterAddAssetToToken(tokenId, assetId, replacesAssetWithId);
     }
 

--- a/contracts/RMRK/multiasset/AbstractMultiAsset.sol
+++ b/contracts/RMRK/multiasset/AbstractMultiAsset.sol
@@ -295,7 +295,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
      * @dev If the asset ID is invalid, the execution will be reverted.
      * @dev If the token already has the maximum amount of pending assets (128), the execution will be
      *  reverted.
-     * @dev Emits ***AssetAddedToToken*** event.
+     * @dev Emits ***AssetAddedToTokens*** event.
      * @param tokenId ID of the token to add the asset to
      * @param assetId ID of the asset to add to the token
      * @param replacesAssetWithId ID of the asset to replace from the token's list of active assets
@@ -322,7 +322,7 @@ abstract contract AbstractMultiAsset is Context, IRMRKMultiAsset {
 
         uint256[] memory tokenIds = new uint256[](1);
         tokenIds[0] = tokenId;
-        emit AssetAddedToToken(tokenIds, assetId, replacesAssetWithId);
+        emit AssetAddedToTokens(tokenIds, assetId, replacesAssetWithId);
         _afterAddAssetToToken(tokenId, assetId, replacesAssetWithId);
     }
 

--- a/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
@@ -19,12 +19,12 @@ interface IRMRKMultiAsset is IERC165 {
     /**
      * @notice Used to notify listeners that an asset object at `assetId` is added to token's pending asset
      *  array.
-     * @param tokenId ID of the token that received a new pending asset
+     * @param tokenIds An array of token IDs that received a new pending asset
      * @param assetId ID of the asset that has been added to the token's pending assets array
      * @param replacesId ID of the asset that would be replaced
      */
     event AssetAddedToToken(
-        uint256 indexed tokenId,
+        uint256[] tokenIds,
         uint64 indexed assetId,
         uint64 indexed replacesId
     );

--- a/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/IRMRKMultiAsset.sol
@@ -23,7 +23,7 @@ interface IRMRKMultiAsset is IERC165 {
      * @param assetId ID of the asset that has been added to the token's pending assets array
      * @param replacesId ID of the asset that would be replaced
      */
-    event AssetAddedToToken(
+    event AssetAddedToTokens(
         uint256[] tokenIds,
         uint64 indexed assetId,
         uint64 indexed replacesId

--- a/docs/RMRK/equippable/IRMRKEquippable.md
+++ b/docs/RMRK/equippable/IRMRKEquippable.md
@@ -487,7 +487,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -498,7 +498,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/equippable/IRMRKExternalEquip.md
+++ b/docs/RMRK/equippable/IRMRKExternalEquip.md
@@ -504,7 +504,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -515,7 +515,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -1041,7 +1041,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1052,7 +1052,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/equippable/RMRKExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKExternalEquip.md
@@ -504,7 +504,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -515,7 +515,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
@@ -388,7 +388,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -399,7 +399,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
@@ -653,7 +653,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -664,7 +664,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/multiasset/AbstractMultiAsset.md
+++ b/docs/RMRK/multiasset/AbstractMultiAsset.md
@@ -354,7 +354,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -365,7 +365,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/multiasset/IRMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/IRMRKMultiAsset.md
@@ -354,7 +354,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -365,7 +365,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/multiasset/RMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/RMRKMultiAsset.md
@@ -619,7 +619,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -630,7 +630,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -908,7 +908,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -919,7 +919,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -1433,7 +1433,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1444,7 +1444,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -984,7 +984,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -995,7 +995,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -1257,7 +1257,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1268,7 +1268,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -1485,7 +1485,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1496,7 +1496,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -1018,7 +1018,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1029,7 +1029,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -1309,7 +1309,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1320,7 +1320,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -1468,7 +1468,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1479,7 +1479,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
@@ -731,7 +731,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -742,7 +742,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -1001,7 +1001,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1012,7 +1012,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -1292,7 +1292,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1303,7 +1303,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -1468,7 +1468,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1479,7 +1479,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -1001,7 +1001,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1012,7 +1012,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -1292,7 +1292,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1303,7 +1303,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/RMRKEquippableMock.md
+++ b/docs/mocks/RMRKEquippableMock.md
@@ -1167,7 +1167,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1178,7 +1178,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/RMRKExternalEquipMock.md
+++ b/docs/mocks/RMRKExternalEquipMock.md
@@ -576,7 +576,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -587,7 +587,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/RMRKMultiAssetAutoIndexMock.md
+++ b/docs/mocks/RMRKMultiAssetAutoIndexMock.md
@@ -705,7 +705,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -716,7 +716,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/RMRKMultiAssetMock.md
+++ b/docs/mocks/RMRKMultiAssetMock.md
@@ -739,7 +739,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -750,7 +750,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/RMRKNestableMultiAssetMock.md
+++ b/docs/mocks/RMRKNestableMultiAssetMock.md
@@ -1048,7 +1048,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1059,7 +1059,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
+++ b/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
@@ -677,7 +677,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -688,7 +688,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
@@ -778,7 +778,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -789,7 +789,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
@@ -800,7 +800,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -811,7 +811,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
@@ -1189,7 +1189,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1200,7 +1200,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
@@ -761,7 +761,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -772,7 +772,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
@@ -1070,7 +1070,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1081,7 +1081,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
@@ -861,7 +861,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -872,7 +872,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
@@ -1088,7 +1088,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1099,7 +1099,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
@@ -1210,7 +1210,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -1221,7 +1221,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedExternalEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedExternalEquippableMock.md
@@ -619,7 +619,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -630,7 +630,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
@@ -802,7 +802,7 @@ Used to notify listeners that an asset object at `assetId` is accepted by the to
 ### AssetAddedToToken
 
 ```solidity
-event AssetAddedToToken(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+event AssetAddedToToken(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
 ```
 
 Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
@@ -813,7 +813,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId `indexed` | uint256 | ID of the token that received a new pending asset |
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
 | assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
 | replacesId `indexed` | uint64 | ID of the asset that would be replaced |
 

--- a/test/behavior/equippableAssets.ts
+++ b/test/behavior/equippableAssets.ts
@@ -330,7 +330,7 @@ async function shouldBehaveLikeEquippableAssets(
       // Add new asset to replace the first, and accept
       await expect(chunkyEquip.addAssetToToken(tokenId, resId2, resId))
         .to.emit(chunkyEquip, 'AssetAddedToToken')
-        .withArgs(tokenId, resId2, resId);
+        .withArgs([tokenId], resId2, resId);
 
       expect(await chunkyEquip.getAssetReplacements(tokenId, resId2)).to.eql(resId);
       await expect(chunkyEquip.acceptAsset(tokenId, 0, resId2))

--- a/test/behavior/equippableAssets.ts
+++ b/test/behavior/equippableAssets.ts
@@ -168,11 +168,11 @@ async function shouldBehaveLikeEquippableAssets(
       await addAssets([resId, resId2]);
       await expect(chunkyEquip.addAssetToToken(tokenId, resId, 0)).to.emit(
         chunkyEquip,
-        'AssetAddedToToken',
+        'AssetAddedToTokens',
       );
       await expect(chunkyEquip.addAssetToToken(tokenId, resId2, 0)).to.emit(
         chunkyEquip,
-        'AssetAddedToToken',
+        'AssetAddedToTokens',
       );
 
       expect(await chunkyEquip.getPendingAssets(tokenId)).to.eql([resId, resId2]);
@@ -329,7 +329,7 @@ async function shouldBehaveLikeEquippableAssets(
 
       // Add new asset to replace the first, and accept
       await expect(chunkyEquip.addAssetToToken(tokenId, resId2, resId))
-        .to.emit(chunkyEquip, 'AssetAddedToToken')
+        .to.emit(chunkyEquip, 'AssetAddedToTokens')
         .withArgs([tokenId], resId2, resId);
 
       expect(await chunkyEquip.getAssetReplacements(tokenId, resId2)).to.eql(resId);

--- a/test/behavior/multiasset.ts
+++ b/test/behavior/multiasset.ts
@@ -52,7 +52,7 @@ async function shouldBehaveLikeMultiAsset(
       it('can add asset to token', async function () {
         const resId = await addAssetEntryFunc(this.token);
         await expect(addAssetToTokenFunc(this.token, tokenId, resId, 0))
-          .to.emit(this.token, 'AssetAddedToToken')
+          .to.emit(this.token, 'AssetAddedToTokens')
           .withArgs([tokenId], resId, 0);
       });
 
@@ -122,7 +122,7 @@ async function shouldBehaveLikeMultiAsset(
 
         // Add new asset to replace the first, and accept
         await expect(this.token.addAssetToToken(tokenId, resId3, resId2))
-          .to.emit(this.token, 'AssetAddedToToken')
+          .to.emit(this.token, 'AssetAddedToTokens')
           .withArgs([tokenId], resId3, resId2);
 
         expect(await this.token.getAssetReplacements(tokenId, resId3)).to.eql(resId2);

--- a/test/behavior/multiasset.ts
+++ b/test/behavior/multiasset.ts
@@ -53,7 +53,7 @@ async function shouldBehaveLikeMultiAsset(
         const resId = await addAssetEntryFunc(this.token);
         await expect(addAssetToTokenFunc(this.token, tokenId, resId, 0))
           .to.emit(this.token, 'AssetAddedToToken')
-          .withArgs(tokenId, resId, 0);
+          .withArgs([tokenId], resId, 0);
       });
 
       it('cannot add non existing asset to token', async function () {
@@ -123,7 +123,7 @@ async function shouldBehaveLikeMultiAsset(
         // Add new asset to replace the first, and accept
         await expect(this.token.addAssetToToken(tokenId, resId3, resId2))
           .to.emit(this.token, 'AssetAddedToToken')
-          .withArgs(tokenId, resId3, resId2);
+          .withArgs([tokenId], resId3, resId2);
 
         expect(await this.token.getAssetReplacements(tokenId, resId3)).to.eql(resId2);
         await expect(this.token.connect(tokenOwner).acceptAsset(tokenId, 0, resId3))

--- a/test/multiasset.ts
+++ b/test/multiasset.ts
@@ -124,8 +124,8 @@ describe('MultiAssetMock Other Behavior', async function () {
       const resId2 = await addAssetEntryFromMock(token, 'data2');
       const tokenId = await mintFromMock(token, tokenOwner.address);
 
-      await expect(token.addAssetToToken(tokenId, resId, 0)).to.emit(token, 'AssetAddedToToken');
-      await expect(token.addAssetToToken(tokenId, resId2, 0)).to.emit(token, 'AssetAddedToToken');
+      await expect(token.addAssetToToken(tokenId, resId, 0)).to.emit(token, 'AssetAddedToTokens');
+      await expect(token.addAssetToToken(tokenId, resId2, 0)).to.emit(token, 'AssetAddedToTokens');
 
       expect(await renderUtils.getPendingAssets(token.address, tokenId)).to.eql([
         [resId, bn(0), bn(0), 'data1'],


### PR DESCRIPTION
Warning: It increases the contract size by 0.129.

# Description

Changes the event parameter from `uint256 indexed tokenId` to `uint256 tokenIds[]`

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
