### PR TITLE
Render utils abandoned child

### DIFF
--- a/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
@@ -92,6 +92,17 @@ contract RMRKNestableRenderUtils {
         if (!isNFT) revert RMRKParentIsNotNFT();
     }
 
+    /**
+     * @notice Used to retrieve the immediate owner of the given token, and whether it is on the parent's active or pending children list.
+     * @dev If the immediate owner is not an NFT, the function returns false for both `inParentsActiveChildren` and `inParentsPendingChildren`.
+     * @param collection Address of the token's collection smart contract
+     * @param tokenId ID of the token
+     * @return directOwner Address of the given token's owner
+     * @return ownerId The ID of the parent token. Should be `0` if the owner is an externally owned account
+     * @return isNFT The boolean value signifying whether the owner is an NFT or not
+     * @return inParentsActiveChildren Whether the token is on the parent's active children list
+     * @return inParentsPendingChildren Whether the token is on the parent's pending children list
+     */
     function directOwnerOfWithParentsPerspective(
         address collection,
         uint256 tokenId
@@ -150,6 +161,13 @@ contract RMRKNestableRenderUtils {
         }
     }
 
+    /**
+     * @notice Used to identify if the given token is rejected or abandoned. That is, it's parent is an NFT but this token is neither on the parent's active nor pending children list.
+     * @dev Returns false if the immediate owner is not an NFT.
+     * @param collection Address of the token's collection smart contract
+     * @param tokenId ID of the token
+     * @return isRejectedOrAbandoned Whether the token is rejected or abandoned
+     */
     function isTokenRejectedOrAbandoned(
         address collection,
         uint256 tokenId

--- a/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
@@ -100,8 +100,8 @@ contract RMRKNestableRenderUtils {
      * @return directOwner Address of the given token's owner
      * @return ownerId The ID of the parent token. Should be `0` if the owner is an externally owned account
      * @return isNFT The boolean value signifying whether the owner is an NFT or not
-     * @return inParentsActiveChildren Whether the token is on the parent's active children list
-     * @return inParentsPendingChildren Whether the token is on the parent's pending children list
+     * @return inParentsActiveChildren A boolean value signifying whether the token is in the parent's active children list
+     * @return inParentsPendingChildren A boolean value signifying whether the token is in the parent's pending children list
      */
     function directOwnerOfWithParentsPerspective(
         address collection,

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -81,8 +81,8 @@ Used to retrieve the immediate owner of the given token, and whether it is on th
 | directOwner | address | Address of the given token&#39;s owner |
 | ownerId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
-| inParentsActiveChildren | bool | Whether the token is on the parent&#39;s active children list |
-| inParentsPendingChildren | bool | Whether the token is on the parent&#39;s pending children list |
+| inParentsActiveChildren | bool | A boolean value signifying whether the token is in the parent&#39;s active children list |
+| inParentsPendingChildren | bool | A boolean value signifying whether the token is in the parent&#39;s pending children list |
 
 ### equippedChildrenOf
 

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -63,26 +63,26 @@ Used to compose the given equippables.
 function directOwnerOfWithParentsPerspective(address collection, uint256 tokenId) external view returns (address directOwner, uint256 ownerId, bool isNFT, bool inParentsActiveChildren, bool inParentsPendingChildren)
 ```
 
+Used to retrieve the immediate owner of the given token, and whether it is on the parent&#39;s active or pending children list.
 
-
-
+*If the immediate owner is not an NFT, the function returns false for both `inParentsActiveChildren` and `inParentsPendingChildren`.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| collection | address | undefined |
-| tokenId | uint256 | undefined |
+| collection | address | Address of the token&#39;s collection smart contract |
+| tokenId | uint256 | ID of the token |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| directOwner | address | undefined |
-| ownerId | uint256 | undefined |
-| isNFT | bool | undefined |
-| inParentsActiveChildren | bool | undefined |
-| inParentsPendingChildren | bool | undefined |
+| directOwner | address | Address of the given token&#39;s owner |
+| ownerId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
+| inParentsActiveChildren | bool | Whether the token is on the parent&#39;s active children list |
+| inParentsPendingChildren | bool | Whether the token is on the parent&#39;s pending children list |
 
 ### equippedChildrenOf
 
@@ -646,22 +646,22 @@ Used to verify whether a given child asset is equipped into a given parent slot.
 function isTokenRejectedOrAbandoned(address collection, uint256 tokenId) external view returns (bool isRejectedOrAbandoned)
 ```
 
+Used to identify if the given token is rejected or abandoned. That is, it&#39;s parent is an NFT but this token is neither on the parent&#39;s active nor pending children list.
 
-
-
+*Returns false if the immediate owner is not an NFT.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| collection | address | undefined |
-| tokenId | uint256 | undefined |
+| collection | address | Address of the token&#39;s collection smart contract |
+| tokenId | uint256 | ID of the token |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| isRejectedOrAbandoned | bool | undefined |
+| isRejectedOrAbandoned | bool | Whether the token is rejected or abandoned |
 
 ### splitSlotAndFixedParts
 

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -57,6 +57,33 @@ Used to compose the given equippables.
 | fixedParts | RMRKEquipRenderUtils.FixedPart[] | An array of fixed parts respresented by the `FixedPart` structs present on the asset |
 | slotParts | RMRKEquipRenderUtils.EquippedSlotPart[] | An array of slot parts represented by the `EquippedSlotPart` structs present on the asset |
 
+### directOwnerOfWithParentsPerspective
+
+```solidity
+function directOwnerOfWithParentsPerspective(address collection, uint256 tokenId) external view returns (address directOwner, uint256 ownerId, bool isNFT, bool inParentsActiveChildren, bool inParentsPendingChildren)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection | address | undefined |
+| tokenId | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| directOwner | address | undefined |
+| ownerId | uint256 | undefined |
+| isNFT | bool | undefined |
+| inParentsActiveChildren | bool | undefined |
+| inParentsPendingChildren | bool | undefined |
+
 ### equippedChildrenOf
 
 ```solidity
@@ -612,6 +639,29 @@ Used to verify whether a given child asset is equipped into a given parent slot.
 | Name | Type | Description |
 |---|---|---|
 | isEquipped | bool | Boolean value signifying whether the child asset is equipped into the parent slot or not |
+
+### isTokenRejectedOrAbandoned
+
+```solidity
+function isTokenRejectedOrAbandoned(address collection, uint256 tokenId) external view returns (bool isRejectedOrAbandoned)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection | address | undefined |
+| tokenId | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| isRejectedOrAbandoned | bool | undefined |
 
 ### splitSlotAndFixedParts
 

--- a/docs/RMRK/utils/RMRKNestableRenderUtils.md
+++ b/docs/RMRK/utils/RMRKNestableRenderUtils.md
@@ -29,6 +29,33 @@ Check if the child is owned by the expected parent.
 | expectedParent | address | Address of the expected parent contract |
 | expectedParentId | uint256 | ID of the expected parent token |
 
+### directOwnerOfWithParentsPerspective
+
+```solidity
+function directOwnerOfWithParentsPerspective(address collection, uint256 tokenId) external view returns (address directOwner, uint256 ownerId, bool isNFT, bool inParentsActiveChildren, bool inParentsPendingChildren)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection | address | undefined |
+| tokenId | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| directOwner | address | undefined |
+| ownerId | uint256 | undefined |
+| isNFT | bool | undefined |
+| inParentsActiveChildren | bool | undefined |
+| inParentsPendingChildren | bool | undefined |
+
 ### getChildIndex
 
 ```solidity
@@ -102,6 +129,29 @@ Used to retrieve the given child&#39;s index in its parent&#39;s pending child t
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | The index of the child token in the parent token&#39;s pending child tokens array |
+
+### isTokenRejectedOrAbandoned
+
+```solidity
+function isTokenRejectedOrAbandoned(address collection, uint256 tokenId) external view returns (bool isRejectedOrAbandoned)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection | address | undefined |
+| tokenId | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| isRejectedOrAbandoned | bool | undefined |
 
 ### validateChildOf
 

--- a/docs/RMRK/utils/RMRKNestableRenderUtils.md
+++ b/docs/RMRK/utils/RMRKNestableRenderUtils.md
@@ -35,26 +35,26 @@ Check if the child is owned by the expected parent.
 function directOwnerOfWithParentsPerspective(address collection, uint256 tokenId) external view returns (address directOwner, uint256 ownerId, bool isNFT, bool inParentsActiveChildren, bool inParentsPendingChildren)
 ```
 
+Used to retrieve the immediate owner of the given token, and whether it is on the parent&#39;s active or pending children list.
 
-
-
+*If the immediate owner is not an NFT, the function returns false for both `inParentsActiveChildren` and `inParentsPendingChildren`.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| collection | address | undefined |
-| tokenId | uint256 | undefined |
+| collection | address | Address of the token&#39;s collection smart contract |
+| tokenId | uint256 | ID of the token |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| directOwner | address | undefined |
-| ownerId | uint256 | undefined |
-| isNFT | bool | undefined |
-| inParentsActiveChildren | bool | undefined |
-| inParentsPendingChildren | bool | undefined |
+| directOwner | address | Address of the given token&#39;s owner |
+| ownerId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
+| inParentsActiveChildren | bool | Whether the token is on the parent&#39;s active children list |
+| inParentsPendingChildren | bool | Whether the token is on the parent&#39;s pending children list |
 
 ### getChildIndex
 
@@ -136,22 +136,22 @@ Used to retrieve the given child&#39;s index in its parent&#39;s pending child t
 function isTokenRejectedOrAbandoned(address collection, uint256 tokenId) external view returns (bool isRejectedOrAbandoned)
 ```
 
+Used to identify if the given token is rejected or abandoned. That is, it&#39;s parent is an NFT but this token is neither on the parent&#39;s active nor pending children list.
 
-
-
+*Returns false if the immediate owner is not an NFT.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| collection | address | undefined |
-| tokenId | uint256 | undefined |
+| collection | address | Address of the token&#39;s collection smart contract |
+| tokenId | uint256 | ID of the token |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| isRejectedOrAbandoned | bool | undefined |
+| isRejectedOrAbandoned | bool | Whether the token is rejected or abandoned |
 
 ### validateChildOf
 

--- a/docs/RMRK/utils/RMRKNestableRenderUtils.md
+++ b/docs/RMRK/utils/RMRKNestableRenderUtils.md
@@ -53,8 +53,8 @@ Used to retrieve the immediate owner of the given token, and whether it is on th
 | directOwner | address | Address of the given token&#39;s owner |
 | ownerId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
-| inParentsActiveChildren | bool | Whether the token is on the parent&#39;s active children list |
-| inParentsPendingChildren | bool | Whether the token is on the parent&#39;s pending children list |
+| inParentsActiveChildren | bool | A boolean value signifying whether the token is in the parent&#39;s active children list |
+| inParentsPendingChildren | bool | A boolean value signifying whether the token is in the parent&#39;s pending children list |
 
 ### getChildIndex
 

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -1065,6 +1065,48 @@ describe('Extended NFT render utils', function () {
         ),
       ).to.eql([false, [true, false, true]]);
     });
+
+    it('can identify rejected children', async function () {
+      expect(await renderUtils.isTokenRejectedOrAbandoned(nestable.address, childTokenOne)).to.be
+        .false;
+      await nestable
+        .connect(rootOwner)
+        .transferChild(
+          parentTokenOne,
+          ethers.constants.AddressZero,
+          0,
+          0,
+          nestable.address,
+          childTokenOne,
+          true,
+          '0x',
+        );
+      expect(await renderUtils.isTokenRejectedOrAbandoned(nestable.address, childTokenOne)).to.be
+        .true;
+    });
+
+    it('can identify abandoned children', async function () {
+      await nestable
+        .connect(rootOwner)
+        .acceptChild(parentTokenOne, 0, nestable.address, childTokenOne);
+
+      expect(await renderUtils.isTokenRejectedOrAbandoned(nestable.address, childTokenOne)).to.be
+        .false;
+      await nestable
+        .connect(rootOwner)
+        .transferChild(
+          parentTokenOne,
+          ethers.constants.AddressZero,
+          0,
+          0,
+          nestable.address,
+          childTokenOne,
+          false,
+          '0x',
+        );
+      expect(await renderUtils.isTokenRejectedOrAbandoned(nestable.address, childTokenOne)).to.be
+        .true;
+    });
   });
 });
 

--- a/test/renderUtils.ts
+++ b/test/renderUtils.ts
@@ -1066,6 +1066,12 @@ describe('Extended NFT render utils', function () {
       ).to.eql([false, [true, false, true]]);
     });
 
+    it('can get directOwnerOf with parents perspective', async function () {
+      expect(
+        await renderUtils.directOwnerOfWithParentsPerspective(nestable.address, parentTokenOne),
+      ).to.eql([rootOwner.address, ethers.BigNumber.from(0), false, false, false]);
+    });
+
     it('can identify rejected children', async function () {
       expect(await renderUtils.isTokenRejectedOrAbandoned(nestable.address, childTokenOne)).to.be
         .false;


### PR DESCRIPTION
# Description

UI needs an easy way to detect if a child was rejected/abandoned. This PR adds utility method which extends `IERC6059.directOwnerOf` to add information about whether the parent (if direct owner is an NFT) considers the token a pending or active child.

# Actions

Adds 
```
directOwnerOfWithParentsPerspective(
    address collection,
    uint256 tokenId
): (
    address directOwner,
    uint256 ownerId,
    bool isNFT,
    bool inParentsActiveChildren,
    bool inParentsPendingChildren
)
```
Adds
```
function isTokenRejectedOrAbandoned(
    address collection,
    uint256 tokenId
): (bool isRejectedOrAbandoned)
```
# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds two functions to `RMRKNestableRenderUtils`: `directOwnerOfWithParentsPerspective` and `isTokenRejectedOrAbandoned`. The former retrieves the immediate owner of a given token and whether it is on the parent's active or pending children list. The latter identifies if a given token is rejected or abandoned. 

### Detailed summary
- Adds `directOwnerOfWithParentsPerspective` function to `RMRKNestableRenderUtils`
- Adds `isTokenRejectedOrAbandoned` function to `RMRKNestableRenderUtils`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->