### PR TITLE
Change return type in EmoteTracker

### DIFF
--- a/contracts/RMRK/extension/emotable/IRMRKEmoteTracker.sol
+++ b/contracts/RMRK/extension/emotable/IRMRKEmoteTracker.sol
@@ -48,14 +48,15 @@ interface IRMRKEmoteTracker is IERC165 {
      * @param collection Address of the collection smart contract containing the token being checked for emoji reaction
      * @param tokenId ID of the token being checked for emoji reaction
      * @param emoji The ASCII emoji code being checked for reaction
-     * @return A numeric value indicating whether the `emoter` has used the `emoji` on the token (`1`) or not (`0`)
+     * @return A boolean value indicating whether the `emoter` has used the `emoji` on the token (`true`) or not
+     *  (`false`)
      */
     function hasEmoterUsedEmote(
         address emoter,
         address collection,
         uint256 tokenId,
         bytes4 emoji
-    ) external view returns (uint256);
+    ) external view returns (bool);
 
     /**
      * @notice Used to emote or undo an emote on a token.

--- a/contracts/RMRK/extension/emotable/RMRKEmoteTracker.sol
+++ b/contracts/RMRK/extension/emotable/RMRKEmoteTracker.sol
@@ -37,8 +37,8 @@ abstract contract RMRKEmoteTracker is IRMRKEmoteTracker {
         address collection,
         uint256 tokenId,
         bytes4 emoji
-    ) public view returns (uint256) {
-        return _emotesUsedByEmoter[emoter][collection][tokenId][emoji];
+    ) public view returns (bool) {
+        return _emotesUsedByEmoter[emoter][collection][tokenId][emoji] == 1;
     }
 
     /**

--- a/docs/RMRK/extension/emotable/IRMRKEmoteTracker.md
+++ b/docs/RMRK/extension/emotable/IRMRKEmoteTracker.md
@@ -56,7 +56,7 @@ Used to get the number of emotes for a specific emoji on a token.
 ### hasEmoterUsedEmote
 
 ```solidity
-function hasEmoterUsedEmote(address emoter, address collection, uint256 tokenId, bytes4 emoji) external view returns (uint256)
+function hasEmoterUsedEmote(address emoter, address collection, uint256 tokenId, bytes4 emoji) external view returns (bool)
 ```
 
 Used to get the information on whether the specified address has used a specific emoji on a specific  token.
@@ -76,7 +76,7 @@ Used to get the information on whether the specified address has used a specific
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | A numeric value indicating whether the `emoter` has used the `emoji` on the token (`1`) or not (`0`) |
+| _0 | bool | A boolean value indicating whether the `emoter` has used the `emoji` on the token (`true`) or not  (`false`) |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/emotable/RMRKEmoteTracker.md
+++ b/docs/RMRK/extension/emotable/RMRKEmoteTracker.md
@@ -56,7 +56,7 @@ Used to get the number of emotes for a specific emoji on a token.
 ### hasEmoterUsedEmote
 
 ```solidity
-function hasEmoterUsedEmote(address emoter, address collection, uint256 tokenId, bytes4 emoji) external view returns (uint256)
+function hasEmoterUsedEmote(address emoter, address collection, uint256 tokenId, bytes4 emoji) external view returns (bool)
 ```
 
 Used to get the information on whether the specified address has used a specific emoji on a specific  token.
@@ -76,7 +76,7 @@ Used to get the information on whether the specified address has used a specific
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | A numeric value indicating whether the `emoter` has used the `emoji` on the token (`1`) or not (`0`) |
+| _0 | bool | A boolean value indicating whether the `emoter` has used the `emoji` on the token (`true`) or not  (`false`) |
 
 ### supportsInterface
 

--- a/docs/mocks/extensions/emotable/RMRKEmoteTrackerMock.md
+++ b/docs/mocks/extensions/emotable/RMRKEmoteTrackerMock.md
@@ -56,7 +56,7 @@ Used to get the number of emotes for a specific emoji on a token.
 ### hasEmoterUsedEmote
 
 ```solidity
-function hasEmoterUsedEmote(address emoter, address collection, uint256 tokenId, bytes4 emoji) external view returns (uint256)
+function hasEmoterUsedEmote(address emoter, address collection, uint256 tokenId, bytes4 emoji) external view returns (bool)
 ```
 
 Used to get the information on whether the specified address has used a specific emoji on a specific  token.
@@ -76,7 +76,7 @@ Used to get the information on whether the specified address has used a specific
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | A numeric value indicating whether the `emoter` has used the `emoji` on the token (`1`) or not (`0`) |
+| _0 | bool | A boolean value indicating whether the `emoter` has used the `emoji` on the token (`true`) or not  (`false`) |
 
 ### supportsInterface
 

--- a/test/extensions/emotable.ts
+++ b/test/extensions/emotable.ts
@@ -199,10 +199,10 @@ describe('RMRKEmoteTrackerMock', async function () {
       await emoteTracker.connect(addrs[0]).emote(tokenA.address, tokenId, emoji1, true);
       expect(
         await emoteTracker.hasEmoterUsedEmote(addrs[0].address, tokenA.address, tokenId, emoji1),
-      ).to.equal(bn(1));
+      ).to.be.true;
       expect(
         await emoteTracker.hasEmoterUsedEmote(addrs[0].address, tokenA.address, tokenId, emoji2),
-      ).to.equal(bn(0));
+      ).to.be.false;
     });
 
     it('does nothing if new state is the same as old state', async function () {


### PR DESCRIPTION
# Description

We agreed that the `hasEmoterUsedEmote` should return `bool`, but it was returning `uint256`. This PR fixes the issue.

# Actions

Changed the return type to ` bool`.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
