### PR TITLE
Add set lock event to OwnableLock

### DIFF
--- a/contracts/RMRK/access/OwnableLock.sol
+++ b/contracts/RMRK/access/OwnableLock.sol
@@ -14,6 +14,11 @@ contract OwnableLock is Ownable {
     uint256 private _lock;
 
     /**
+     * @notice Emitted when the smart contract is locked.
+     */
+    event LockSet();
+
+    /**
      * @notice Reverts if the lock flag is set to true.
      */
     modifier notLocked() {
@@ -24,9 +29,11 @@ contract OwnableLock is Ownable {
     /**
      * @notice Locks the operation.
      * @dev Once locked, functions using `notLocked` modifier cannot be executed.
+     * @dev Emits ***LockSet*** event.
      */
     function setLock() public virtual onlyOwner {
         _lock = 1;
+        emit LockSet();
     }
 
     /**

--- a/docs/RMRK/access/OwnableLock.md
+++ b/docs/RMRK/access/OwnableLock.md
@@ -102,7 +102,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### transferOwnership
@@ -141,6 +141,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/RMRK/utils/RMRKMintingUtils.md
+++ b/docs/RMRK/utils/RMRKMintingUtils.md
@@ -136,7 +136,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### totalSupply
@@ -209,6 +209,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/implementations/RMRKCatalogImpl.md
+++ b/docs/implementations/RMRKCatalogImpl.md
@@ -323,7 +323,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### supportsInterface
@@ -421,6 +421,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -1056,7 +1056,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1591,6 +1591,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -705,7 +705,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1064,6 +1064,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -632,7 +632,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### supportsInterface
@@ -934,6 +934,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -916,7 +916,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1373,6 +1373,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -1108,7 +1108,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1643,6 +1643,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -739,7 +739,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1098,6 +1098,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -684,7 +684,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### supportsInterface
@@ -986,6 +986,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -968,7 +968,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1425,6 +1425,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -1091,7 +1091,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1626,6 +1626,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md
@@ -543,7 +543,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setNestableAddress
@@ -853,6 +853,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestableAddressSet
 

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -722,7 +722,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1081,6 +1081,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -723,7 +723,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### supportsInterface
@@ -1042,6 +1042,17 @@ used to notify the listeners that the address of the `Equippable` associated sma
 |---|---|---|
 | old  | address | Address of the previous `Equippable` smart contract |
 | new_  | address | Address of the new `Equippable` smart contract |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -667,7 +667,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### supportsInterface
@@ -969,6 +969,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -951,7 +951,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1408,6 +1408,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -1091,7 +1091,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1626,6 +1626,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -722,7 +722,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1081,6 +1081,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -667,7 +667,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### supportsInterface
@@ -969,6 +969,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -951,7 +951,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setPriority
@@ -1408,6 +1408,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### NestTransfer
 

--- a/docs/mocks/MintingUtilsMock.md
+++ b/docs/mocks/MintingUtilsMock.md
@@ -152,7 +152,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### setupTestSaleIsOpen
@@ -253,6 +253,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/docs/mocks/OwnableLockMock.md
+++ b/docs/mocks/OwnableLockMock.md
@@ -102,7 +102,7 @@ function setLock() external nonpayable
 
 Locks the operation.
 
-*Once locked, functions using `notLocked` modifier cannot be executed.*
+*Once locked, functions using `notLocked` modifier cannot be executed.Emits ***LockSet*** event.*
 
 
 ### testLock
@@ -158,6 +158,17 @@ Event that signifies that an address was granted contributor role or that the pe
 |---|---|---|
 | contributor `indexed` | address | Address of the account that had contributor role status updated |
 | isContributor  | bool | A boolean value signifying whether the role has been granted (`true`) or revoked (`false`) |
+
+### LockSet
+
+```solidity
+event LockSet()
+```
+
+Emitted when the smart contract is locked.
+
+
+
 
 ### OwnershipTransferred
 

--- a/test/behavior/ownableLock.ts
+++ b/test/behavior/ownableLock.ts
@@ -22,6 +22,10 @@ async function shouldBehaveOwnableLock(ismock: boolean) {
       expect(await ownableLock.owner()).to.equal(owner.address);
     });
 
+    it('emits LockSet event when the lock is set', async function () {
+      await expect(ownableLock.connect(owner).setLock()).to.emit(ownableLock, 'LockSet');
+    });
+
     it('can get lock', async function () {
       expect(await ownableLock.getLock()).to.equal(false);
       await ownableLock.connect(owner).setLock();


### PR DESCRIPTION
# Description

There was no event being emitted when the smart contract operation was locked.

# Actions

Added LockSet event to OwnableLock contract. This event is emitted when the lock is set.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an `event` to `OwnableLock.sol` and emits it when the smart contract is locked. 

### Detailed summary
- Adds `event LockSet()` to `OwnableLock.sol`
- Emits `LockSet` event when the smart contract is locked

> The following files were skipped due to too many changes: `docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md`, `docs/implementations/premint/RMRKMultiAssetImplPreMint.md`, `docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md`, `docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md`, `docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md`, `docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md`, `docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md`, `docs/implementations/nativeTokenPay/RMRKExternalEquipImpl.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->