### PR TITLE
Renames RMRKMintUnderpriced error to RMRKWrongValueSent

### DIFF
--- a/contracts/implementations/nativeTokenPay/RMRKEquippableImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKEquippableImpl.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 
 import "../abstracts/RMRKAbstractEquippableImpl.sol";
 
-error RMRKMintUnderpriced();
+error RMRKWrongValueSent();
 
 /**
  * @title RMRKEquippableImpl
@@ -92,6 +92,6 @@ contract RMRKEquippableImpl is RMRKAbstractEquippableImpl {
      * @param value The expected amount to be received for the mint
      */
     function _charge(uint256 value) internal virtual override {
-        if (value != msg.value) revert RMRKMintUnderpriced();
+        if (value != msg.value) revert RMRKWrongValueSent();
     }
 }

--- a/contracts/implementations/nativeTokenPay/RMRKMultiAssetImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKMultiAssetImpl.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 
 import "./../abstracts/RMRKAbstractMultiAssetImpl.sol";
 
-error RMRKMintUnderpriced();
+error RMRKWrongValueSent();
 
 /**
  * @title RMRKMultiAssetImpl
@@ -58,7 +58,7 @@ contract RMRKMultiAssetImpl is RMRKAbstractMultiAssetImpl {
         if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
-        if (mintPriceRequired != msg.value) revert RMRKMintUnderpriced();
+        if (mintPriceRequired != msg.value) revert RMRKWrongValueSent();
 
         uint256 nextToken = _totalSupply + 1;
         unchecked {

--- a/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
@@ -9,7 +9,7 @@ import "../../RMRK/utils/RMRKMintingUtils.sol";
 import "../../RMRK/utils/RMRKTokenURI.sol";
 import "../IRMRKInitData.sol";
 
-error RMRKMintUnderpriced();
+error RMRKWrongValueSent();
 error RMRKMintZero();
 
 /**
@@ -118,7 +118,7 @@ contract RMRKNestableExternalEquipImpl is
         if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
-        if (mintPriceRequired != msg.value) revert RMRKMintUnderpriced();
+        if (mintPriceRequired != msg.value) revert RMRKWrongValueSent();
 
         uint256 nextToken = _totalSupply + 1;
         unchecked {

--- a/contracts/implementations/nativeTokenPay/RMRKNestableImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKNestableImpl.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 
 import "../abstracts/RMRKAbstractNestableImpl.sol";
 
-error RMRKMintUnderpriced();
+error RMRKWrongValueSent();
 
 /**
  * @title RMRKNestableImpl
@@ -92,6 +92,6 @@ contract RMRKNestableImpl is RMRKAbstractNestableImpl {
      * @param value The expected amount to be received for the mint
      */
     function _charge(uint256 value) internal virtual override {
-        if (value != msg.value) revert RMRKMintUnderpriced();
+        if (value != msg.value) revert RMRKWrongValueSent();
     }
 }

--- a/contracts/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.18;
 
 import "../abstracts/RMRKAbstractNestableMultiAssetImpl.sol";
 
-error RMRKMintUnderpriced();
+error RMRKWrongValueSent();
 
 /**
  * @title RMRKNestableMultiAssetImpl
@@ -92,6 +92,6 @@ contract RMRKNestableMultiAssetImpl is RMRKAbstractNestableMultiAssetImpl {
      * @param value The expected amount to be received for the mint
      */
     function _charge(uint256 value) internal virtual override {
-        if (value != msg.value) revert RMRKMintUnderpriced();
+        if (value != msg.value) revert RMRKWrongValueSent();
     }
 }

--- a/test/behavior/mintingImpl.ts
+++ b/test/behavior/mintingImpl.ts
@@ -15,7 +15,7 @@ async function shouldControlValidMinting(): Promise<void> {
     const HALF_ETH = ethers.utils.parseEther('0.05');
     await expect(
       this.token.mint(addrs[0].address, 1, { value: HALF_ETH }),
-    ).to.be.revertedWithCustomError(this.token, 'RMRKMintUnderpriced');
+    ).to.be.revertedWithCustomError(this.token, 'RMRKWrongValueSent');
   });
 
   it('cannot mint 0 units', async function () {

--- a/test/implementations/lazyMintNativeTokenPay.ts
+++ b/test/implementations/lazyMintNativeTokenPay.ts
@@ -113,7 +113,7 @@ async function shouldControlValidMintingNativeTokenPay(): Promise<void> {
     const HALF_ETH = ethers.utils.parseEther('0.05');
     await expect(
       this.token.mint(addrs[0].address, 1, { value: HALF_ETH }),
-    ).to.be.revertedWithCustomError(this.token, 'RMRKMintUnderpriced');
+    ).to.be.revertedWithCustomError(this.token, 'RMRKWrongValueSent');
   });
 
   it('cannot mint 0 units', async function () {

--- a/test/implementations/multiasset.ts
+++ b/test/implementations/multiasset.ts
@@ -68,10 +68,10 @@ describe('MultiAssetImpl Other Behavior', async () => {
 
       await expect(
         token.connect(owner).mint(owner.address, 1, { value: ONE_ETH.div(2) }),
-      ).to.be.revertedWithCustomError(token, 'RMRKMintUnderpriced');
+      ).to.be.revertedWithCustomError(token, 'RMRKWrongValueSent');
       await expect(
         token.connect(owner).mint(owner.address, 1, { value: 0 }),
-      ).to.be.revertedWithCustomError(token, 'RMRKMintUnderpriced');
+      ).to.be.revertedWithCustomError(token, 'RMRKWrongValueSent');
     });
 
     it('can mint multiple tokens through sale logic', async function () {
@@ -80,10 +80,10 @@ describe('MultiAssetImpl Other Behavior', async () => {
       expect(await token.balanceOf(owner.address)).to.equal(10);
       await expect(
         token.connect(owner).mint(owner.address, 1, { value: ONE_ETH.div(2) }),
-      ).to.be.revertedWithCustomError(token, 'RMRKMintUnderpriced');
+      ).to.be.revertedWithCustomError(token, 'RMRKWrongValueSent');
       await expect(
         token.connect(owner).mint(owner.address, 1, { value: 0 }),
-      ).to.be.revertedWithCustomError(token, 'RMRKMintUnderpriced');
+      ).to.be.revertedWithCustomError(token, 'RMRKWrongValueSent');
     });
 
     it('auto accepts resource if send is token owner', async function () {


### PR DESCRIPTION
Error raises also if value is higher so it was misleading.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
