### PR TITLE
Renames ERC6454beta to ERC6454.

### DIFF
--- a/contracts/RMRK/extension/soulbound/IERC6454.sol
+++ b/contracts/RMRK/extension/soulbound/IERC6454.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.18;
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
- * @title IERC6454beta
+ * @title IERC6454
  * @author RMRK team
  * @notice A minimal extension to identify the transferability of Non-Fungible Tokens.
  */
-interface IERC6454beta is IERC165 {
+interface IERC6454 is IERC165 {
     /**
      * @notice Used to check whether the given token is transferable or not.
      * @dev If this function returns `false`, the transfer of the token MUST revert execution.

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.18;
 
 import "../../core/RMRKCore.sol";
-import "./IERC6454beta.sol";
+import "./IERC6454.sol";
 import "../../library/RMRKErrors.sol";
 
 /**
@@ -11,7 +11,7 @@ import "../../library/RMRKErrors.sol";
  * @author RMRK team
  * @notice Smart contract of the RMRK Soulbound module.
  */
-abstract contract RMRKSoulbound is IERC6454beta, RMRKCore {
+abstract contract RMRKSoulbound is IERC6454, RMRKCore {
     /**
      * @notice Hook that is called before any token transfer. This includes minting and burning.
      * @dev This is a hook ensuring that all transfers of tokens are reverted if the token is soulbound.
@@ -46,6 +46,6 @@ abstract contract RMRKSoulbound is IERC6454beta, RMRKCore {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual returns (bool) {
-        return interfaceId == type(IERC6454beta).interfaceId;
+        return interfaceId == type(IERC6454).interfaceId;
     }
 }

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol
@@ -30,7 +30,7 @@ abstract contract RMRKSoulboundAfterBlockNumber is RMRKSoulbound {
     }
 
     /**
-     * @inheritdoc IERC6454beta
+     * @inheritdoc IERC6454
      */
     function isTransferable(
         uint256,

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol
@@ -65,7 +65,7 @@ abstract contract RMRKSoulboundAfterTransactions is RMRKSoulbound {
     }
 
     /**
-     * @inheritdoc IERC6454beta
+     * @inheritdoc IERC6454
      */
     function isTransferable(
         uint256 tokenId,

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundPerToken.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundPerToken.sol
@@ -32,7 +32,7 @@ abstract contract RMRKSoulboundPerToken is RMRKSoulbound {
     }
 
     /**
-     * @inheritdoc IERC6454beta
+     * @inheritdoc IERC6454
      */
     function isTransferable(
         uint256 tokenId,

--- a/contracts/RMRK/utils/RMRKRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKRenderUtils.sol
@@ -159,8 +159,8 @@ contract RMRKRenderUtils {
             data.pendingAssetCount = target.getPendingAssets(tokenId).length;
             data.priorities = target.getActiveAssetPriorities(tokenId);
         }
-        if (target.supportsInterface(type(IERC6454beta).interfaceId)) {
-            data.isSoulbound = !IERC6454beta(targetCollection).isTransferable(
+        if (target.supportsInterface(type(IERC6454).interfaceId)) {
+            data.isSoulbound = !IERC6454(targetCollection).isTransferable(
                 tokenId,
                 address(0),
                 address(0)

--- a/docs/RMRK/extension/soulbound/IERC6454.md
+++ b/docs/RMRK/extension/soulbound/IERC6454.md
@@ -1,8 +1,8 @@
-# IERC6454beta
+# IERC6454
 
 *RMRK team*
 
-> IERC6454beta
+> IERC6454
 
 A minimal extension to identify the transferability of Non-Fungible Tokens.
 

--- a/test/extensions/soulbound.ts
+++ b/test/extensions/soulbound.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { loadFixture, mine } from '@nomicfoundation/hardhat-network-helpers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { bn, mintFromMock, nestMintFromMock } from '../utils';
-import { IERC165, IERC6454beta, IOtherInterface } from '../interfaces';
+import { IERC165, IERC6454, IOtherInterface } from '../interfaces';
 import {
   RMRKSoulboundAfterBlockNumberMock,
   RMRKSoulboundAfterTransactionsMock,
@@ -133,7 +133,7 @@ describe('RMRKSoulbound variants', async function () {
     });
 
     it('can support IERC6454', async function () {
-      expect(await token.supportsInterface(IERC6454beta)).to.equal(true);
+      expect(await token.supportsInterface(IERC6454)).to.equal(true);
     });
 
     it('can get last block to transfer', async function () {
@@ -168,7 +168,7 @@ describe('RMRKSoulbound variants', async function () {
     });
 
     it('can support IERC6454', async function () {
-      expect(await token.supportsInterface(IERC6454beta)).to.equal(true);
+      expect(await token.supportsInterface(IERC6454)).to.equal(true);
     });
 
     it('does not support other interfaces', async function () {
@@ -200,7 +200,7 @@ describe('RMRKSoulbound variants', async function () {
     });
 
     it('can support IERC6454', async function () {
-      expect(await token.supportsInterface(IERC6454beta)).to.equal(true);
+      expect(await token.supportsInterface(IERC6454)).to.equal(true);
     });
 
     it('does not support other interfaces', async function () {
@@ -251,7 +251,7 @@ async function shouldBehaveLikeSoulboundBasic() {
   });
 
   it('can support IERC6454', async function () {
-    expect(await soulbound.supportsInterface(IERC6454beta)).to.equal(true);
+    expect(await soulbound.supportsInterface(IERC6454)).to.equal(true);
   });
 
   it('does not support other interfaces', async function () {

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -13,7 +13,7 @@ const IRMRKNestableAutoIndex = '0x1884d52d';
 const IRMRKMultiAssetAutoIndex = '0x1cf132fe';
 const IRMRKNestableExternalEquip = '0x8b7f3e99';
 const IRMRKReclaimableChild = '0x2fb59acf';
-const IERC6454beta = '0x91a6262f'; // ERC6454
+const IERC6454 = '0x91a6262f'; // ERC6454
 const IRMRKTokenProperties = '0x6a49fd01';
 const IRMRKTokenPropertiesRepository = '0x3280e8fd';
 const IRMRKTypedMultiAsset = '0x7f7bb665';
@@ -35,7 +35,7 @@ export {
   IRMRKMultiAssetAutoIndex,
   IRMRKNestableExternalEquip,
   IRMRKReclaimableChild,
-  IERC6454beta,
+  IERC6454,
   IRMRKTypedMultiAsset,
   IRMRKTokenPropertiesRepository,
   IRMRKTokenProperties,


### PR DESCRIPTION

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
