### PR TITLE
Adds Equip render Utils: equippedChildrenOf

### DIFF
--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -536,8 +536,7 @@ contract RMRKEquipRenderUtils is
     }
 
     /**
-     * @notice Used to get the child's assets and slot parts pairs, identifying parts the said assets can be equipped into.
-     * @dev Reverts if child token is not owned by an NFT.
+     * @notice Used to get information about the current children equipped into a specific parent and asset.
      * @dev The full `IRMRKEquippable.Equipment` struct looks like this:
      *  [
      *       assetId

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -57,6 +57,30 @@ Used to compose the given equippables.
 | fixedParts | RMRKEquipRenderUtils.FixedPart[] | An array of fixed parts respresented by the `FixedPart` structs present on the asset |
 | slotParts | RMRKEquipRenderUtils.EquippedSlotPart[] | An array of slot parts represented by the `EquippedSlotPart` structs present on the asset |
 
+### equippedChildrenOf
+
+```solidity
+function equippedChildrenOf(address parentAddress, uint256 parentId, uint64 parentAssetId) external view returns (struct IRMRKEquippable.Equipment[] equippedChildren)
+```
+
+Used to get the child&#39;s assets and slot parts pairs, identifying parts the said assets can be equipped into.
+
+*Reverts if child token is not owned by an NFT.The full `IRMRKEquippable.Equipment` struct looks like this:  [       assetId       childAssetId       childId       childEquippableAddress  ]*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| parentAddress | address | Address of the parent token&#39;s smart contract |
+| parentId | uint256 | ID of the parent token |
+| parentAssetId | uint64 | ID of the target parent asset to use to equip the child |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| equippedChildren | IRMRKEquippable.Equipment[] | An array of `IRMRKEquippable.Equipment` structs containing the info  about the equipped children |
+
 ### getAllEquippableSlotsFromParent
 
 ```solidity
@@ -369,13 +393,13 @@ Used to get the pending assets of the given token.
 |---|---|---|
 | _0 | RMRKMultiAssetRenderUtils.PendingAsset[] | An array of PendingAssets present on the given token |
 
-### getSlotParts
+### getSlotPartsAndCatalog
 
 ```solidity
-function getSlotParts(address tokenAddress, uint256 tokenId, uint64 assetId) external view returns (uint64[] parentSlotPartIds)
+function getSlotPartsAndCatalog(address tokenAddress, uint256 tokenId, uint64 assetId) external view returns (uint64[] parentSlotPartIds, address catalogAddress)
 ```
 
-Used to retrieve the parent address and its slot part IDs for a given target child.
+Used to retrieve the parent address and its slot part IDs for a given target child, and the catalog of the parent asset.
 
 
 
@@ -392,6 +416,7 @@ Used to retrieve the parent address and its slot part IDs for a given target chi
 | Name | Type | Description |
 |---|---|---|
 | parentSlotPartIds | uint64[] | Array of slot part IDs of the parent token&#39;s asset |
+| catalogAddress | address | Address of the catalog the parent asset belongs to |
 
 ### getTopAsset
 

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -63,9 +63,9 @@ Used to compose the given equippables.
 function equippedChildrenOf(address parentAddress, uint256 parentId, uint64 parentAssetId) external view returns (struct IRMRKEquippable.Equipment[] equippedChildren)
 ```
 
-Used to get the child&#39;s assets and slot parts pairs, identifying parts the said assets can be equipped into.
+Used to get information about the current children equipped into a specific parent and asset.
 
-*Reverts if child token is not owned by an NFT.The full `IRMRKEquippable.Equipment` struct looks like this:  [       assetId       childAssetId       childId       childEquippableAddress  ]*
+*The full `IRMRKEquippable.Equipment` struct looks like this:  [       assetId       childAssetId       childId       childEquippableAddress  ]*
 
 #### Parameters
 

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -308,6 +308,33 @@ describe('Advanced Equip Render Utils', async function () {
     await kanaria.acceptChild(kanariaId, 0, gem.address, gemId3);
   });
 
+  it('can get equipped children from parent', async function () {
+    await setUpCatalog(catalog, gem.address);
+    await setUpKanariaAsset(kanaria, kanariaId, catalog.address);
+    await setUpGemAssets(gem, gemId1, gemId2, gemId3, kanaria.address, catalog.address);
+
+    await kanaria.equip({
+      tokenId: kanariaId,
+      childIndex: 0,
+      assetId: assetForKanariaFull,
+      slotPartId: slotIdGemLeft,
+      childAssetId: assetForGemALeft,
+    });
+    await kanaria.equip({
+      tokenId: kanariaId,
+      childIndex: 1,
+      assetId: assetForKanariaFull,
+      slotPartId: slotIdGemMid,
+      childAssetId: assetForGemAMid,
+    });
+    expect(
+      await renderUtilsEquip.equippedChildrenOf(kanaria.address, kanariaId, assetForKanariaFull),
+    ).to.eql([
+      [bn(assetForKanariaFull), bn(assetForGemALeft), bn(gemId1), gem.address],
+      [bn(assetForKanariaFull), bn(assetForGemAMid), bn(gemId2), gem.address],
+    ]);
+  });
+
   it('can get equippable slots from parent', async function () {
     await setUpCatalog(catalog, gem.address);
     await setUpKanariaAsset(kanaria, kanariaId, catalog.address);


### PR DESCRIPTION
# Description

Adds util to get information about the current children equipped into a specific parent and asset:
`RMRKEquipRenderUtils.equippedChildrenOf`

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
