### PR TITLE
Update v2 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Core implementations updates include breaking changes as well; names and symbols
 
 ### Changed
 
-- Recreated all ready-to-use implementations for premint and lazy minting with a native token or custom ERC20 token.
+- Recreated all ready-to-use implementations for premint and lazy minting with native tokens or custom ERC20 tokens.
 - Reduced size of `MinifiedEquippable` contract.
 - Premint versions now receive `tokenURI` on mint. Lazy mint versions use the base URL passed to a constructor and append `tokenId` to compose the `tokenURI`.
 - Removed Split Equippable implementations, which kept `MultiAsset` and `Equippable` legos in a different contract to `Nestable`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.0.0] - 2023-08-01
 
-This Release has major breaking changes in all ready to use implementations. The inheritance flow was highly simplified by merging all extra utilities which a marketplace would typically expect, into a single abstract contract: `RMRKImplementationBase`. This replaces `RMRKCollectionMetadata`, `RMRKMintingUtils` contracts, and `name` and `symbol` from all core implementations.
+This Release has significant breaking changes in all ready-to-use implementations. The inheritance flow was highly simplified, by merging all extra utilities, which a marketplace would typically expect, into a single abstract contract: `RMRKImplementationBase`. This contract replaces `RMRKCollectionMetadata`, `RMRKMintingUtils` contracts and `name` and `symbol` of all core implementations.
 
-The contract includes royalties, a method to update the royalties recipient, internal utils to keep tack of next token and asset Ids, and these getters which marketplaces typically expect:
+The contract includes royalties, a method to update the royalties recipient, internal utils to keep track of next token and asset IDs, and the following getters that marketplaces commonly expect:
 
 - `totalSupply`
 - `maxSupply`
@@ -17,42 +17,44 @@ The contract includes royalties, a method to update the royalties recipient, int
 - `symbol`
 - `collectionMetadata`
 
-Implementations no longer share the same constructor data, they take only the minimum needed. This reduces the size of the contracts giving more room to custom logic on top.
+Implementations no longer share the same constructor data; they only accept the necessary data. This reduces the size of the contracts allowing for more custom logic within your smart contract.
 
-Core implementations also have breaking changes, as name and symbol were removed from them to keep them fully non-opinionated.
+Core implementations updates include breaking changes as well; names and symbols were removed from them to keep them fully non-opinionated.
 
 ### Added
 
-- Added Soulbound implementation versions for all ready to use implementations.
-- Added `CollectionUtils` with methods to get several data points in a single call. This is a utility contract that needs to be deployed only once per chain, as `RenderUtils`. `getPaginatedMintedIds` Was moved from render utils to this contract.
-- Added new Render Utils: `getTotalDescendants`, `hasMoreThanOneLevelOfNesting`
+- Added Soulbound implementation versions for all ready-to-use implementations.
+- Added `CollectionUtils` with methods to get several data points with a single call. This is a utility contract that only needs to be deployed once per chain, just like `RenderUtils`. `getPaginatedMintedIds` was moved from render utils to this contract.
+- Added new Render Utils methods: `getTotalDescendants`, `hasMoreThanOneLevelOfNesting`
 - Added `TokenPropertiesRepository`.
 - Added `TokenHolder` extension.
-- Added new networks on hardhat config: Sepolia, Polygon Mumbai, Polygon and Mainnet. Removed Goerli.
-- Started Changelog.
+- Added new networks to Hardhat config: Sepolia, Polygon Mumbai, Polygon, and Mainnet. Removed Görli.
+- Started keeping a Changelog.
 
 ### Changed
 
-- Recreated all ready to use implementations for premint and lazy minting with native token or custom ERC20.
+- Recreated all ready-to-use implementations for premint and lazy minting with a native token or custom ERC20 token.
 - Reduced size of `MinifiedEquippable` contract.
-- Premint versions now receive `tokenURI` on mint. Lazy mint versions use base URL on constructor and append `tokenId` to get the `tokenURI`.
-- Removed Split Implementations, which kept `MultiAsset` and `Equippable` legos in a different contract to `Nestable`.
+- Premint versions now receive `tokenURI` on mint. Lazy mint versions use the base URL passed to a constructor and append `tokenId` to compose the `tokenURI`.
+- Removed Split Equippable implementations, which kept `MultiAsset` and `Equippable` legos in a different contract to `Nestable`.
 - Merged all the extras needed for a full implementation into a single contract: `RMRKImplementationBase`.
-- Splits tokenURI extension into 2 versions, one using Id per token, `RMRKTokenURIPerToken` and one using base URI, appending tokenId, `RMRKTokenURIEnumerated`.
+- Splits `tokenURI` extension into two versions, one using ID per token (`RMRKTokenURIPerToken`) and one using base URI, appending tokenId, (`RMRKTokenURIEnumerated`).
 - Removes several unneeded mocks.
 - Rellocates all errors into `RMRKErrors` lib.
-- Adds `IERC721Metadata` interface support on implementations
-- Emotes extension was removed in favor of shared repository.
-- All contracts now use solidity version 0.8.21
+- Adds `IERC721Metadata` interface support to implementations.
+- Emotes extension was removed in favor of the shared repository.
+- All contracts now use solidity version 0.8.21.
 - Upgrades dependencies.
-- Increases Istanbul code coverage to
-  - Statements: 100%
-  - Branches: 96.78%
-  - Functions: 99.72%
-  - Lines: 99.64%
+- Increases Istanbul code coverage:
+|                	| **Previous** 	| **Current** 	| **Change** 	|
+|:--------------:	|:------------:	|:-----------:	|------------	|
+| **Statements** 	|   100.00 %   	|   100.00 %  	|  + 0.00 %  	|
+|  **Branches**  	|    95.53 %   	|   96.78 %   	|  + 1.25 %  	|
+|  **Functions** 	|    99.60 %   	|   99.72 %   	|  + 0.12 %  	|
+|    **Lines**   	|    99.63 %   	|   99.46 %   	|  - 0.17 %  	|
 
 ### Fixed
 
-- Fix on `Transfer` event, which was sending root owner instead of direct owner in some cases.
-- Fixes reducing on balance of owner before the `_beforeTransfer` hooks in some contracts.
-- Fixes emotes repository so it supports every possible emoji, and relocates out of extensions folder.
+- Fixes `Transfer` event, which was sometimes sending root owner instead of the direct owner.
+- Fixes reducing the owner's balance before the `_beforeTransfer` hooks in some contracts.
+- Fixes emotes repository to support every possible emoji and relocate it from the extensions folder.


### PR DESCRIPTION
# Description

Minor rewordings and updates to the CHANGELOG for v2.0.0.

The coverage reporting has been redesigned to be presented in a table.

# Checklist

- [N/A] Verified code additions
- [N/A] Updated NatSpec comments (if applicable)
- [N/A] Regenerated docs
- [N/A] Ran prettier
- [N/A] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR focuses on a major release with significant breaking changes. The main changes include:
- Merging all extra utilities into a single abstract contract.
- Adding royalties, getters, and internal utils.
- Removing name and symbol from core implementations.
- Adding Soulbound implementation versions.
- Adding `CollectionUtils` and new Render Utils methods.
- Adding `TokenPropertiesRepository` and `TokenHolder` extension.
- Updating Hardhat config and keeping a Changelog.
- Recreating implementations for premint and lazy minting.
- Reducing size of `MinifiedEquippable` contract.
- Splitting `tokenURI` extension into two versions.
- Removing Split Equippable implementations.
- Removing unneeded mocks.
- Relocating errors into `RMRKErrors` lib.
- Adding `IERC721Metadata` interface support.
- Removing Emotes extension.
- Upgrading dependencies.
- Increasing Istanbul code coverage.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->