### PR TITLE
Fixes checking of events in some cases.

### DIFF
--- a/test/behavior/erc721.ts
+++ b/test/behavior/erc721.ts
@@ -115,7 +115,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
         });
 
         it('emits a Transfer event', async function () {
-          expect(receipt)
+          await expect(receipt)
             .to.emit(this.token, 'Transfer')
             .withArgs(owner.address, toWhom.address, tokenId);
         });
@@ -211,7 +211,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
           });
 
           it('emits only a transfer event', async function () {
-            expect(receipt)
+            await expect(receipt)
               .to.emit(this.token, 'Transfer')
               .withArgs(owner.address, owner.address, tokenId);
           });
@@ -330,7 +330,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
                 owner,
               );
 
-              expect(receipt)
+              await expect(receipt)
                 .to.emit(receiver, 'Received')
                 .withArgs(owner.address, owner.address, tokenId, data);
             });
@@ -343,7 +343,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
                 tokenId,
                 approved,
               );
-              expect(receipt)
+              await expect(receipt)
                 .to.emit(receiver, 'Received')
                 .withArgs(approved.address, owner.address, tokenId, data);
             });
@@ -586,7 +586,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
 
         const itEmitsApprovalEvent = function (address: string) {
           it('emits an approval event', async function () {
-            expect(receipt)
+            await expect(receipt)
               .to.emit(this.token, 'Approval')
               .withArgs(owner.address, address, tokenId);
           });
@@ -717,7 +717,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
             it('emits an approval event', async function () {
               const receipt = await this.token.setApprovalForAll(operator.address, true);
 
-              expect(receipt)
+              await expect(receipt)
                 .to.emit(this.token, 'ApprovalForAll')
                 .withArgs(owner.address, operator.address, true);
             });
@@ -739,7 +739,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
             it('emits an approval event', async function () {
               const receipt = await this.token.setApprovalForAll(operator.address, true);
 
-              expect(receipt)
+              await expect(receipt)
                 .to.emit(this.token, 'ApprovalForAll')
                 .withArgs(owner.address, operator.address, true);
             });
@@ -769,7 +769,7 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
             it('emits an approval event', async function () {
               const receipt = await this.token.setApprovalForAll(operator.address, true);
 
-              expect(receipt)
+              await expect(receipt)
                 .to.emit(this.token, 'ApprovalForAll')
                 .withArgs(owner.address, operator.address, true);
             });
@@ -832,8 +832,8 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
         receipt = await this.token['mint(address,uint256)'](owner.address, firstTokenId);
       });
 
-      it('emits a Transfer event', function () {
-        expect(receipt)
+      it('emits a Transfer event', async function () {
+        await expect(receipt)
           .to.emit(this.token, 'Transfer')
           .withArgs(ethers.constants.AddressZero, owner.address, firstTokenId);
       });
@@ -874,14 +874,14 @@ async function shouldBehaveLikeERC721(name: string, symbol: string) {
           receipt = await this.token['burn(uint256)'](firstTokenId);
         });
 
-        it('emits a Transfer event', function () {
-          expect(receipt)
+        it('emits a Transfer event', async function () {
+          await expect(receipt)
             .to.emit(this.token, 'Transfer')
             .withArgs(owner.address, ethers.constants.AddressZero, firstTokenId);
         });
 
-        it('emits an Approval event', function () {
-          expect(receipt)
+        it('emits an Approval event', async function () {
+          await expect(receipt)
             .to.emit(this.token, 'Approval')
             .withArgs(owner.address, ethers.constants.AddressZero, firstTokenId);
         });

--- a/test/externalEquip.ts
+++ b/test/externalEquip.ts
@@ -287,12 +287,12 @@ describe('ExternalEquippableMock Assets', async () => {
 
   describe('Linking', async function () {
     it('can set nestable/equippable addresses', async function () {
-      expect(await this.nestable.setEquippableAddress(ethers.constants.AddressZero))
+      await expect(this.nestable.setEquippableAddress(ethers.constants.AddressZero))
         .to.emit(this.nestable, 'EquippableAddressSet')
         .withArgs(this.equip.address, ethers.constants.AddressZero);
 
-      expect(await this.equip.setNestableAddress(ethers.constants.AddressZero))
-        .to.emit(this.equip, 'EquippableAddressSet')
+      await expect(this.equip.setNestableAddress(ethers.constants.AddressZero))
+        .to.emit(this.equip, 'NestableAddressSet')
         .withArgs(this.nestable.address, ethers.constants.AddressZero);
     });
 

--- a/test/multiasset.ts
+++ b/test/multiasset.ts
@@ -201,7 +201,7 @@ describe('MultiAssetMock Other Behavior', async function () {
       // Create array with 1000 consecutive numbers
       const tokenIds = Array.from(Array(3000).keys()).map((i) => i + 1);
       const resId = await addAssetEntryFromMock(token);
-      expect(await token.addAssetToTokensEventTest(tokenIds, resId, 0)).to.emit(
+      await expect(token.addAssetToTokensEventTest(tokenIds, resId, 0)).to.emit(
         token,
         'AssetAddedToTokens',
       );


### PR DESCRIPTION
Makes sure when checking for events that the `await` is behind the `expect`

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
