### PR TITLE
Implements General BulkWriter.

### DIFF
--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -161,3 +161,7 @@ error RMRKUnexpectedParent();
 error RMRKZeroLengthIdsPassed();
 /// Attempting to set the royalties to a value higher than 100% (10000 in base points)
 error RMRKRoyaltiesTooHigh();
+/// Attempting to do a bulk operation on a token that is not owned by the caller
+error RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
+/// Attempting to do a bulk operation with multiple tokens at a time
+error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();

--- a/contracts/RMRK/utils/RMRKBulkWriter.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriter.sol
@@ -4,9 +4,7 @@ pragma solidity ^0.8.18;
 
 import "../equippable/IERC6220.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-
-error RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
-error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
+import "../library/RMRKErrors.sol";
 
 /**
  * @title RMRKBulkWriter

--- a/contracts/RMRK/utils/RMRKBulkWriter.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriter.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.18;
+
+import "../equippable/IERC6220.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+error RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
+error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
+
+/**
+ * @title RMRKBulkWriter
+ * @author RMRK team
+ * @notice Smart contract of the RMRK Bulk Writer module.
+ * @dev Extra utility functions for RMRK contracts.
+ */
+contract RMRKBulkWriter {
+    /**
+     * @notice Used to provide a struct for inputing unequip data.
+     * @dev Only used for input and not storage of data
+     * @return assetId ID of the asset that we are equipping into
+     * @return slotPartId ID of the slot part that we are using to unequip
+     */
+    struct IntakeUnequip {
+        uint64 assetId;
+        uint64 slotPartId;
+    }
+
+    /**
+     * @notice Reverts if the caller is not the owner of the token
+     * @param collection Address of the collection that this contract is managing.
+     * @param tokenId ID of the token we are managing.
+     */
+    modifier onlyTokenOwner(address collection, uint256 tokenId) {
+        _checkTokenOwner(collection, tokenId);
+        _;
+    }
+
+    /**
+     * @notice Initializes the contract
+     */
+    constructor() {}
+
+    /**
+     * @notice Replaces the current equipped child on the asset and slot combination with the given one
+     * @dev The `IntakeEquip` stuct contains the following data:
+     *  [
+     *      tokenId,
+     *      childIndex,
+     *      assetId,
+     *      slotPartId,
+     *      childAssetId
+     *  ]
+     * @param collection Address of the collection that this contract is managing.
+     * @param data An `IntakeEquip` struct specifying the equip data.
+     */
+    function replaceEquip(
+        address collection,
+        IERC6220.IntakeEquip memory data
+    ) public onlyTokenOwner(collection, data.tokenId) {
+        IERC6220(collection).unequip(
+            data.tokenId,
+            data.assetId,
+            data.slotPartId
+        );
+        IERC6220(collection).equip(data);
+    }
+
+    /**
+     * @notice Performs multiple unequip and equip operations
+     * @dev Unequip operations must run first
+     * @dev tokenId is included as a parameter to be able to do a single check for ownership
+     * @dev Every tokenId in the `IntakeEquip` structs must match the tokenId passed in
+     * @dev The `IntakeUnequip` stuct contains the following data:
+     *  [
+     *      assetId,
+     *      slotPartId,
+     *  ]
+     * @dev The `IntakeEquip` stuct contains the following data:
+     *  [
+     *      tokenId,
+     *      childIndex,
+     *      assetId,
+     *      slotPartId,
+     *      childAssetId
+     *  ]
+     * @param collection Address of the collection that this contract is managing.
+     * @param tokenId ID of the token we are managing.
+     * @param unequips[] An array of `IntakeUnequip` structs specifying the slots to unequip.
+     * @param equips[] An array of `IntakeEquip` structs specifying the slots to equip.
+     */
+    function bulkEquip(
+        address collection,
+        uint256 tokenId,
+        IntakeUnequip[] memory unequips,
+        IERC6220.IntakeEquip[] memory equips
+    ) public onlyTokenOwner(collection, tokenId) {
+        uint256 length = unequips.length;
+        for (uint256 i = 0; i < length; ) {
+            IERC6220(collection).unequip(
+                tokenId,
+                unequips[i].assetId,
+                unequips[i].slotPartId
+            );
+            unchecked {
+                ++i;
+            }
+        }
+        length = equips.length;
+        for (uint256 i = 0; i < length; ) {
+            if (equips[i].tokenId != tokenId) {
+                revert RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
+            }
+            IERC6220(collection).equip(equips[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice Checks if the caller is the owner of the token
+     * @dev Reverts if the caller is not the owner of the token
+     * @param collection Address of the collection that this contract is managing.
+     * @param tokenId ID of the token we are managing.
+     */
+    function _checkTokenOwner(
+        address collection,
+        uint256 tokenId
+    ) internal view {
+        address tokenOwner = IERC721(collection).ownerOf(tokenId);
+        if (tokenOwner != msg.sender) {
+            revert RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
+        }
+    }
+}

--- a/contracts/RMRK/utils/RMRKBulkWriter.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriter.sol
@@ -17,7 +17,7 @@ error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
 contract RMRKBulkWriter {
     /**
      * @notice Used to provide a struct for inputing unequip data.
-     * @dev Only used for input and not storage of data
+     * @dev Only used for input and not storage of data.
      * @return assetId ID of the asset that we are equipping into
      * @return slotPartId ID of the slot part that we are using to unequip
      */
@@ -27,9 +27,9 @@ contract RMRKBulkWriter {
     }
 
     /**
-     * @notice Reverts if the caller is not the owner of the token
-     * @param collection Address of the collection that this contract is managing.
-     * @param tokenId ID of the token we are managing.
+     * @notice Reverts if the caller is not the owner of the token.
+     * @param collection Address of the collection that this contract is managing
+     * @param tokenId ID of the token we are managing
      */
     modifier onlyTokenOwner(address collection, uint256 tokenId) {
         _checkTokenOwner(collection, tokenId);
@@ -37,12 +37,12 @@ contract RMRKBulkWriter {
     }
 
     /**
-     * @notice Initializes the contract
+     * @notice Initializes the contract.
      */
     constructor() {}
 
     /**
-     * @notice Replaces the current equipped child on the asset and slot combination with the given one
+     * @notice Replaces the current equipped child in the asset and slot combination with the given one.
      * @dev The `IntakeEquip` stuct contains the following data:
      *  [
      *      tokenId,
@@ -51,8 +51,8 @@ contract RMRKBulkWriter {
      *      slotPartId,
      *      childAssetId
      *  ]
-     * @param collection Address of the collection that this contract is managing.
-     * @param data An `IntakeEquip` struct specifying the equip data.
+     * @param collection Address of the collection that this contract is managing
+     * @param data An `IntakeEquip` struct specifying the equip data
      */
     function replaceEquip(
         address collection,
@@ -67,10 +67,11 @@ contract RMRKBulkWriter {
     }
 
     /**
-     * @notice Performs multiple unequip and equip operations
-     * @dev Unequip operations must run first
-     * @dev tokenId is included as a parameter to be able to do a single check for ownership
-     * @dev Every tokenId in the `IntakeEquip` structs must match the tokenId passed in
+     * @notice Performs multiple unequip and/or equip operations.
+     * @dev Unequip operations must run first.
+     * @dev Unequip operations do not need to be related to the equip operations; this method does not force you to only equip the assets into the slots that were unequipped.
+     * @dev `tokenId` is included as a parameter to be able to do a single check for ownership.
+     * @dev Every `tokenId` in the `IntakeEquip` structs must match the `tokenId` passed as the argument.
      * @dev The `IntakeUnequip` stuct contains the following data:
      *  [
      *      assetId,
@@ -84,10 +85,10 @@ contract RMRKBulkWriter {
      *      slotPartId,
      *      childAssetId
      *  ]
-     * @param collection Address of the collection that this contract is managing.
-     * @param tokenId ID of the token we are managing.
-     * @param unequips[] An array of `IntakeUnequip` structs specifying the slots to unequip.
-     * @param equips[] An array of `IntakeEquip` structs specifying the slots to equip.
+     * @param collection Address of the collection that this contract is managing
+     * @param tokenId ID of the token we are managing
+     * @param unequips[] An array of `IntakeUnequip` structs specifying the slots to unequip
+     * @param equips[] An array of `IntakeEquip` structs specifying the slots to equip
      */
     function bulkEquip(
         address collection,
@@ -96,7 +97,7 @@ contract RMRKBulkWriter {
         IERC6220.IntakeEquip[] memory equips
     ) public onlyTokenOwner(collection, tokenId) {
         uint256 length = unequips.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i; i < length; ) {
             IERC6220(collection).unequip(
                 tokenId,
                 unequips[i].assetId,
@@ -107,7 +108,7 @@ contract RMRKBulkWriter {
             }
         }
         length = equips.length;
-        for (uint256 i = 0; i < length; ) {
+        for (uint256 i; i < length; ) {
             if (equips[i].tokenId != tokenId) {
                 revert RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
             }
@@ -119,10 +120,10 @@ contract RMRKBulkWriter {
     }
 
     /**
-     * @notice Checks if the caller is the owner of the token
-     * @dev Reverts if the caller is not the owner of the token
-     * @param collection Address of the collection that this contract is managing.
-     * @param tokenId ID of the token we are managing.
+     * @notice Validates that the caller is the owner of the token.
+     * @dev Reverts if the caller is not the owner of the token.
+     * @param collection Address of the collection that this contract is managing
+     * @param tokenId ID of the token we are managing
      */
     function _checkTokenOwner(
         address collection,

--- a/docs/RMRK/utils/RMRKBulkWriter.md
+++ b/docs/RMRK/utils/RMRKBulkWriter.md
@@ -1,0 +1,76 @@
+# RMRKBulkWriter
+
+*RMRK team*
+
+> RMRKBulkWriter
+
+Smart contract of the RMRK Bulk Writer module.
+
+*Extra utility functions for RMRK contracts.*
+
+## Methods
+
+### bulkEquip
+
+```solidity
+function bulkEquip(address collection, uint256 tokenId, RMRKBulkWriter.IntakeUnequip[] unequips, IERC6220.IntakeEquip[] equips) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection | address | undefined |
+| tokenId | uint256 | undefined |
+| unequips | RMRKBulkWriter.IntakeUnequip[] | undefined |
+| equips | IERC6220.IntakeEquip[] | undefined |
+
+### replaceEquip
+
+```solidity
+function replaceEquip(address collection, IERC6220.IntakeEquip data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection | address | undefined |
+| data | IERC6220.IntakeEquip | undefined |
+
+
+
+
+## Errors
+
+### RMRKCanOnlyDoBulkOperationsOnOwnedTokens
+
+```solidity
+error RMRKCanOnlyDoBulkOperationsOnOwnedTokens()
+```
+
+
+
+
+
+
+### RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime
+
+```solidity
+error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime()
+```
+
+
+
+
+
+
+

--- a/docs/RMRK/utils/RMRKBulkWriter.md
+++ b/docs/RMRK/utils/RMRKBulkWriter.md
@@ -57,7 +57,7 @@ function replaceEquip(address collection, IERC6220.IntakeEquip data) external no
 error RMRKCanOnlyDoBulkOperationsOnOwnedTokens()
 ```
 
-
+Attempting to do a bulk operation on a token that is not owned by the caller
 
 
 
@@ -68,7 +68,7 @@ error RMRKCanOnlyDoBulkOperationsOnOwnedTokens()
 error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime()
 ```
 
-
+Attempting to do a bulk operation with multiple tokens at a time
 
 
 

--- a/scripts/deploy_bulkWriter.ts
+++ b/scripts/deploy_bulkWriter.ts
@@ -1,0 +1,32 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers, run } from 'hardhat';
+
+export const sleep = (ms: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+};
+
+async function main() {
+  const accounts: SignerWithAddress[] = await ethers.getSigners();
+  const owner = accounts[0];
+  console.log('Deployer address: ' + owner.address);
+  // We get the contract to deploy
+  const factory = await ethers.getContractFactory('RMRKBulkWriter');
+  const bulkwriter = await factory.deploy();
+  await bulkwriter.deployed();
+  console.log('RMRK Bulk Writer deployed to:', bulkwriter.address);
+  await sleep(1000);
+
+  await run('verify:verify', {
+    address: bulkwriter.address,
+    constructorArguments: [],
+  });
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
# Description

Describe the additions/improvements this PR contains.

# Actions

Provide overview of actions taken to address the additions/improvements.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new bulk operation error and a sleep function to the RMRK project. It also adds a new general bulk writer contract and modifies the existing one. 

### Detailed summary
- Adds `RMRKCanOnlyDoBulkOperationsOnOwnedTokens()` error to `RMRKErrors.sol`
- Adds `RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime()` error to `RMRKErrors.sol`
- Adds `sleep()` function to `deploy_bulkWriter.ts`
- Adds `RMRKBulkWriter` contract to `RMRKBulkWriter.sol`
- Modifies `RMRKBulkWriterPerCollection` contract to inherit from `RMRKBulkWriter`
- Adds `bulkWriterPerCollection` to `bulkWriterFixture()` in `bulkWriter.ts`
- Adds `bulkWriterPerCollection` to beforeEach() in `Advanced Equip Render Utils` tests
- Adds new tests for `bulkWriterPerCollection` contract

> The following files were skipped due to too many changes: `test/bulkWriter.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->