### PR TITLE
Removes non reentrant guard from equipping.

### DIFF
--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -8,7 +8,6 @@ import "../catalog/IRMRKCatalog.sol";
 import "../library/RMRKLib.sol";
 import "../multiasset/AbstractMultiAsset.sol";
 import "../nestable/RMRKNestable.sol";
-import "../security/ReentrancyGuard.sol";
 import "./IRMRKEquippable.sol";
 
 /**
@@ -16,12 +15,7 @@ import "./IRMRKEquippable.sol";
  * @author RMRK team
  * @notice Smart contract of the RMRK Equippable module.
  */
-contract RMRKEquippable is
-    ReentrancyGuard,
-    RMRKNestable,
-    AbstractMultiAsset,
-    IRMRKEquippable
-{
+contract RMRKEquippable is RMRKNestable, AbstractMultiAsset, IRMRKEquippable {
     using RMRKLib for uint64[];
 
     // ------------------- ASSETS --------------
@@ -323,7 +317,7 @@ contract RMRKEquippable is
      */
     function equip(
         IntakeEquip memory data
-    ) public virtual onlyApprovedOrOwner(data.tokenId) nonReentrant {
+    ) public virtual onlyApprovedOrOwner(data.tokenId) {
         _equip(data);
     }
 
@@ -360,7 +354,8 @@ contract RMRKEquippable is
         );
 
         // Check from child perspective intention to be used in part
-        // We add reentrancy guard because of this call, it happens before updating state
+        // Ideally we would add reentrancy guard because of this call, since it happens before updating state
+        // However, impact is so low and contract size so tight that we decided to skip it.
         if (
             !IRMRKEquippable(child.contractAddress)
                 .canTokenBeEquippedWithAssetIntoSlot(

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -1668,15 +1668,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -2193,15 +2193,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -2311,15 +2311,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -2305,15 +2305,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -2294,15 +2294,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 

--- a/docs/mocks/RMRKEquippableMock.md
+++ b/docs/mocks/RMRKEquippableMock.md
@@ -1882,15 +1882,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
@@ -1915,15 +1915,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
@@ -1925,15 +1925,4 @@ Attempting to reject all pending children but children assets than expected are 
 
 
 
-### RentrantCall
-
-```solidity
-error RentrantCall()
-```
-
-
-
-
-
-
 


### PR DESCRIPTION
# Description

Ideally we would keep the reentrancy guard on equip since there's an external call before the state is updated.  However, impact is so low and contract size so tight that I propose to remove it. It saves 0.056 on contract size.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
