### PR TITLE
Implements new renderUtils getTopAssetMetadataForTokens and improves ExtendedNFT struct

### DIFF
--- a/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
@@ -173,6 +173,27 @@ contract RMRKMultiAssetRenderUtils {
     }
 
     /**
+     * @notice Used to retrieve the metadata URI of the specified token's asset with the highest priority for each of the given tokens.
+     * @param target Address of the smart contract of the given token
+     * @param tokenIds IDs of the tokens for which to retrieve the metadata URI
+     * @return metadata An array of strings with the top asset metadata for each the given tokens, in the same order of input
+     */
+    function getTopAssetMetadataForTokens(
+        address target,
+        uint256[] memory tokenIds
+    ) public view returns (string[] memory metadata) {
+        uint256 len = tokenIds.length;
+        metadata = new string[](len);
+
+        for (uint256 i; i < len; ) {
+            metadata[i] = getTopAssetMetaForToken(target, tokenIds[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
      * @notice Used to retrieve the ID of the specified token's asset with the highest priority.
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token for which to retrieve the ID of the asset with the highest priority

--- a/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
@@ -174,9 +174,9 @@ contract RMRKMultiAssetRenderUtils {
 
     /**
      * @notice Used to retrieve the metadata URI of the specified token's asset with the highest priority for each of the given tokens.
-     * @param target Address of the smart contract of the given token
-     * @param tokenIds IDs of the tokens for which to retrieve the metadata URI
-     * @return metadata An array of strings with the top asset metadata for each the given tokens, in the same order of input
+     * @param target Address of the smart contract of the tokens
+     * @param tokenIds IDs of the tokens for which to retrieve the metadata URIs
+     * @return metadata An array of strings with the top asset metadata for each of the given tokens, in the same order as the tokens passed in the `tokenIds` input array
      */
     function getTopAssetMetadataForTokens(
         address target,

--- a/contracts/RMRK/utils/RMRKRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKRenderUtils.sol
@@ -35,6 +35,8 @@ contract RMRKRenderUtils {
      * @return symbol Symbol of the collection the token belongs to
      * @return activeChildrenNumber Number of active child tokens of the given token (only account for direct child
      *  tokens)
+     * @return pendingChildrenNumber Number of pending child tokens of the given token (only account for direct child
+     *  tokens)
      * @return isSoulbound Boolean value signifying whether the token is soulbound or not
      * @return hasMultiAssetInterface Boolean value signifying whether the toke supports MultiAsset interface
      * @return hasNestingInterface Boolean value signifying whether the toke supports Nestable interface
@@ -53,6 +55,7 @@ contract RMRKRenderUtils {
         string name;
         string symbol;
         uint256 activeChildrenNumber;
+        uint256 pendingChildrenNumber;
         bool isSoulbound;
         bool hasMultiAssetInterface;
         bool hasNestingInterface;
@@ -120,6 +123,7 @@ contract RMRKRenderUtils {
      *      name,
      *      symbol,
      *      activeChildrenNumber,
+     *      pendingChildrenNumber,
      *      isSoulbound,
      *      hasMultiAssetInterface,
      *      hasNestingInterface,
@@ -146,6 +150,9 @@ contract RMRKRenderUtils {
         if (data.hasNestingInterface) {
             (data.directOwner, , ) = target.directOwnerOf(tokenId);
             data.activeChildrenNumber = target.childrenOf(tokenId).length;
+            data.pendingChildrenNumber = target
+                .pendingChildrenOf(tokenId)
+                .length;
         }
         if (data.hasMultiAssetInterface) {
             data.activeAssetCount = target.getActiveAssets(tokenId).length;

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -562,6 +562,29 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 |---|---|---|
 | _0 | string | The metadata URI of the asset with the highest priority |
 
+### getTopAssetMetadataForTokens
+
+```solidity
+function getTopAssetMetadataForTokens(address target, uint256[] tokenIds) external view returns (string[] metadata)
+```
+
+Used to retrieve the metadata URI of the specified token&#39;s asset with the highest priority for each of the given tokens.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| target | address | Address of the smart contract of the given token |
+| tokenIds | uint256[] | IDs of the tokens for which to retrieve the metadata URI |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| metadata | string[] | An array of strings with the top asset metadata for each the given tokens, in the same order of input |
+
 ### isAssetEquipped
 
 ```solidity

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -332,7 +332,7 @@ function getExtendedNft(uint256 tokenId, address targetCollection) external view
 
 Used to get extended information about a specified token.
 
-*The full `ExtendedNft` struct looks like this:  [      tokenMetadataUri,      directOwner,      rootOwner,      activeAssetCount,      pendingAssetCount      priorities,      maxSupply,      totalSupply,      issuer,      name,      symbol,      activeChildrenNumber,      isSoulbound,      hasMultiAssetInterface,      hasNestingInterface,      hasEquippableInterface  ]*
+*The full `ExtendedNft` struct looks like this:  [      tokenMetadataUri,      directOwner,      rootOwner,      activeAssetCount,      pendingAssetCount      priorities,      maxSupply,      totalSupply,      issuer,      name,      symbol,      activeChildrenNumber,      pendingChildrenNumber,      isSoulbound,      hasMultiAssetInterface,      hasNestingInterface,      hasEquippableInterface  ]*
 
 #### Parameters
 

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -576,14 +576,14 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 
 | Name | Type | Description |
 |---|---|---|
-| target | address | Address of the smart contract of the given token |
-| tokenIds | uint256[] | IDs of the tokens for which to retrieve the metadata URI |
+| target | address | Address of the smart contract of the tokens |
+| tokenIds | uint256[] | IDs of the tokens for which to retrieve the metadata URIs |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| metadata | string[] | An array of strings with the top asset metadata for each the given tokens, in the same order of input |
+| metadata | string[] | An array of strings with the top asset metadata for each of the given tokens, in the same order as the tokens passed in the `tokenIds` input array |
 
 ### isAssetEquipped
 

--- a/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
+++ b/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
@@ -166,14 +166,14 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 
 | Name | Type | Description |
 |---|---|---|
-| target | address | Address of the smart contract of the given token |
-| tokenIds | uint256[] | IDs of the tokens for which to retrieve the metadata URI |
+| target | address | Address of the smart contract of the tokens |
+| tokenIds | uint256[] | IDs of the tokens for which to retrieve the metadata URIs |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| metadata | string[] | An array of strings with the top asset metadata for each the given tokens, in the same order of input |
+| metadata | string[] | An array of strings with the top asset metadata for each of the given tokens, in the same order as the tokens passed in the `tokenIds` input array |
 
 
 

--- a/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
+++ b/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
@@ -152,6 +152,29 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 |---|---|---|
 | _0 | string | The metadata URI of the asset with the highest priority |
 
+### getTopAssetMetadataForTokens
+
+```solidity
+function getTopAssetMetadataForTokens(address target, uint256[] tokenIds) external view returns (string[] metadata)
+```
+
+Used to retrieve the metadata URI of the specified token&#39;s asset with the highest priority for each of the given tokens.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| target | address | Address of the smart contract of the given token |
+| tokenIds | uint256[] | IDs of the tokens for which to retrieve the metadata URI |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| metadata | string[] | An array of strings with the top asset metadata for each the given tokens, in the same order of input |
+
 
 
 

--- a/docs/RMRK/utils/RMRKRenderUtils.md
+++ b/docs/RMRK/utils/RMRKRenderUtils.md
@@ -18,7 +18,7 @@ function getExtendedNft(uint256 tokenId, address targetCollection) external view
 
 Used to get extended information about a specified token.
 
-*The full `ExtendedNft` struct looks like this:  [      tokenMetadataUri,      directOwner,      rootOwner,      activeAssetCount,      pendingAssetCount      priorities,      maxSupply,      totalSupply,      issuer,      name,      symbol,      activeChildrenNumber,      isSoulbound,      hasMultiAssetInterface,      hasNestingInterface,      hasEquippableInterface  ]*
+*The full `ExtendedNft` struct looks like this:  [      tokenMetadataUri,      directOwner,      rootOwner,      activeAssetCount,      pendingAssetCount      priorities,      maxSupply,      totalSupply,      issuer,      name,      symbol,      activeChildrenNumber,      pendingChildrenNumber,      isSoulbound,      hasMultiAssetInterface,      hasNestingInterface,      hasEquippableInterface  ]*
 
 #### Parameters
 

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -704,6 +704,7 @@ describe('Extended NFT render utils', function () {
     expect(data.name).to.eql('MultiAsset');
     expect(data.symbol).to.eql('MA');
     expect(data.activeChildrenNumber).to.eql(bn(0));
+    expect(data.pendingChildrenNumber).to.eql(bn(0));
     expect(data.isSoulbound).to.be.false;
     expect(data.hasMultiAssetInterface).to.be.true;
     expect(data.hasNestingInterface).to.be.false;
@@ -738,6 +739,7 @@ describe('Extended NFT render utils', function () {
     expect(data.name).to.eql('MultiAssetPreMint');
     expect(data.symbol).to.eql('MApM');
     expect(data.activeChildrenNumber).to.eql(bn(0));
+    expect(data.pendingChildrenNumber).to.eql(bn(0));
     expect(data.isSoulbound).to.be.false;
     expect(data.hasMultiAssetInterface).to.be.true;
     expect(data.hasNestingInterface).to.be.false;
@@ -771,6 +773,7 @@ describe('Extended NFT render utils', function () {
     expect(data.name).to.eql('Nestable');
     expect(data.symbol).to.eql('Ne');
     expect(data.activeChildrenNumber).to.eql(bn(2));
+    expect(data.pendingChildrenNumber).to.eql(bn(1));
     expect(data.isSoulbound).to.be.false;
     expect(data.hasMultiAssetInterface).to.be.false;
     expect(data.hasNestingInterface).to.be.true;
@@ -803,6 +806,7 @@ describe('Extended NFT render utils', function () {
     expect(data.name).to.eql('NestableSoulbound');
     expect(data.symbol).to.eql('NS');
     expect(data.activeChildrenNumber).to.eql(bn(2));
+    expect(data.pendingChildrenNumber).to.eql(bn(1));
     expect(data.isSoulbound).to.be.true;
     expect(data.hasMultiAssetInterface).to.be.false;
     expect(data.hasNestingInterface).to.be.true;
@@ -853,6 +857,7 @@ describe('Extended NFT render utils', function () {
     expect(data.name).to.eql('NestableMultiAsset');
     expect(data.symbol).to.eql('NMA');
     expect(data.activeChildrenNumber).to.eql(bn(2));
+    expect(data.pendingChildrenNumber).to.eql(bn(1));
     expect(data.isSoulbound).to.be.false;
     expect(data.hasMultiAssetInterface).to.be.true;
     expect(data.hasNestingInterface).to.be.true;
@@ -897,6 +902,7 @@ describe('Extended NFT render utils', function () {
     expect(data.name).to.eql('Equippable');
     expect(data.symbol).to.eql('EQ');
     expect(data.activeChildrenNumber).to.eql(bn(2));
+    expect(data.pendingChildrenNumber).to.eql(bn(1));
     expect(data.isSoulbound).to.be.false;
     expect(data.hasMultiAssetInterface).to.be.true;
     expect(data.hasNestingInterface).to.be.true;

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -526,6 +526,14 @@ describe('Advanced Equip Render Utils', async function () {
       [gem.address, BigNumber.from(gemId2), 'ipfs://gems/typeA/full.svg'],
       [gem.address, BigNumber.from(gemId3), 'ipfs://gems/typeB/right.svg'],
     ]);
+
+    expect(
+      await renderUtilsEquip.getTopAssetMetadataForTokens(gem.address, [gemId1, gemId2, gemId3]),
+    ).to.eql([
+      'ipfs://gems/typeA/left.svg',
+      'ipfs://gems/typeA/full.svg',
+      'ipfs://gems/typeB/right.svg',
+    ]);
   });
 
   it('can get equippable slots from parent for pending child', async function () {


### PR DESCRIPTION
- Adds getTopAssetMetadataForTokens. Used to retrieve the metadata URI of the specified token's asset with the highest priority for each of the given tokens.
- Adds pendingChildrenNumber to ExtendedNft struct.

# Checklist

- [X] Verified code additions
- [X] Updated NatSpec comments (if applicable)
- [X] Regenerated docs
- [X] Ran prettier
- [X] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new function `getTopAssetMetadataForTokens` to the `RMRKMultiAssetRenderUtils` contract and updates the `ExtendedNft` struct in `RMRKRenderUtils` to include `pendingChildrenNumber` field. It also adds tests to ensure everything works as expected.

### Detailed summary
- Adds `getTopAssetMetadataForTokens` function to `RMRKMultiAssetRenderUtils` contract
- Updates `ExtendedNft` struct in `RMRKRenderUtils` to include `pendingChildrenNumber`
- Adds tests to ensure everything works as expected

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->