### PR TITLE
Adds support to custom RMRK interface on implementations.

### DIFF
--- a/contracts/RMRK/core/RMRKCore.sol
+++ b/contracts/RMRK/core/RMRKCore.sol
@@ -16,6 +16,7 @@ contract RMRKCore is IRMRKCore {
      * @return Version identifier of the smart contract
      */
     string public constant VERSION = "1.1.0";
+    bytes4 public constant RMRK_INTERFACE = 0x524D524B; // "RMRK" in ASCII hex
 
     /**
      * @notice Used to initialize the smart contract.

--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.18;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
@@ -1691,6 +1692,7 @@ contract RMRKMinifiedEquippable is
         return
             interfaceId == type(IERC165).interfaceId ||
             interfaceId == type(IERC721).interfaceId ||
+            interfaceId == type(IERC721Metadata).interfaceId ||
             interfaceId == type(IERC6059).interfaceId ||
             interfaceId == type(IERC5773).interfaceId ||
             interfaceId == type(IERC6220).interfaceId;

--- a/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
+++ b/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
@@ -7,9 +7,6 @@ pragma solidity ^0.8.18;
 import "../multiasset/AbstractMultiAsset.sol";
 import "./IERC6059.sol";
 import "./RMRKNestable.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**

--- a/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol
@@ -172,4 +172,21 @@ abstract contract RMRKAbstractEquippableImpl is
             }
         }
     }
+
+    /**
+     * @inheritdoc IERC165
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        virtual
+        override(IERC165, RMRKMinifiedEquippable)
+        returns (bool)
+    {
+        return
+            super.supportsInterface(interfaceId) ||
+            interfaceId == RMRK_INTERFACE;
+    }
 }

--- a/contracts/implementations/abstracts/RMRKAbstractMultiAssetImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractMultiAssetImpl.sol
@@ -92,4 +92,15 @@ abstract contract RMRKAbstractMultiAssetImpl is
     ) public virtual override onlyOwner {
         _setRoyaltyRecipient(newRoyaltyRecipient);
     }
+
+    /**
+     * @inheritdoc IERC165
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165, RMRKMultiAsset) returns (bool) {
+        return
+            super.supportsInterface(interfaceId) ||
+            interfaceId == RMRK_INTERFACE;
+    }
 }

--- a/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol
@@ -76,4 +76,15 @@ abstract contract RMRKAbstractNestableImpl is
             }
         }
     }
+
+    /**
+     * @inheritdoc IERC165
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165, RMRKNestable) returns (bool) {
+        return
+            super.supportsInterface(interfaceId) ||
+            interfaceId == RMRK_INTERFACE;
+    }
 }

--- a/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
+++ b/contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol
@@ -123,4 +123,21 @@ abstract contract RMRKAbstractNestableMultiAssetImpl is
             }
         }
     }
+
+    /**
+     * @inheritdoc IERC165
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        virtual
+        override(IERC165, RMRKNestableMultiAsset)
+        returns (bool)
+    {
+        return
+            super.supportsInterface(interfaceId) ||
+            interfaceId == RMRK_INTERFACE;
+    }
 }

--- a/docs/RMRK/core/RMRKCore.md
+++ b/docs/RMRK/core/RMRKCore.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK core module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Equippable module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/equippable/RMRKMinifiedEquippable.md
+++ b/docs/RMRK/equippable/RMRKMinifiedEquippable.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Equippable module, without utility internal functions
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/equippable/RMRKNestableExternalEquip.md
+++ b/docs/RMRK/equippable/RMRKNestableExternalEquip.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Nestable External Equippable module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK MultiAsset AutoIndex module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Nestable AutoIndex module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
+++ b/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Reclaimable child module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/extension/soulbound/RMRKSoulbound.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulbound.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Soulbound module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Soulbound module where transfers are only allowed unt
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Soulbound module where transfers are allowed for a li
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundPerToken.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundPerToken.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Soulbound module where the transfers are permitted or
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/multiasset/RMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/RMRKMultiAsset.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Multi asset module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/nestable/RMRKNestable.md
+++ b/docs/RMRK/nestable/RMRKNestable.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Nestable module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -10,6 +10,23 @@ Smart contract of the joined RMRK Nestable and Multi asset module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractEquippableImpl.md
@@ -10,6 +10,23 @@ Abstract implementation of RMRK equippable module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractMultiAssetImpl.md
@@ -10,6 +10,23 @@ Abstract implementation of RMRK multi asset module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableImpl.md
@@ -10,6 +10,23 @@ Abstract implementation of RMRK nestable module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
+++ b/docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md
@@ -10,6 +10,23 @@ Abstract implementation of RMRK nestable multi asset module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKEquippableImplErc20Pay.md
@@ -10,6 +10,23 @@ Implementation of RMRK equippable module with ERC20 pay.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.md
@@ -10,6 +10,23 @@ Implementation of RMRK multi asset module with ERC20 pay.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableImplErc20Pay.md
@@ -10,6 +10,23 @@ Implementation of RMRK nestable module with ERC20 pay.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
+++ b/docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md
@@ -10,6 +10,23 @@ Implementation of RMRK nestable multi asset module with ERC20 pay.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKEquippableImpl.md
@@ -10,6 +10,23 @@ Implementation of RMRK equippable module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKMultiAssetImpl.md
@@ -10,6 +10,23 @@ Implementation of RMRK multi asset module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md
@@ -10,6 +10,23 @@ Implementation of RMRK nestable external equip module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableImpl.md
@@ -10,6 +10,23 @@ Implementation of RMRK nestable module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
+++ b/docs/implementations/nativeTokenPay/RMRKNestableMultiAssetImpl.md
@@ -10,6 +10,23 @@ Implementation of RMRK nestable multi asset module.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/premint/RMRKEquippableImplPreMint.md
+++ b/docs/implementations/premint/RMRKEquippableImplPreMint.md
@@ -10,6 +10,23 @@ Implementation of RMRK equippable module with pre minting by collection owner.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetImplPreMint.md
@@ -10,6 +10,23 @@ Implementation of RMRK multi asset module with pre minting by collection owner.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableImplPreMint.md
@@ -10,6 +10,23 @@ Implementation of RMRK nestable module with pre minting by collection owner.
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md
@@ -10,6 +10,23 @@ Implementation of RMRK nestable multi asset module with pre minting by collectio
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKEquippableMock.md
+++ b/docs/mocks/RMRKEquippableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKMinifiedEquippableMock.md
+++ b/docs/mocks/RMRKMinifiedEquippableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKMultiAssetAutoIndexMock.md
+++ b/docs/mocks/RMRKMultiAssetAutoIndexMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKMultiAssetMock.md
+++ b/docs/mocks/RMRKMultiAssetMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKNestableAutoIndexMock.md
+++ b/docs/mocks/RMRKNestableAutoIndexMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKNestableExternalEquipMock.md
+++ b/docs/mocks/RMRKNestableExternalEquipMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKNestableMock.md
+++ b/docs/mocks/RMRKNestableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/RMRKNestableMultiAssetMock.md
+++ b/docs/mocks/RMRKNestableMultiAssetMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
+++ b/docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
+++ b/docs/mocks/extensions/emotable/RMRKMultiAssetEmotableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
+++ b/docs/mocks/extensions/soulbound/RMRKSoulboundPerTokenMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
+++ b/docs/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.md
@@ -10,6 +10,23 @@
 
 ## Methods
 
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
 ### VERSION
 
 ```solidity

--- a/test/behavior/metadata.ts
+++ b/test/behavior/metadata.ts
@@ -1,9 +1,9 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 
 async function shouldHaveMetadata(
-  mint: (token: Contract, to: string) => Promise<number>,
+  mint: (token: Contract, to: string) => Promise<BigNumber>,
   isTokenUriEnumerated: boolean,
 ): Promise<void> {
   it('can get tokenURI', async function () {

--- a/test/behavior/multiasset.ts
+++ b/test/behavior/multiasset.ts
@@ -6,7 +6,7 @@ import { bn } from '../utils';
 import { IERC165, IOtherInterface, IERC5773 } from '../interfaces';
 
 async function shouldBehaveLikeMultiAsset(
-  mint: (token: Contract, to: string) => Promise<number>,
+  mint: (token: Contract, to: string) => Promise<BigNumber>,
   addAssetEntryFunc: (token: Contract, data?: string) => Promise<BigNumber>,
   addAssetToTokenFunc: (
     token: Contract,

--- a/test/behavior/nestable.ts
+++ b/test/behavior/nestable.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { bn, ADDRESS_ZERO } from '../utils';
 import { IERC165, IERC721, IERC6059, IOtherInterface } from '../interfaces';
 
 async function shouldBehaveLikeNestable(
-  mint: (token: Contract, to: string) => Promise<number>,
-  nestMint: (token: Contract, to: string, parentId: number) => Promise<number>,
+  mint: (token: Contract, to: string) => Promise<BigNumber>,
+  nestMint: (token: Contract, to: string, parentId: number) => Promise<BigNumber>,
   transfer: (
     token: Contract,
     caller: SignerWithAddress,

--- a/test/behavior/royalties.ts
+++ b/test/behavior/royalties.ts
@@ -1,10 +1,10 @@
 import { ethers } from 'hardhat';
 import { expect } from 'chai';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { ADDRESS_ZERO, bn, ONE_ETH } from '../utils';
 
 async function shouldHaveRoyalties(
-  mint: (token: Contract, to: string) => Promise<number>,
+  mint: (token: Contract, to: string) => Promise<BigNumber>,
 ): Promise<void> {
   it('can get royalty data', async function () {
     const owner = (await ethers.getSigners())[0];

--- a/test/implementations/equippable.ts
+++ b/test/implementations/equippable.ts
@@ -1,4 +1,4 @@
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
@@ -15,6 +15,14 @@ import {
   ONE_ETH,
 } from '../utils';
 import { RMRKEquippableImpl, RMRKMultiAssetRenderUtils } from '../../typechain-types';
+import {
+  IERC5773,
+  IERC6059,
+  IERC6220,
+  IERC721,
+  IERC721Metadata,
+  IRMRKImplementation,
+} from '../interfaces';
 
 const isTokenUriEnumerated = false;
 
@@ -55,9 +63,9 @@ describe('RMRKEquippableImpl MR behavior', async () => {
     this.renderUtils = renderUtils;
   });
 
-  async function mintToNestable(token: Contract, to: string): Promise<number> {
+  async function mintToNestable(token: Contract, to: string): Promise<BigNumber> {
     await equip.mint(to, 1, { value: ONE_ETH });
-    return (await equip.totalSupply()).toNumber();
+    return await equip.totalSupply();
   }
 
   shouldBehaveLikeMultiAsset(mintToNestable, addAssetEntryEquippablesFromImpl, addAssetToToken);
@@ -80,6 +88,15 @@ describe('RMRKEquippableImpl Other', async function () {
       expect(await equip.name()).to.equal('equipWithEquippable');
       expect(await equip.symbol()).to.equal('NWE');
     });
+  });
+
+  it('can support expected interfaces', async function () {
+    expect(await equip.supportsInterface(IERC721)).to.equal(true);
+    expect(await equip.supportsInterface(IERC721Metadata)).to.equal(true);
+    expect(await equip.supportsInterface(IERC5773)).to.equal(true);
+    expect(await equip.supportsInterface(IERC6059)).to.equal(true);
+    expect(await equip.supportsInterface(IERC6220)).to.equal(true);
+    expect(await equip.supportsInterface(IRMRKImplementation)).to.equal(true);
   });
 
   it('auto accepts resource if send is token owner', async function () {

--- a/test/implementations/multiasset.ts
+++ b/test/implementations/multiasset.ts
@@ -16,7 +16,7 @@ import {
   ONE_ETH,
   singleFixtureWithArgs,
 } from '../utils';
-import { IERC721 } from '../interfaces';
+import { IERC721, IERC721Metadata, IERC5773, IRMRKImplementation } from '../interfaces';
 import { RMRKMultiAssetImpl, RMRKMultiAssetRenderUtils } from '../../typechain-types';
 
 const isTokenUriEnumerated = true;
@@ -54,8 +54,11 @@ describe('MultiAssetImpl Other Behavior', async () => {
       this.token = token;
     });
 
-    it('can support IERC721', async function () {
+    it('can support expected interfaces', async function () {
       expect(await token.supportsInterface(IERC721)).to.equal(true);
+      expect(await token.supportsInterface(IERC721Metadata)).to.equal(true);
+      expect(await token.supportsInterface(IERC5773)).to.equal(true);
+      expect(await token.supportsInterface(IRMRKImplementation)).to.equal(true);
     });
 
     shouldBehaveLikeOwnableLock(isOwnableLockMock);

--- a/test/implementations/nestableMultiasset.ts
+++ b/test/implementations/nestableMultiasset.ts
@@ -21,6 +21,7 @@ import {
   transfer,
 } from '../utils';
 import { RMRKMultiAssetRenderUtils, RMRKNestableMultiAssetImpl } from '../../typechain-types';
+import { IERC6059, IERC721, IRMRKImplementation } from '../interfaces';
 
 const isTokenUriEnumerated = false;
 
@@ -99,6 +100,12 @@ describe('NestableMultiAssetImpl Other Behavior', function () {
 
     ({ token } = await loadFixture(singleFixture));
     this.parentToken = token;
+  });
+
+  it('can support expected interfaces', async function () {
+    expect(await token.supportsInterface(IERC721)).to.equal(true);
+    expect(await token.supportsInterface(IERC6059)).to.equal(true);
+    expect(await token.supportsInterface(IRMRKImplementation)).to.equal(true);
   });
 
   describe('Approval Cleaning', async function () {

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -17,6 +17,7 @@ const IERC6454alpha = '0x23f06346'; // ERC6454
 const IRMRKTokenProperties = '0x6a49fd01';
 const IRMRKTokenPropertiesRepository = '0x3280e8fd';
 const IRMRKTypedMultiAsset = '0x7f7bb665';
+const IRMRKImplementation = '0x524D524B'; // "RMRK" in ASCII hex
 
 export {
   IERC165,
@@ -38,4 +39,5 @@ export {
   IRMRKTypedMultiAsset,
   IRMRKTokenPropertiesRepository,
   IRMRKTokenProperties,
+  IRMRKImplementation,
 };


### PR DESCRIPTION
# Description

Improves interface support testing on implementations. The interface is included as public constant on core, and it comes from the ASCII code on hex corresponding to "RMRK".

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new constant `RMRK_INTERFACE` to the `RMRKCore` contract and several other contracts, along with corresponding documentation updates.

### Detailed summary
- Adds `RMRK_INTERFACE` constant to `RMRKCore` contract and several other contracts
- `RMRK_INTERFACE` is a bytes4 value representing the ASCII hex code for "RMRK"
- Documentation updates for affected contracts to include `RMRK_INTERFACE` in the list of methods

> The following files were skipped due to too many changes: `docs/implementations/premint/RMRKNestableMultiAssetImplPreMint.md`, `docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md`, `docs/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.md`, `docs/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.md`, `docs/implementations/nativeTokenPay/RMRKNestableExternalEquipImpl.md`, `docs/mocks/extensions/soulbound/RMRKSoulboundAfterBlockNumberMock.md`, `docs/mocks/extensions/soulbound/RMRKSoulboundAfterTransactionsMock.md`, `docs/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.md`, `docs/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.md`, `docs/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.md`, `docs/mocks/extensions/soulbound/RMRKSoulboundNestableExternalEquippableMock.md`, `test/behavior/multiasset.ts`, `contracts/implementations/abstracts/RMRKAbstractNestableImpl.sol`, `contracts/implementations/abstracts/RMRKAbstractEquippableImpl.sol`, `test/interfaces.ts`, `contracts/implementations/abstracts/RMRKAbstractNestableMultiAssetImpl.sol`, `contracts/implementations/abstracts/RMRKAbstractMultiAssetImpl.sol`, `contracts/RMRK/nestable/RMRKNestableMultiAsset.sol`, `test/behavior/metadata.ts`, `test/behavior/royalties.ts`, `test/behavior/nestable.ts`, `contracts/RMRK/equippable/RMRKMinifiedEquippable.sol`, `test/implementations/nestableMultiasset.ts`, `test/implementations/multiasset.ts`, `test/implementations/equippable.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->