### PR TITLE
Uses memory parameters instead of calldata to receive partIds

### DIFF
--- a/contracts/RMRK/catalog/IRMRKCatalog.sol
+++ b/contracts/RMRK/catalog/IRMRKCatalog.sol
@@ -153,6 +153,6 @@ interface IRMRKCatalog is IERC165 {
      * @return An array of `Part` structs associated with given `partIds`
      */
     function getParts(
-        uint64[] calldata partIds
+        uint64[] memory partIds
     ) external view returns (Part[] memory);
 }

--- a/contracts/RMRK/catalog/RMRKCatalog.sol
+++ b/contracts/RMRK/catalog/RMRKCatalog.sol
@@ -262,7 +262,7 @@ contract RMRKCatalog is IRMRKCatalog {
      * @inheritdoc IRMRKCatalog
      */
     function getParts(
-        uint64[] calldata partIds
+        uint64[] memory partIds
     ) public view returns (Part[] memory) {
         uint256 numParts = partIds.length;
         Part[] memory parts = new Part[](numParts);

--- a/contracts/RMRK/equippable/IRMRKEquippable.sol
+++ b/contracts/RMRK/equippable/IRMRKEquippable.sol
@@ -189,6 +189,6 @@ interface IRMRKEquippable is IRMRKMultiAsset {
             string memory metadataURI,
             uint64 equippableGroupId,
             address catalogAddress,
-            uint64[] calldata partIds
+            uint64[] memory partIds
         );
 }

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -204,7 +204,7 @@ contract RMRKEquippable is
         uint64 equippableGroupId,
         address catalogAddress,
         string memory metadataURI,
-        uint64[] calldata partIds
+        uint64[] memory partIds
     ) internal virtual {
         _addAssetEntry(id, metadataURI);
 

--- a/contracts/RMRK/equippable/RMRKExternalEquip.sol
+++ b/contracts/RMRK/equippable/RMRKExternalEquip.sol
@@ -515,7 +515,7 @@ contract RMRKExternalEquip is
         uint64 equippableGroupId,
         address catalogAddress,
         string memory metadataURI,
-        uint64[] calldata partIds
+        uint64[] memory partIds
     ) internal {
         _addAssetEntry(id, metadataURI);
 

--- a/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
@@ -92,7 +92,7 @@ abstract contract RMRKAbstractEquippableImpl is
         uint64 equippableGroupId,
         address catalogAddress,
         string memory metadataURI,
-        uint64[] calldata partIds
+        uint64[] memory partIds
     ) public virtual onlyOwnerOrContributor returns (uint256) {
         unchecked {
             _totalAssets += 1;

--- a/contracts/implementations/nativeTokenPay/RMRKExternalEquipImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKExternalEquipImpl.sol
@@ -63,7 +63,7 @@ contract RMRKExternalEquipImpl is OwnableLock, RMRKExternalEquip {
         uint64 equippableGroupId,
         address catalogAddress,
         string memory metadataURI,
-        uint64[] calldata partIds
+        uint64[] memory partIds
     ) public virtual onlyOwnerOrContributor returns (uint256) {
         unchecked {
             _totalAssets += 1;


### PR DESCRIPTION
# Description

Any use case which builds the list of parts with code will be blocked otherwise, since this happens in the core implementation and all variables are private. The only workaround would be to modify the installed package which is a really bad practice.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
