### PR TITLE
Adds internal methods to accept child and asset on minified equippable.

### DIFF
--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -903,6 +903,31 @@ contract RMRKMinifiedEquippable is
         address childAddress,
         uint256 childId
     ) public virtual onlyApprovedOrOwner(parentId) {
+        _acceptChild(parentId, childIndex, childAddress, childId);
+    }
+
+    /**
+     * @notice Used to accept a pending child token for a given parent token.
+     * @dev This moves the child token from parent token's pending child tokens array into the active child tokens
+     *  array.
+     * @dev Requirements:
+     *
+     *  - `tokenId` must exist
+     *  - `index` must be in range of the pending children array
+     * @dev Emits ***ChildAccepted*** event.
+     * @param parentId ID of the parent token for which the child token is being accepted
+     * @param childIndex Index of a child tokem in the given parent's pending children array
+     * @param childAddress Address of the collection smart contract of the child token expected to be located at the
+     *  specified index of the given parent token's pending children array
+     * @param childId ID of the child token expected to be located at the specified index of the given parent token's
+     *  pending children array
+     */
+    function _acceptChild(
+        uint256 parentId,
+        uint256 childIndex,
+        address childAddress,
+        uint256 childId
+    ) internal virtual {
         Child memory child = pendingChildOf(parentId, childIndex);
         _checkExpectedChild(child, childAddress, childId);
         if (_childIsInActive[childAddress][childId] != 0)
@@ -1719,6 +1744,22 @@ contract RMRKMinifiedEquippable is
         uint256 index,
         uint64 assetId
     ) public virtual onlyApprovedForAssetsOrOwner(tokenId) {
+        _acceptAsset(tokenId, index, assetId);
+    }
+
+    /**
+     * @notice Used to accept a pending asset.
+     * @dev The call is reverted if there is no pending asset at a given index.
+     * @dev Emits ***AssetAccepted*** event.
+     * @param tokenId ID of the token for which to accept the pending asset
+     * @param index Index of the asset in the pending array to accept
+     * @param assetId ID of the asset to accept in token's pending array
+     */
+    function _acceptAsset(
+        uint256 tokenId,
+        uint256 index,
+        uint64 assetId
+    ) internal virtual {
         _validatePendingAssetAtIndex(tokenId, index, assetId);
         _beforeAcceptAsset(tokenId, index, assetId);
 


### PR DESCRIPTION
# Description

Even though this version is meant to be minimal, the internal methods to accept child and asset are commonly needed to bypass the acceptance from the holder under certain circumstances, such as allow listed collections or accepting the first ever asset on a soulbound collection.

This increased size by 0.030 kb 

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds two new internal functions `_acceptChild` and `_acceptAsset` to the `RMRKMinifiedEquippable` contract for accepting pending child tokens and assets respectively.

### Detailed summary
- Adds `_acceptChild` function for accepting pending child tokens.
- Adds `_acceptAsset` function for accepting pending assets.
- Both functions are internal and emit events upon successful acceptance.
- Includes documentation for both functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->