### PR TITLE
Total Supply reduce

### DIFF
--- a/contracts/RMRK/utils/RMRKMintingUtils.sol
+++ b/contracts/RMRK/utils/RMRKMintingUtils.sol
@@ -12,6 +12,7 @@ import "../library/RMRKErrors.sol";
  * @dev Max supply-related and pricing variables are immutable after deployment.
  */
 contract RMRKMintingUtils is OwnableLock {
+    uint256 internal _nextId;
     uint256 internal _totalSupply;
     uint256 internal _maxSupply;
     uint256 internal immutable _pricePerMint;
@@ -93,6 +94,6 @@ contract RMRKMintingUtils is OwnableLock {
      * @dev In case the maximum supply of the collection is reached, the execution is reverted.
      */
     function _checkSaleIsOpen() private view {
-        if (_totalSupply >= _maxSupply) revert RMRKMintOverMax();
+        if (_nextId >= _maxSupply) revert RMRKMintOverMax();
     }
 }

--- a/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
@@ -36,16 +36,17 @@ abstract contract RMRKAbstractEquippableImpl is
      */
     function _preMint(uint256 numToMint) internal returns (uint256, uint256) {
         if (numToMint == uint256(0)) revert RMRKMintZero();
-        if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
+        if (numToMint + _nextId > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
         _charge(mintPriceRequired);
 
-        uint256 nextToken = _totalSupply + 1;
+        uint256 nextToken = _nextId + 1;
         unchecked {
+            _nextId += numToMint;
             _totalSupply += numToMint;
         }
-        uint256 totalSupplyOffset = _totalSupply + 1;
+        uint256 totalSupplyOffset = _nextId + 1;
 
         return (nextToken, totalSupplyOffset);
     }

--- a/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
@@ -158,4 +158,17 @@ abstract contract RMRKAbstractEquippableImpl is
     ) public virtual override onlyOwner {
         _setRoyaltyRecipient(newRoyaltyRecipient);
     }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (to == address(0)) {
+            unchecked {
+                _totalSupply -= 1;
+            }
+        }
+    }
 }

--- a/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
@@ -34,16 +34,17 @@ abstract contract RMRKAbstractNestableImpl is
         uint256 numToMint
     ) internal virtual returns (uint256, uint256) {
         if (numToMint == uint256(0)) revert RMRKMintZero();
-        if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
+        if (numToMint + _nextId > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
         _charge(mintPriceRequired);
 
-        uint256 nextToken = _totalSupply + 1;
+        uint256 nextToken = _nextId + 1;
         unchecked {
+            _nextId += numToMint;
             _totalSupply += numToMint;
         }
-        uint256 totalSupplyOffset = _totalSupply + 1;
+        uint256 totalSupplyOffset = _nextId + 1;
 
         return (nextToken, totalSupplyOffset);
     }

--- a/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
@@ -62,4 +62,17 @@ abstract contract RMRKAbstractNestableImpl is
     ) public virtual override onlyOwner {
         _setRoyaltyRecipient(newRoyaltyRecipient);
     }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (to == address(0)) {
+            unchecked {
+                _totalSupply -= 1;
+            }
+        }
+    }
 }

--- a/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
@@ -109,4 +109,17 @@ abstract contract RMRKAbstractNestableMultiAssetImpl is
     ) public override onlyOwner {
         _setRoyaltyRecipient(newRoyaltyRecipient);
     }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (to == address(0)) {
+            unchecked {
+                _totalSupply -= 1;
+            }
+        }
+    }
 }

--- a/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
@@ -34,16 +34,17 @@ abstract contract RMRKAbstractNestableMultiAssetImpl is
      */
     function _preMint(uint256 numToMint) internal returns (uint256, uint256) {
         if (numToMint == uint256(0)) revert RMRKMintZero();
-        if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
+        if (numToMint + _nextId > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
         _charge(mintPriceRequired);
 
-        uint256 nextToken = _totalSupply + 1;
+        uint256 nextToken = _nextId + 1;
         unchecked {
+            _nextId += numToMint;
             _totalSupply += numToMint;
         }
-        uint256 totalSupplyOffset = _totalSupply + 1;
+        uint256 totalSupplyOffset = _nextId + 1;
 
         return (nextToken, totalSupplyOffset);
     }

--- a/contracts/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.sol
@@ -55,15 +55,16 @@ contract RMRKMultiAssetImplErc20Pay is
      */
     function mint(address to, uint256 numToMint) public virtual notLocked {
         if (numToMint == uint256(0)) revert RMRKMintZero();
-        if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
+        if (numToMint + _nextId > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
         _chargeFromToken(msg.sender, address(this), mintPriceRequired);
-        uint256 nextToken = _totalSupply + 1;
+        uint256 nextToken = _nextId + 1;
         unchecked {
+            _nextId += numToMint;
             _totalSupply += numToMint;
         }
-        uint256 totalSupplyOffset = _totalSupply + 1;
+        uint256 totalSupplyOffset = _nextId + 1;
 
         for (uint256 i = nextToken; i < totalSupplyOffset; ) {
             _safeMint(to, i, "");

--- a/contracts/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.sol
@@ -72,4 +72,17 @@ contract RMRKMultiAssetImplErc20Pay is
             }
         }
     }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (to == address(0)) {
+            unchecked {
+                _totalSupply -= 1;
+            }
+        }
+    }
 }

--- a/contracts/implementations/nativeTokenPay/RMRKMultiAssetImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKMultiAssetImpl.sol
@@ -73,4 +73,17 @@ contract RMRKMultiAssetImpl is RMRKAbstractMultiAssetImpl {
             }
         }
     }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (to == address(0)) {
+            unchecked {
+                _totalSupply -= 1;
+            }
+        }
+    }
 }

--- a/contracts/implementations/nativeTokenPay/RMRKMultiAssetImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKMultiAssetImpl.sol
@@ -55,16 +55,17 @@ contract RMRKMultiAssetImpl is RMRKAbstractMultiAssetImpl {
         uint256 numToMint
     ) public payable virtual notLocked {
         if (numToMint == uint256(0)) revert RMRKMintZero();
-        if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
+        if (numToMint + _nextId > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
         if (mintPriceRequired != msg.value) revert RMRKWrongValueSent();
 
-        uint256 nextToken = _totalSupply + 1;
+        uint256 nextToken = _nextId + 1;
         unchecked {
+            _nextId += numToMint;
             _totalSupply += numToMint;
         }
-        uint256 totalSupplyOffset = _totalSupply + 1;
+        uint256 totalSupplyOffset = _nextId + 1;
 
         for (uint256 i = nextToken; i < totalSupplyOffset; ) {
             _safeMint(to, i, "");

--- a/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
@@ -115,16 +115,17 @@ contract RMRKNestableExternalEquipImpl is
      */
     function _preMint(uint256 numToMint) private returns (uint256, uint256) {
         if (numToMint == uint256(0)) revert RMRKMintZero();
-        if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
+        if (numToMint + _nextId > _maxSupply) revert RMRKMintOverMax();
 
         uint256 mintPriceRequired = numToMint * _pricePerMint;
         if (mintPriceRequired != msg.value) revert RMRKWrongValueSent();
 
-        uint256 nextToken = _totalSupply + 1;
+        uint256 nextToken = _nextId + 1;
         unchecked {
+            _nextId += numToMint;
             _totalSupply += numToMint;
         }
-        uint256 totalSupplyOffset = _totalSupply + 1;
+        uint256 totalSupplyOffset = _nextId + 1;
 
         return (nextToken, totalSupplyOffset);
     }

--- a/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
+++ b/contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol
@@ -146,4 +146,17 @@ contract RMRKNestableExternalEquipImpl is
     ) public virtual override onlyOwner {
         _setRoyaltyRecipient(newRoyaltyRecipient);
     }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (to == address(0)) {
+            unchecked {
+                _totalSupply -= 1;
+            }
+        }
+    }
 }

--- a/contracts/implementations/premint/RMRKMultiAssetImplPreMint.sol
+++ b/contracts/implementations/premint/RMRKMultiAssetImplPreMint.sol
@@ -53,13 +53,14 @@ contract RMRKMultiAssetImplPreMint is RMRKAbstractMultiAssetImpl {
         uint256 numToMint
     ) public virtual notLocked onlyOwnerOrContributor {
         if (numToMint == uint256(0)) revert RMRKMintZero();
-        if (numToMint + _totalSupply > _maxSupply) revert RMRKMintOverMax();
+        if (numToMint + _nextId > _maxSupply) revert RMRKMintOverMax();
 
-        uint256 nextToken = _totalSupply + 1;
+        uint256 nextToken = _nextId + 1;
         unchecked {
+            _nextId += numToMint;
             _totalSupply += numToMint;
         }
-        uint256 totalSupplyOffset = _totalSupply + 1;
+        uint256 totalSupplyOffset = _nextId + 1;
 
         for (uint256 i = nextToken; i < totalSupplyOffset; ) {
             _safeMint(to, i, "");

--- a/contracts/implementations/premint/RMRKMultiAssetImplPreMint.sol
+++ b/contracts/implementations/premint/RMRKMultiAssetImplPreMint.sol
@@ -68,4 +68,17 @@ contract RMRKMultiAssetImplPreMint is RMRKAbstractMultiAssetImpl {
             }
         }
     }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, tokenId);
+        if (to == address(0)) {
+            unchecked {
+                _totalSupply -= 1;
+            }
+        }
+    }
 }

--- a/contracts/mocks/MintingUtilsMock.sol
+++ b/contracts/mocks/MintingUtilsMock.sol
@@ -11,7 +11,7 @@ contract MintingUtilsMock is RMRKMintingUtils {
     ) RMRKMintingUtils(maxSupply_, pricePerMint_) {}
 
     function setupTestSaleIsOpen() external {
-        _totalSupply = _maxSupply;
+        _nextId = _maxSupply;
     }
 
     function testSaleIsOpen() external view saleIsOpen returns (bool) {
@@ -20,5 +20,6 @@ contract MintingUtilsMock is RMRKMintingUtils {
 
     function mockMint(uint256 total) external payable {
         _totalSupply += total;
+        _nextId += total;
     }
 }

--- a/contracts/mocks/RMRKMinifiedEquippableMock.sol
+++ b/contracts/mocks/RMRKMinifiedEquippableMock.sol
@@ -33,20 +33,6 @@ contract RMRKMinifiedEquippableMock is RMRKMinifiedEquippable {
         _nestMint(to, tokenId, destinationId, "");
     }
 
-    // Utility transfers:
-
-    function transfer(address to, uint256 tokenId) public virtual {
-        transferFrom(_msgSender(), to, tokenId);
-    }
-
-    function nestTransfer(
-        address to,
-        uint256 tokenId,
-        uint256 destinationId
-    ) public virtual {
-        nestTransferFrom(_msgSender(), to, tokenId, destinationId, "");
-    }
-
     function addAssetToToken(
         uint256 tokenId,
         uint64 assetId,

--- a/docs/mocks/RMRKMinifiedEquippableMock.md
+++ b/docs/mocks/RMRKMinifiedEquippableMock.md
@@ -653,24 +653,6 @@ function nestMint(address to, uint256 tokenId, uint256 destinationId) external n
 | tokenId | uint256 | undefined |
 | destinationId | uint256 | undefined |
 
-### nestTransfer
-
-```solidity
-function nestTransfer(address to, uint256 tokenId, uint256 destinationId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
-| destinationId | uint256 | undefined |
-
 ### nestTransferFrom
 
 ```solidity
@@ -989,23 +971,6 @@ Used to retrieve the collection symbol.
 | Name | Type | Description |
 |---|---|---|
 | _0 | string | Symbol of the collection |
-
-### transfer
-
-```solidity
-function transfer(address to, uint256 tokenId) external nonpayable
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| to | address | undefined |
-| tokenId | uint256 | undefined |
 
 ### transferChild
 

--- a/test/implementations/lazyMintErc20Pay.ts
+++ b/test/implementations/lazyMintErc20Pay.ts
@@ -157,7 +157,7 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(0);
   });
 
-  it('reduces total supply on burn and does not reuse Id', async function () {
+  it('reduces total supply on burn and does not reuse ID', async function () {
     const tokenId = await mintFromImplErc20Pay(this.token, addrs[0].address);
     await this.token.connect(addrs[0])['burn(uint256)'](tokenId);
 

--- a/test/implementations/lazyMintErc20Pay.ts
+++ b/test/implementations/lazyMintErc20Pay.ts
@@ -151,6 +151,12 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
     expect(await this.token.balanceOf(addrs[0].address)).to.equal(1);
   });
 
+  it('reduces total supply on burn', async function () {
+    const tokenId = await mintFromImplErc20Pay(this.token, addrs[0].address);
+    await this.token.connect(addrs[0])['burn(uint256)'](tokenId);
+    expect(await this.token.totalSupply()).to.equal(0);
+  });
+
   it('can mint multiple tokens through sale logic', async function () {
     await erc20.mint(addrs[0].address, ONE_ETH.mul(10));
     await erc20.connect(addrs[0]).approve(this.token.address, ONE_ETH.mul(10));

--- a/test/implementations/lazyMintErc20Pay.ts
+++ b/test/implementations/lazyMintErc20Pay.ts
@@ -157,6 +157,15 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(0);
   });
 
+  it('reduces total supply on burn and does not reuse Id', async function () {
+    const tokenId = await mintFromImplErc20Pay(this.token, addrs[0].address);
+    await this.token.connect(addrs[0])['burn(uint256)'](tokenId);
+
+    const newTokenId = await mintFromImplErc20Pay(this.token, addrs[0].address);
+    expect(newTokenId).to.equal(tokenId.add(1));
+    expect(await this.token.totalSupply()).to.equal(1);
+  });
+
   it('can mint multiple tokens through sale logic', async function () {
     await erc20.mint(addrs[0].address, ONE_ETH.mul(10));
     await erc20.connect(addrs[0]).approve(this.token.address, ONE_ETH.mul(10));

--- a/test/implementations/lazyMintErc20Pay.ts
+++ b/test/implementations/lazyMintErc20Pay.ts
@@ -153,6 +153,7 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
 
   it('reduces total supply on burn', async function () {
     const tokenId = await mintFromImplErc20Pay(this.token, addrs[0].address);
+    expect(await this.token.totalSupply()).to.equal(1);
     await this.token.connect(addrs[0])['burn(uint256)'](tokenId);
     expect(await this.token.totalSupply()).to.equal(0);
   });

--- a/test/implementations/lazyMintNativeTokenPay.ts
+++ b/test/implementations/lazyMintNativeTokenPay.ts
@@ -156,7 +156,7 @@ async function shouldControlValidMintingNativeTokenPay(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(0);
   });
 
-  it('reduces total supply on burn and does not reuse Id', async function () {
+  it('reduces total supply on burn and does not reuse ID', async function () {
     const tokenId = await mintFromImplNativeToken(this.token, addrs[0].address);
     await this.token.connect(addrs[0])['burn(uint256)'](tokenId);
 

--- a/test/implementations/lazyMintNativeTokenPay.ts
+++ b/test/implementations/lazyMintNativeTokenPay.ts
@@ -156,6 +156,15 @@ async function shouldControlValidMintingNativeTokenPay(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(0);
   });
 
+  it('reduces total supply on burn and does not reuse Id', async function () {
+    const tokenId = await mintFromImplNativeToken(this.token, addrs[0].address);
+    await this.token.connect(addrs[0])['burn(uint256)'](tokenId);
+
+    const newTokenId = await mintFromImplNativeToken(this.token, addrs[0].address);
+    expect(newTokenId).to.equal(tokenId.add(1));
+    expect(await this.token.totalSupply()).to.equal(1);
+  });
+
   it('can mint multiple tokens through sale logic', async function () {
     await this.token.connect(addrs[0]).mint(addrs[0].address, 10, { value: ONE_ETH.mul(10) });
     expect(await this.token.totalSupply()).to.equal(10);

--- a/test/implementations/lazyMintNativeTokenPay.ts
+++ b/test/implementations/lazyMintNativeTokenPay.ts
@@ -152,6 +152,7 @@ async function shouldControlValidMintingNativeTokenPay(): Promise<void> {
 
   it('reduces total supply on burn', async function () {
     const tokenId = await mintFromImplNativeToken(this.token, addrs[0].address);
+    expect(await this.token.totalSupply()).to.equal(1);
     await this.token.connect(addrs[0])['burn(uint256)'](tokenId);
     expect(await this.token.totalSupply()).to.equal(0);
   });

--- a/test/implementations/multiasset.ts
+++ b/test/implementations/multiasset.ts
@@ -80,6 +80,15 @@ describe('MultiAssetImpl Other Behavior', async () => {
       expect(await this.token.totalSupply()).to.equal(0);
     });
 
+    it('reduces total supply on burn and does not reuse Id', async function () {
+      const tokenId = await mintFromImplNativeToken(token, owner.address);
+      await this.token.connect(owner)['burn(uint256)'](tokenId);
+
+      const newTokenId = await mintFromImplNativeToken(this.token, owner.address);
+      expect(newTokenId).to.equal(tokenId.add(1));
+      expect(await this.token.totalSupply()).to.equal(1);
+    });
+
     it('can mint multiple tokens through sale logic', async function () {
       await token.connect(owner).mint(owner.address, 10, { value: ONE_ETH.mul(10) });
       expect(await token.totalSupply()).to.equal(10);

--- a/test/implementations/multiasset.ts
+++ b/test/implementations/multiasset.ts
@@ -74,6 +74,12 @@ describe('MultiAssetImpl Other Behavior', async () => {
       ).to.be.revertedWithCustomError(token, 'RMRKWrongValueSent');
     });
 
+    it('reduces total supply on burn', async function () {
+      const tokenId = await mintFromImplNativeToken(token, owner.address);
+      await this.token.connect(owner)['burn(uint256)'](tokenId);
+      expect(await this.token.totalSupply()).to.equal(0);
+    });
+
     it('can mint multiple tokens through sale logic', async function () {
       await token.connect(owner).mint(owner.address, 10, { value: ONE_ETH.mul(10) });
       expect(await token.totalSupply()).to.equal(10);

--- a/test/implementations/multiasset.ts
+++ b/test/implementations/multiasset.ts
@@ -76,6 +76,7 @@ describe('MultiAssetImpl Other Behavior', async () => {
 
     it('reduces total supply on burn', async function () {
       const tokenId = await mintFromImplNativeToken(token, owner.address);
+      expect(await this.token.totalSupply()).to.equal(1);
       await this.token.connect(owner)['burn(uint256)'](tokenId);
       expect(await this.token.totalSupply()).to.equal(0);
     });

--- a/test/implementations/multiasset.ts
+++ b/test/implementations/multiasset.ts
@@ -80,7 +80,7 @@ describe('MultiAssetImpl Other Behavior', async () => {
       expect(await this.token.totalSupply()).to.equal(0);
     });
 
-    it('reduces total supply on burn and does not reuse Id', async function () {
+    it('reduces total supply on burn and does not reuse ID', async function () {
       const tokenId = await mintFromImplNativeToken(token, owner.address);
       await this.token.connect(owner)['burn(uint256)'](tokenId);
 

--- a/test/implementations/premint.ts
+++ b/test/implementations/premint.ts
@@ -126,7 +126,7 @@ async function shouldControlValidPreMinting(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(0);
   });
 
-  it('reduces total supply on burn and does not reuse Id', async function () {
+  it('reduces total supply on burn and does not reuse ID', async function () {
     let tx = await this.token.connect(owner).mint(owner.address, 1);
     let event = (await tx.wait()).events?.find((e) => e.event === 'Transfer');
     const tokenId = event?.args?.tokenId;

--- a/test/implementations/premint.ts
+++ b/test/implementations/premint.ts
@@ -126,6 +126,20 @@ async function shouldControlValidPreMinting(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(0);
   });
 
+  it('reduces total supply on burn and does not reuse Id', async function () {
+    let tx = await this.token.connect(owner).mint(owner.address, 1);
+    let event = (await tx.wait()).events?.find((e) => e.event === 'Transfer');
+    const tokenId = event?.args?.tokenId;
+    await this.token.connect(owner)['burn(uint256)'](tokenId);
+
+    tx = await this.token.connect(owner).mint(owner.address, 1);
+    event = (await tx.wait()).events?.find((e) => e.event === 'Transfer');
+    const newTokenId = event?.args?.tokenId;
+
+    expect(newTokenId).to.equal(tokenId.add(1));
+    expect(await this.token.totalSupply()).to.equal(1);
+  });
+
   describe('Nest minting', async () => {
     beforeEach(async function () {
       if (this.token.nestMint === undefined) {

--- a/test/implementations/premint.ts
+++ b/test/implementations/premint.ts
@@ -122,6 +122,7 @@ async function shouldControlValidPreMinting(): Promise<void> {
   it('reduces total supply on burn', async function () {
     await this.token.connect(owner).mint(owner.address, 1);
     const tokenId = this.token.totalSupply();
+    expect(await tokenId).to.equal(1);
     await this.token.connect(owner)['burn(uint256)'](tokenId);
     expect(await this.token.totalSupply()).to.equal(0);
   });

--- a/test/implementations/premint.ts
+++ b/test/implementations/premint.ts
@@ -119,6 +119,13 @@ async function shouldControlValidPreMinting(): Promise<void> {
     ).to.be.revertedWithCustomError(this.token, 'RMRKLocked');
   });
 
+  it('reduces total supply on burn', async function () {
+    await this.token.connect(owner).mint(owner.address, 1);
+    const tokenId = this.token.totalSupply();
+    await this.token.connect(owner)['burn(uint256)'](tokenId);
+    expect(await this.token.totalSupply()).to.equal(0);
+  });
+
   describe('Nest minting', async () => {
     beforeEach(async function () {
       if (this.token.nestMint === undefined) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -15,6 +15,7 @@ async function mintFromMock(token: Contract, to: string): Promise<number> {
   const tokenId = nextTokenId;
   nextTokenId++;
   await token['mint(address,uint256)'](to, tokenId);
+
   return tokenId;
 }
 
@@ -25,7 +26,7 @@ async function nestMintFromMock(token: Contract, to: string, parentId: number): 
   return childTokenId;
 }
 
-async function mintFromImplErc20Pay(token: Contract, to: string): Promise<number> {
+async function mintFromImplErc20Pay(token: Contract, to: string): Promise<BigNumber> {
   const erc20Address = token.erc20TokenAddress();
   const erc20Factory = await ethers.getContractFactory('ERC20Mock');
   const erc20 = erc20Factory.attach(erc20Address);
@@ -34,20 +35,26 @@ async function mintFromImplErc20Pay(token: Contract, to: string): Promise<number
   await erc20.mint(owner.address, ONE_ETH);
   await erc20.approve(token.address, ONE_ETH);
 
-  await token.mint(to, 1);
-  return await token.totalSupply();
+  const tx = await token.mint(to, 1);
+  // Get the event from the tx
+  const event = (await tx.wait()).events?.find((e) => e.event === 'Transfer');
+  // Get the tokenId from the event
+  return event?.args?.tokenId;
 }
 
-async function mintFromImplNativeToken(token: Contract, to: string): Promise<number> {
-  await token.mint(to, 1, { value: ONE_ETH });
-  return await token.totalSupply();
+async function mintFromImplNativeToken(token: Contract, to: string): Promise<BigNumber> {
+  const tx = await token.mint(to, 1, { value: ONE_ETH });
+  // Get the event from the tx
+  const event = (await tx.wait()).events?.find((e) => e.event === 'Transfer');
+  // Get the tokenId from the event
+  return event?.args?.tokenId;
 }
 
 async function nestMintFromImplErc20Pay(
   token: Contract,
   to: string,
   destinationId: number,
-): Promise<number> {
+): Promise<BigNumber> {
   const erc20Address = token.erc20TokenAddress();
   const erc20Factory = await ethers.getContractFactory('ERC20Mock');
   const erc20 = erc20Factory.attach(erc20Address);
@@ -56,17 +63,23 @@ async function nestMintFromImplErc20Pay(
   await erc20.mint(owner.address, ONE_ETH);
   await erc20.approve(token.address, ONE_ETH);
 
-  await token.nestMint(to, 1, destinationId);
-  return await token.totalSupply();
+  const tx = await token.nestMint(to, 1, destinationId);
+  // Get the event from the tx
+  const event = (await tx.wait()).events?.find((e) => e.event === 'Transfer');
+  // Get the tokenId from the event
+  return event?.args?.tokenId;
 }
 
 async function nestMintFromImplNativeToken(
   token: Contract,
   to: string,
   destinationId: number,
-): Promise<number> {
-  await token.nestMint(to, 1, destinationId, { value: ONE_ETH });
-  return await token.totalSupply();
+): Promise<BigNumber> {
+  const tx = await token.nestMint(to, 1, destinationId, { value: ONE_ETH });
+  // Get the event from the tx
+  const event = (await tx.wait()).events?.find((e) => e.event === 'Transfer');
+  // Get the tokenId from the event
+  return event?.args?.tokenId;
 }
 
 async function transfer(


### PR DESCRIPTION
# Description

Reduces total supply on burn, for all implementations.
Removes unused mock functions.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to reduce total supply on token burn and prevent ID reuse, as well as updating internal variables to use `_nextId` instead of `_totalSupply`. 

### Detailed summary
- Added `_beforeTokenTransfer` function to reduce total supply on token burn and prevent ID reuse.
- Updated internal variables to use `_nextId` instead of `_totalSupply` for more accurate tracking of available IDs.

> The following files were skipped due to too many changes: `contracts/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.sol`, `test/implementations/lazyMintNativeTokenPay.ts`, `test/utils.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->