### PR TITLE
Checks for catalog matching when detecting equippable slots.

### DIFF
--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -693,7 +693,8 @@ contract RMRKEquipRenderUtils is
                 IERC6220(childAddress),
                 childId,
                 parentSlotPartIds,
-                parentAddress
+                parentAddress,
+                parentAssetCatalog
             );
         // Finally, we copy the matches into the final array which has the right lenght according to results
         equippableData = new EquippableData[](totalMatches);
@@ -778,6 +779,7 @@ contract RMRKEquipRenderUtils is
      * @param childId ID of the child token whose assets will be matched against parent's slot parts
      * @param parentSlotPartIds Array of slot part IDs of the parent token's asset
      * @param parentAddress Address of the parent smart contract
+     * @param parentAssetCatalog Address of the parent asset's catalog
      * @return allAssetsWithSlots An array of `EquippableData` structs containing info about the equippable child assets
      *  and their corresponding slot parts
      * @return totalMatches Total of valid matches found
@@ -786,7 +788,8 @@ contract RMRKEquipRenderUtils is
         IERC6220 childContract,
         uint256 childId,
         uint64[] memory parentSlotPartIds,
-        address parentAddress
+        address parentAddress,
+        address parentAssetCatalog
     )
         private
         view
@@ -801,14 +804,16 @@ contract RMRKEquipRenderUtils is
         );
 
         uint256 totalChildAssets = childAssets.length;
-        uint256 totalParentSlots = parentSlotPartIds.length;
 
         // There can be at most min(totalChildAssets, totalParentSlots) resulting matches, we just pick one of them.
-        allAssetsWithSlots = new EquippableData[](totalParentSlots);
+        allAssetsWithSlots = new EquippableData[](totalChildAssets);
 
         for (uint256 i; i < totalChildAssets; ) {
-            for (uint256 j; j < totalParentSlots; ) {
+            (, , address catalogAddress, ) = childContract
+                .getAssetAndEquippableData(childId, childAssets[i]);
+            for (uint256 j; j < parentSlotPartIds.length; ) {
                 if (
+                    catalogAddress == parentAssetCatalog &&
                     childContract.canTokenBeEquippedWithAssetIntoSlot(
                         parentAddress,
                         childId,

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -369,7 +369,7 @@ describe('Advanced Equip Render Utils', async function () {
     ).to.eql([
       bn(0), // child Index
       [
-        // [Slot Id, asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
+        // [Slot Id, child asset Id, parent asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
         [
           bn(slotIdGemRight),
           bn(assetForGemARight),
@@ -410,7 +410,7 @@ describe('Advanced Equip Render Utils', async function () {
     ).to.eql([
       bn(1), // child Index
       [
-        // [Slot Id, asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
+        // [Slot Id, child asset Id, parent asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
         [
           bn(slotIdGemRight),
           bn(assetForGemARight),
@@ -452,7 +452,7 @@ describe('Advanced Equip Render Utils', async function () {
     ).to.eql([
       bn(2), // child Index
       [
-        // [Slot Id, asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
+        // [Slot Id, child asset Id, parent asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
         [
           bn(slotIdGemRight),
           bn(assetForGemBRight),
@@ -495,7 +495,7 @@ describe('Advanced Equip Render Utils', async function () {
     ).to.eql([
       bn(2), // child Index
       [
-        // [Slot Id, asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
+        // [Slot Id, child asset Id, parent asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
         [
           bn(slotIdGemRight),
           bn(assetForGemBRight),
@@ -558,7 +558,72 @@ describe('Advanced Equip Render Utils', async function () {
     ).to.eql([
       bn(0), // child Index
       [
-        // [Slot Id, asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
+        // [Slot Id, child asset Id, parent asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
+        [
+          bn(slotIdGemRight),
+          bn(assetForGemBRight),
+          bn(assetForKanariaFull),
+          bn(0),
+          catalog.address,
+          false,
+          'ipfs://metadataSlotGemRight',
+          'ipfs://gems/typeB/right.svg',
+          'ipfs://kanaria/full.svg',
+        ],
+        [
+          bn(slotIdGemMid),
+          bn(assetForGemBMid),
+          bn(assetForKanariaFull),
+          bn(1),
+          catalog.address,
+          false,
+          'ipfs://metadataSlotGemMid',
+          'ipfs://gems/typeB/mid.svg',
+          'ipfs://kanaria/full.svg',
+        ],
+        [
+          bn(slotIdGemLeft),
+          bn(assetForGemBLeft),
+          bn(assetForKanariaFull),
+          bn(2),
+          catalog.address,
+          false,
+          'ipfs://metadataSlotGemLeft',
+          'ipfs://gems/typeB/left.svg',
+          'ipfs://kanaria/full.svg',
+        ],
+      ],
+    ]);
+  });
+
+  it('can get equippable slots from parent asset and excludes if catalog does not match', async function () {
+    await setUpCatalog(catalog, gem.address);
+    await setUpKanariaAsset(kanaria, kanariaId, catalog.address);
+    await setUpGemAssets(gem, gemId1, gemId2, gemId3, kanaria.address, catalog.address);
+
+    const catalogFactory = await ethers.getContractFactory('RMRKCatalogMock');
+    const otherCatalog = <RMRKCatalogMock>(
+      await catalogFactory.deploy('ipfs://catalog.json', 'misc')
+    );
+    await otherCatalog.deployed();
+
+    const newResourceId = bn(99);
+    await gem.addEquippableAssetEntry(
+      newResourceId,
+      1,
+      otherCatalog.address,
+      'ipfs://assetFromOtherCatalog.jpg',
+      [],
+    );
+    await gem.addAssetToToken(gemId3, newResourceId, 0);
+    await gem.acceptAsset(gemId3, 0, newResourceId);
+
+    expect(
+      await renderUtilsEquip.getEquippableSlotsFromParent(gem.address, gemId3, assetForKanariaFull),
+    ).to.eql([
+      bn(2), // child Index
+      [
+        // [Slot Id, child asset Id, parent asset Id, Asset priority, catalog address, isEquipped, partMetadata, childAssetMetadata, parentAssetMetadata]
         [
           bn(slotIdGemRight),
           bn(assetForGemBRight),


### PR DESCRIPTION
# Description

It could happened that assets using different catalogs matched on slot Ids, but they are however not meant to be equipped if the catalog does not match.

# Checklist

- [ ] Verified code additions
- [ ] Updated NatSpec comments (if applicable)
- [ ] Regenerated docs
- [ ] Ran prettier
- [ ] Added tests to fully cover the changes
