### PR TITLE
Royalties checks and improvements

### DIFF
--- a/contracts/RMRK/extension/RMRKRoyalties.sol
+++ b/contracts/RMRK/extension/RMRKRoyalties.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.18;
 
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import "../library/RMRKErrors.sol";
 
 /**
  * @title RMRKRoyalties
@@ -25,6 +26,7 @@ abstract contract RMRKRoyalties is IERC2981 {
         uint256 royaltyPercentageBps //in basis points
     ) {
         _setRoyaltyRecipient(royaltyRecipient);
+        if (royaltyPercentageBps >= 10000) revert RMRKRoyaltiesTooHigh();
         _royaltyPercentageBps = royaltyPercentageBps;
     }
 

--- a/contracts/RMRK/extension/RMRKRoyalties.sol
+++ b/contracts/RMRK/extension/RMRKRoyalties.sol
@@ -52,7 +52,7 @@ abstract contract RMRKRoyalties is IERC2981 {
      * @notice Used to retrieve the recipient of royalties.
      * @return Address of the recipient of royalties
      */
-    function getRoyaltyRecipient() external view virtual returns (address) {
+    function getRoyaltyRecipient() public view virtual returns (address) {
         return _royaltyRecipient;
     }
 
@@ -60,7 +60,7 @@ abstract contract RMRKRoyalties is IERC2981 {
      * @notice Used to retrieve the specified royalty percentage.
      * @return The royalty percentage expressed in the basis points
      */
-    function getRoyaltyPercentage() external view virtual returns (uint256) {
+    function getRoyaltyPercentage() public view virtual returns (uint256) {
         return _royaltyPercentageBps;
     }
 

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -141,3 +141,5 @@ error RMRKUnexpectedAssetId();
 error RMRKUnexpectedParent();
 /// Attempting not to pass an empty array of equippable addresses when adding or setting the equippable addresses
 error RMRKZeroLengthIdsPassed();
+/// Attempting to set the royalties to a value higher than 100% (10000 in base points)
+error RMRKRoyaltiesTooHigh();

--- a/docs/RMRK/extension/RMRKRoyalties.md
+++ b/docs/RMRK/extension/RMRKRoyalties.md
@@ -109,3 +109,17 @@ Used to update recipient of royalties.
 
 
 
+## Errors
+
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
+

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -2105,6 +2105,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKSlotAlreadyUsed
 
 ```solidity

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -1346,6 +1346,17 @@ Attempting to interact with a function without being the owner or contributor of
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -1276,6 +1276,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKUnexpectedChildId
 
 ```solidity

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -1825,6 +1825,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -2223,6 +2223,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKSlotAlreadyUsed
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -1435,6 +1435,17 @@ Attempting to interact with a function without being the owner or contributor of
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -1405,6 +1405,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKUnexpectedChildId
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -1943,6 +1943,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -2217,6 +2217,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKSlotAlreadyUsed
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -1429,6 +1429,17 @@ Attempting to interact with a function without being the owner or contributor of
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -1483,6 +1483,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKUnexpectedChildId
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -1399,6 +1399,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKUnexpectedChildId
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -1937,6 +1937,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -2206,6 +2206,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKSlotAlreadyUsed
 
 ```solidity

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -1418,6 +1418,17 @@ Attempting to interact with a function without being the owner or contributor of
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -1399,6 +1399,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKUnexpectedChildId
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -1926,6 +1926,17 @@ Attempting to interact with a pending child using an index greater than the size
 
 
 
+### RMRKRoyaltiesTooHigh
+
+```solidity
+error RMRKRoyaltiesTooHigh()
+```
+
+Attempting to set the royalties to a value higher than 100% (10000 in base points)
+
+
+
+
 ### RMRKTokenDoesNotHaveAsset
 
 ```solidity


### PR DESCRIPTION
# Description

Prevents deploying a contract with royalties over 100%
Also changes the getters from external to public.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
