### PR TITLE
Revert "Fix typos"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ That's it! This contract can receive and be nested by other instances of RMRKNes
 
 ### Nestable with MultiAsset
 
-A combination of Nestable and MultiAsset lego is a powerful way of designing Non-Fungible Tokens. To quickstart this
+A combintation of Nestable and MultiAsset lego is a powerful way of designing Non-Fungible Tokens. To quickstart this
 implementation ([RMRKNestableMultiAsset](./contracts/RMRK/nestable/RMRKNestableMultiAsset.sol)), you only need to follow
 the steps outlined for the [MultiAsset lego](#multiasset-rmrkmultiasset-erc-5773-context-dependent-multi-asset-tokens).
 

--- a/docs/RMRK/equippable/IERC6220.md
+++ b/docs/RMRK/equippable/IERC6220.md
@@ -92,9 +92,9 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
 ```
 
-Used to retrieve the priorities of the active resources of a given token.
+Used to retrieve the priorities of the active resoources of a given token.
 
-*Asset priorities are a non-sequential array of uint64 values with an array size equal to active asset  priorities.*
+*Asset priorities are a non-sequential array of uint64 values with an array size equal to active asset  priorites.*
 
 #### Parameters
 
@@ -186,7 +186,7 @@ function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
 
-*Assets are stored by reference mapping `_assets[assetId]`. Can be overridden to implement enumerate, fallback or other custom logic.*
+*Assets are stored by reference mapping `_assets[assetId]`.Can be overriden to implement enumerate, fallback or other custom logic.*
 
 #### Parameters
 
@@ -291,7 +291,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -325,7 +325,7 @@ function rejectAllAssets(uint256 tokenId, uint256 maxRejections) external nonpay
 
 Rejects all assets from the pending array of a given token.
 
-*Effectively deletes the pending array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist. Emits a {AssetRejected} event with assetId = 0.*
+*Effecitvely deletes the pending array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits a {AssetRejected} event with assetId = 0.*
 
 #### Parameters
 
@@ -360,7 +360,7 @@ function setApprovalForAllForAssets(address operator, bool approved) external no
 
 Used to add or remove an operator of assets for the caller.
 
-*Operators can call {acceptAsset}, {rejectAsset}, {rejectAllAssets} or {setPriority} for any token  owned by the caller. Requirements:  - The `operator` cannot be the caller.Emits an {ApprovalForAllForAssets} event.*
+*Operators can call {acceptAsset}, {rejectAsset}, {rejectAllAssets} or {setPriority} for any token  owned by the caller.Requirements:  - The `operator` cannot be the caller.Emits an {ApprovalForAllForAssets} event.*
 
 #### Parameters
 
@@ -377,14 +377,14 @@ function setPriority(uint256 tokenId, uint64[] priorities) external nonpayable
 
 Sets a new priority array for a given token.
 
-*The priority array is a non-sequential list of `uint64`s, where the lowest value is considered highest  priority.Value `0` of a priority is a special case equivalent to uninitialized. Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.  - The length of `priorities` must be equal the length of the active assets array.Emits a {AssetPrioritySet} event.*
+*The priority array is a non-sequential list of `uint64`s, where the lowest value is considered highest  priority.Value `0` of a priority is a special case equivalent to unitialized.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.  - The length of `priorities` must be equal the length of the active assets array.Emits a {AssetPrioritySet} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | ID of the token to set the priorities for |
-| priorities | uint64[] | An array of priorities of active assets. The succession of items in the priorities array  matches that of the succession of items in the active array |
+| priorities | uint64[] | An array of priorities of active assets. The succesion of items in the priorities array  matches that of the succesion of items in the active array |
 
 ### supportsInterface
 
@@ -508,7 +508,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 event AssetPrioritySet(uint256 indexed tokenId)
 ```
 
-Used to notify listeners that token&#39;s priority array is reordered.
+Used to notify listeners that token&#39;s prioritiy array is reordered.
 
 
 

--- a/docs/RMRK/equippable/IRMRKExternalEquip.md
+++ b/docs/RMRK/equippable/IRMRKExternalEquip.md
@@ -92,9 +92,9 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
 ```
 
-Used to retrieve the priorities of the active resources of a given token.
+Used to retrieve the priorities of the active resoources of a given token.
 
-*Asset priorities are a non-sequential array of uint64 values with an array size equal to active asset  priorities.*
+*Asset priorities are a non-sequential array of uint64 values with an array size equal to active asset  priorites.*
 
 #### Parameters
 
@@ -116,7 +116,7 @@ function getActiveAssets(uint256 tokenId) external view returns (uint64[])
 
 Used to retrieve IDs of the active assets of given token.
 
-*Asset data is stored by reference, in order to access the data corresponding to the ID, call  `getAssetMetadata(tokenId, assetId)`. You can safely get 10k*
+*Asset data is stored by reference, in order to access the data corresponding to the ID, call  `getAssetMetadata(tokenId, assetId)`.You can safely get 10k*
 
 #### Parameters
 
@@ -186,7 +186,7 @@ function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
 
-*Assets are stored by reference mapping `_assets[assetId]`. Can be overridden to implement enumerate, fallback or other custom logic.*
+*Assets are stored by reference mapping `_assets[assetId]`.Can be overriden to implement enumerate, fallback or other custom logic.*
 
 #### Parameters
 
@@ -308,7 +308,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
@@ -342,7 +342,7 @@ function rejectAllAssets(uint256 tokenId, uint256 maxRejections) external nonpay
 
 Rejects all assets from the pending array of a given token.
 
-*Effectively deletes the pending array. Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits a {AssetRejected} event with assetId = 0.*
+*Effecitvely deletes the pending array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits a {AssetRejected} event with assetId = 0.*
 
 #### Parameters
 
@@ -394,14 +394,14 @@ function setPriority(uint256 tokenId, uint64[] priorities) external nonpayable
 
 Sets a new priority array for a given token.
 
-*The priority array is a non-sequential list of `uint64`s, where the lowest value is considered highest  priority.Value `0` of a priority is a special case equivalent to uninitialized. Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.  - The length of `priorities` must be equal the length of the active assets array.Emits a {AssetPrioritySet} event.*
+*The priority array is a non-sequential list of `uint64`s, where the lowest value is considered highest  priority.Value `0` of a priority is a special case equivalent to unitialized.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.  - The length of `priorities` must be equal the length of the active assets array.Emits a {AssetPrioritySet} event.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
 | tokenId | uint256 | ID of the token to set the priorities for |
-| priorities | uint64[] | An array of priorities of active assets. The succession of items in the priorities array  matches that of the succession of items in the active array |
+| priorities | uint64[] | An array of priorities of active assets. The succesion of items in the priorities array  matches that of the succesion of items in the active array |
 
 ### supportsInterface
 
@@ -525,7 +525,7 @@ Used to notify listeners that an asset object at `assetId` is added to token&#39
 event AssetPrioritySet(uint256 indexed tokenId)
 ```
 
-Used to notify listeners that token&#39;s priority array is reordered.
+Used to notify listeners that token&#39;s prioritiy array is reordered.
 
 
 

--- a/docs/RMRK/utils/IERC20.md
+++ b/docs/RMRK/utils/IERC20.md
@@ -54,7 +54,7 @@ Used to transfer tokens from the caller&#39;s account to another.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the transfer was successful (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`) |
 
 ### transferFrom
 
@@ -70,7 +70,7 @@ Used to transfer tokens from one address to another.
 
 | Name | Type | Description |
 |---|---|---|
-| from | address | Address of the account from which the tokens are being transferred |
+| from | address | Address of the account from which the the tokens are being transferred |
 | to | address | Address of the account to which the tokens are being transferred |
 | amount | uint256 | Amount of tokens that are being transferred |
 
@@ -78,7 +78,7 @@ Used to transfer tokens from one address to another.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the transfer was successful (`true`) or not (`false`) |
+| _0 | bool | A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`) |
 
 
 


### PR DESCRIPTION
Reverts rmrk-team/evm#214

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes some typos in the documentation of the RMRK contracts. 

### Detailed summary
- Fixed typo in the README.md file
- Fixed typos in the IERC20.md file
- Fixed typos in the IRMRKExternalEquip.md file
- Fixed typos in the IERC6220.md file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->