### PR TITLE
ADds withdrawRaisedERC20 method on all ERC20Pay implementations.

### DIFF
--- a/contracts/RMRK/utils/IERC20.sol
+++ b/contracts/RMRK/utils/IERC20.sol
@@ -8,6 +8,14 @@ pragma solidity ^0.8.18;
  */
 interface IERC20 {
     /**
+     * @notice Used to transfer tokens from the caller's account to another.
+     * @param to Address of the account to which the tokens are being transferred
+     * @param amount Amount of tokens that are being transferred
+     * @return A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`)
+     */
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    /**
      * @notice Used to transfer tokens from one address to another.
      * @param from Address of the account from which the the tokens are being transferred
      * @param to Address of the account to which the tokens are being transferred

--- a/contracts/implementations/erc20Pay/RMRKEquippableImplErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKEquippableImplErc20Pay.sol
@@ -103,4 +103,19 @@ contract RMRKEquippableImplErc20Pay is
     function _charge(uint256 value) internal virtual override {
         _chargeFromToken(msg.sender, address(this), value);
     }
+
+    /**
+     * @notice Used to withdraw the minting proceedings to a specified address.
+     * @dev This function can only be called by the owner.
+     * @param erc20 Address of the ERC20 token to withdraw
+     * @param to Address to receive the given amount of minting proceedings
+     * @param amount The amount to withdraw
+     */
+    function withdrawRaisedERC20(
+        address erc20,
+        address to,
+        uint256 amount
+    ) external onlyOwner {
+        IERC20(erc20).transfer(to, amount);
+    }
 }

--- a/contracts/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKMultiAssetImplErc20Pay.sol
@@ -92,4 +92,19 @@ contract RMRKMultiAssetImplErc20Pay is
             }
         }
     }
+
+    /**
+     * @notice Used to withdraw the minting proceedings to a specified address.
+     * @dev This function can only be called by the owner.
+     * @param erc20 Address of the ERC20 token to withdraw
+     * @param to Address to receive the given amount of minting proceedings
+     * @param amount The amount to withdraw
+     */
+    function withdrawRaisedERC20(
+        address erc20,
+        address to,
+        uint256 amount
+    ) external onlyOwner {
+        IERC20(erc20).transfer(to, amount);
+    }
 }

--- a/contracts/implementations/erc20Pay/RMRKNestableImplErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKNestableImplErc20Pay.sol
@@ -100,4 +100,19 @@ contract RMRKNestableImplErc20Pay is RMRKErc20Pay, RMRKAbstractNestableImpl {
     function _charge(uint256 value) internal virtual override {
         _chargeFromToken(msg.sender, address(this), value);
     }
+
+    /**
+     * @notice Used to withdraw the minting proceedings to a specified address.
+     * @dev This function can only be called by the owner.
+     * @param erc20 Address of the ERC20 token to withdraw
+     * @param to Address to receive the given amount of minting proceedings
+     * @param amount The amount to withdraw
+     */
+    function withdrawRaisedERC20(
+        address erc20,
+        address to,
+        uint256 amount
+    ) external onlyOwner {
+        IERC20(erc20).transfer(to, amount);
+    }
 }

--- a/contracts/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.sol
+++ b/contracts/implementations/erc20Pay/RMRKNestableMultiAssetImplErc20Pay.sol
@@ -103,4 +103,19 @@ contract RMRKNestableMultiAssetImplErc20Pay is
     function _charge(uint256 value) internal virtual override {
         _chargeFromToken(msg.sender, address(this), value);
     }
+
+    /**
+     * @notice Used to withdraw the minting proceedings to a specified address.
+     * @dev This function can only be called by the owner.
+     * @param erc20 Address of the ERC20 token to withdraw
+     * @param to Address to receive the given amount of minting proceedings
+     * @param amount The amount to withdraw
+     */
+    function withdrawRaisedERC20(
+        address erc20,
+        address to,
+        uint256 amount
+    ) external onlyOwner {
+        IERC20(erc20).transfer(to, amount);
+    }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -53,7 +53,7 @@ async function mintFromImplNativeToken(token: Contract, to: string): Promise<Big
 async function nestMintFromImplErc20Pay(
   token: Contract,
   to: string,
-  destinationId: number,
+  destinationId: BigNumber,
 ): Promise<BigNumber> {
   const erc20Address = token.erc20TokenAddress();
   const erc20Factory = await ethers.getContractFactory('ERC20Mock');


### PR DESCRIPTION
# Description

I did not add it on minting utils directly since it would unnecesarily increase the size for all implementations. 
The method expects the ERC20 token address, it could be retrieved from contract but it is more expensive in gas and size, and this way you could even recovered other ERC20s sent by mistake to the contract.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `withdrawRaisedERC20` function to multiple ERC20 payment implementation contracts and updates the `utils.ts` and `IERC20.sol` files to support it.

### Detailed summary
- Added `withdrawRaisedERC20` function to `RMRKMultiAssetImplErc20Pay.sol`, `RMRKNestableImplErc20Pay.sol`, `RMRKEquippableImplErc20Pay.sol`, and `RMRKNestableMultiAssetImplErc20Pay.sol`
- Updated `IERC20.sol` file to include `transfer` function documentation
- Updated `test/utils.ts` file to import `BigNumber` from `ethers`
- Added tests for `withdrawRaisedERC20` function in `lazyMintErc20Pay.ts` test file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->