### PR TITLE
Revealables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ MOONBASE_URL=https://moonbase-alpha.blastapi.io/<YOUR ALCHEMY KEY>
 SEPOLIA_URL=https://eth-sepolia.g.alchemy.com/v2/<YOUR ALCHEMY KEY>
 MUMBAI_URL=https://polygon-mumbai.g.alchemy.com/v2/<YOUR API KEY>
 BASE_GOERLI_URL=https://base-goerli.g.alchemy.com/v2/<YOUR API KEY>
+SHIBUYA_URL=
 
 # Mainnet networks
 MOONRIVER_URL=https://moonriver.blastapi.io/<YOUR ALCHEMY KEY>
@@ -10,12 +11,14 @@ MOONBEAM_URL=https://moonbeam.blastapi.io/<YOUR ALCHEMY KEY>
 ETHEREUM_URL=https://eth-mainnet.g.alchemy.com/v2/<YOUR ALCHEMY KEY>
 POLYGON_URL=https://polygon-mainnet.g.alchemy.com/v2/<YOUR API KEY>
 BASE_URL=https://base-mainnet.g.alchemy.com/v2/<YOUR API KEY>
+ASTAR_URL=
 
 # To verify contracts
 ETHERSCAN_API_KEY=ABC123
 MOONSCAN_APIKEY=ABC123
 POLYGONSCAN_API_KEY=ABC123
 BASESCAN_API_KEY=ABC123
+ASTAR_BLOCKSCOUT_API_KEY=ABC123
 
 # To report gas
 REPORT_GAS=

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # The Github accounts listed here will automatically be requested to review PRs.
-*       @steven2308 @ThunderDeliverer
+*       @steven2308 @Yuripetusko

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.1.1] - 2023-09-21
+## [2.1.2] - 2023-10-06
+
+### Added
+
+- Adds Revealable and Revealer Interfaces, with Abstract implementation for Revealable. The purpose is to make the reveal flow much easier for the holders and cheaper for the issuer.
+
+### Changed
+
+- Makes methods to check for permissions internal instead of private on core implementations:
+  - \_onlyApprovedForAssetsOrOwner
+  - \_onlyApprovedOrDirectOwner
+  - \_onlyApprovedOrOwner
+
+## [2.2.0] - 2023-09-21
 
 ### Changed
 

--- a/contracts/RMRK/core/RMRKCore.sol
+++ b/contracts/RMRK/core/RMRKCore.sol
@@ -13,6 +13,6 @@ contract RMRKCore {
      * @notice Version of the @rmrk-team/evm-contracts package
      * @return Version identifier of the smart contract
      */
-    string public constant VERSION = "2.1.1";
+    string public constant VERSION = "2.2.0";
     bytes4 public constant RMRK_INTERFACE = 0x524D524B; // "RMRK" in ASCII hex
 }

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -60,7 +60,7 @@ contract RMRKEquippable is
      *  of the owner.
      * @param tokenId ID of the token that we are checking
      */
-    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) private view {
+    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) internal view {
         if (!_isApprovedForAssetsOrOwner(_msgSender(), tokenId))
             revert RMRKNotApprovedForAssetsOrOwner();
     }

--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -72,7 +72,7 @@ contract RMRKMinifiedEquippable is
      *  reverted.
      * @param tokenId ID of the token to check
      */
-    function _onlyApprovedOrOwner(uint256 tokenId) private view {
+    function _onlyApprovedOrOwner(uint256 tokenId) internal view {
         address owner = ownerOf(tokenId);
         if (
             !(_msgSender() == owner ||
@@ -98,7 +98,7 @@ contract RMRKMinifiedEquippable is
      * @dev Used for parent-scoped transfers.
      * @param tokenId ID of the token to check.
      */
-    function _onlyApprovedOrDirectOwner(uint256 tokenId) private view {
+    function _onlyApprovedOrDirectOwner(uint256 tokenId) internal view {
         (address owner, uint256 parentId, ) = directOwnerOf(tokenId);
         // When the parent is an NFT, only it can do operations. Otherwise, the owner or approved address can
         if (
@@ -1601,7 +1601,7 @@ contract RMRKMinifiedEquippable is
      *  of the owner.
      * @param tokenId ID of the token that we are checking
      */
-    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) private view {
+    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) internal view {
         address owner = ownerOf(tokenId);
         if (
             !(_msgSender() == owner ||

--- a/contracts/RMRK/extension/revealable/IRMRKRevealable.sol
+++ b/contracts/RMRK/extension/revealable/IRMRKRevealable.sol
@@ -3,13 +3,22 @@
 pragma solidity ^0.8.21;
 
 interface IRMRKRevealable {
+    /**
+     * @notice Gets the `IRMRKRevealer` associated with the contract.
+     * @return revealer The `IRMRKRevealer` associated with the contract
+     */
     function getRevealer() external view returns (address);
 
+    /**
+     * @notice Sets the `IRMRKRevealer` associated with the contract.
+     * @param revealer The `IRMRKRevealer` to associate with the contract
+     */
     function setRevealer(address revealer) external;
 
-    // Should ask revealor which assetId should be added to the token and optionally which asset to replace.
-    // It should send the active asset Ids for the token.
-    // The Revealer might need to be added as contributor on the main contract to add assets if needed
-    // This method should be called by the owner or approved for assets, and should add the asset to the token and accept it
+    /** @notice Reveals the asset for the given tokenIds by adding and accepting and new one.
+     * @dev SHOULD ask revealer which assetId should be added to the token and which asset to replace through `IRMRKRevealer.getAssetsToReveal`
+     * @dev SHOULD be called by the owner or approved for assets
+     * @dev SHOULD add the new asset to each token and accept it
+     */
     function reveal(uint256[] memory tokenIds) external;
 }

--- a/contracts/RMRK/extension/revealable/IRMRKRevealable.sol
+++ b/contracts/RMRK/extension/revealable/IRMRKRevealable.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.21;
+
+interface IRMRKRevealable {
+    function getRevealer() external view returns (address);
+
+    function setRevealer(address revealer) external;
+
+    // Should ask revealor which assetId should be added to the token and optionally which asset to replace.
+    // It should send the active asset Ids for the token.
+    // The Revealer might need to be added as contributor on the main contract to add assets if needed
+    // This method should be called by the owner or approved for assets, and should add the asset to the token and accept it
+    function reveal(uint256[] memory tokenIds) external;
+}

--- a/contracts/RMRK/extension/revealable/IRMRKRevealer.sol
+++ b/contracts/RMRK/extension/revealable/IRMRKRevealer.sol
@@ -3,21 +3,37 @@
 pragma solidity ^0.8.21;
 
 interface IRMRKRevealer {
+    event Revealed(
+        uint256[] tokenIds,
+        uint64[] revealedAssetsIds,
+        uint64[] assetsToReplaceIds
+    );
+
     /**
-     * @notice Returns the assetIds to reveal for the given tokenIds
-     * @param tokenIds The tokenIds to reveal
-     * @dev This method MUST only return existing assetIds
-     * @dev This method MUST return the same amount of assetIds as tokenIds
-     * @return revealedAssetIds The assetIds to reveal
-     * @return assetToReplaceIds The assetIds to replace
+     * @notice For each `tokenId` in `tokenIds` returns whether it can be revealed or not
+     * @param tokenIds The `tokenIds` to check
+     * @return revealable The array of booleans indicating whether each `tokenId` can be revealed or not
      */
-    function getRevealedAssets(
+    function getRevealableTokens(
+        uint256[] memory tokenIds
+    ) external view returns (bool[] memory revealable);
+
+    /**
+     * @notice Returns the revealed `assetIds` for the given `tokenIds` and marks them as revealed.
+     * @param tokenIds The `tokenIds` to reveal
+     * @dev This CAN add new assets to the original contract if necessary, in which case it SHOULD have the necessary permissions
+     * @dev This method MUST only return existing `assetIds`
+     * @dev This method MUST be called only by the contract implementing the `IRMRKRevealable` interface, during the `reveal` method
+     * @dev This method MUST return the same amount of `revealedAssetsIds` and `assetsToReplaceIds`  as `tokenIds`
+     * @return revealedAssetsIds The revealed `assetIds`
+     * @return assetsToReplaceIds The `assetIds` to replace
+     */
+    function reveal(
         uint256[] memory tokenIds
     )
         external
-        view
         returns (
-            uint64[] memory revealedAssetIds,
-            uint64[] memory assetToReplaceIds
+            uint64[] memory revealedAssetsIds,
+            uint64[] memory assetsToReplaceIds
         );
 }

--- a/contracts/RMRK/extension/revealable/IRMRKRevealer.sol
+++ b/contracts/RMRK/extension/revealable/IRMRKRevealer.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.21;
+
+interface IRMRKRevealer {
+    /**
+     * @notice Returns the assetIds to reveal for the given tokenIds
+     * @param tokenIds The tokenIds to reveal
+     * @dev This method MUST only return existing assetIds
+     * @dev This method MUST return the same amount of assetIds as tokenIds
+     * @return revealedAssetIds The assetIds to reveal
+     * @return assetToReplaceIds The assetIds to replace
+     */
+    function getRevealedAssets(
+        uint256[] memory tokenIds
+    )
+        external
+        view
+        returns (
+            uint64[] memory revealedAssetIds,
+            uint64[] memory assetToReplaceIds
+        );
+}

--- a/contracts/RMRK/extension/revealable/RMRKRevealable.sol
+++ b/contracts/RMRK/extension/revealable/RMRKRevealable.sol
@@ -2,7 +2,6 @@
 
 import "./IRMRKRevealable.sol";
 import "./IRMRKRevealer.sol";
-import "hardhat/console.sol";
 
 pragma solidity ^0.8.21;
 
@@ -59,7 +58,6 @@ abstract contract RMRKRevealable is IRMRKRevealable {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual returns (bool) {
-        console.logBytes4(type(IRMRKRevealable).interfaceId);
         return interfaceId == type(IRMRKRevealable).interfaceId;
     }
 

--- a/contracts/RMRK/extension/revealable/RMRKRevealable.sol
+++ b/contracts/RMRK/extension/revealable/RMRKRevealable.sol
@@ -40,14 +40,14 @@ abstract contract RMRKRevealable is IRMRKRevealable {
         _checkRevealPermissions(tokenIds);
         uint256 length = tokenIds.length;
         (
-            uint64[] memory revealedAssetIds,
-            uint64[] memory assetToReplaceIds
-        ) = IRMRKRevealer(_revealer).getRevealedAssets(tokenIds);
+            uint64[] memory revealedAssetsIds,
+            uint64[] memory assetsToReplaceIds
+        ) = IRMRKRevealer(_revealer).reveal(tokenIds);
         for (uint256 i; i < length; ) {
             _addAndAcceptAssetToToken(
                 tokenIds[i],
-                revealedAssetIds[i],
-                assetToReplaceIds[i]
+                revealedAssetsIds[i],
+                assetsToReplaceIds[i]
             );
             unchecked {
                 ++i;

--- a/contracts/RMRK/extension/revealable/RMRKRevealable.sol
+++ b/contracts/RMRK/extension/revealable/RMRKRevealable.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+
+import "./IRMRKRevealable.sol";
+import "./IRMRKRevealer.sol";
+import "hardhat/console.sol";
+
+pragma solidity ^0.8.21;
+
+/**
+ * @title IRMRKRevealable
+ * @author RMRK team
+ * @notice Interface smart contract of the RMRK Revealable extension. This extension simplifies the process of revealing.
+ */
+abstract contract RMRKRevealable is IRMRKRevealable {
+    address private _revealer;
+
+    /**
+     * @notice Returns the address of the revealer contract
+     */
+    function getRevealer() external view returns (address) {
+        return _revealer;
+    }
+
+    /**
+     * @notice Sets the revealer contract address
+     */
+    function _setRevealer(address revealer) internal {
+        _revealer = revealer;
+    }
+
+    /**
+     * @notice Reveals the assets for the given tokenIds
+     * @param tokenIds The tokenIds to reveal
+     * @dev This method SHOULD be called by the owner or approved for assets
+     * @dev This method SHOULD add the asset to the token and accept it
+     * @dev This method SHOULD get the `assetId` to add and replace from the revealer contract
+     * @dev This `assetId` to replace CAN be 0, meaning that the asset is added to the token without replacing anything
+     * @dev The revealer contract MUST take care of ensuring the `assetId` exists on the contract implementating this interface
+     */
+    function reveal(uint256[] memory tokenIds) external {
+        _checkRevealPermissions(tokenIds);
+        uint256 length = tokenIds.length;
+        (
+            uint64[] memory revealedAssetIds,
+            uint64[] memory assetToReplaceIds
+        ) = IRMRKRevealer(_revealer).getRevealedAssets(tokenIds);
+        for (uint256 i; i < length; ) {
+            _addAndAcceptAssetToToken(
+                tokenIds[i],
+                revealedAssetIds[i],
+                assetToReplaceIds[i]
+            );
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual returns (bool) {
+        console.logBytes4(type(IRMRKRevealable).interfaceId);
+        return interfaceId == type(IRMRKRevealable).interfaceId;
+    }
+
+    /**
+     * @notice Adds the asset to the token and accepts it.
+     * @param tokenId The tokenId to add the asset to
+     * @param newAssetId The assetId to add
+     * @param assetToReplaceId The assetId to replace. Might be 0, meaning that the asset is added to the token without replacing anything
+     */
+    function _addAndAcceptAssetToToken(
+        uint256 tokenId,
+        uint64 newAssetId,
+        uint64 assetToReplaceId
+    ) internal virtual {
+        // Expected implementation:
+        // _addAssetToToken(tokenId, newAssetId, assetToReplaceId);
+        // _acceptAsset(tokenId, _pendingAssets[tokenId].length - 1, newAssetId);
+    }
+
+    /**
+     * @notice Checks that the msg sender has permissions to reveal the given tokenIds
+     * @dev The caller SHOULD be either the owner or approved for assets.
+     * @param tokenIds The tokenIds to reveal
+     */
+    function _checkRevealPermissions(
+        uint256[] memory tokenIds
+    ) internal view virtual {
+        // Expected implementation:
+        // uint256 length = tokenIds.length;
+        // for (uint256 i; i < length; ) {
+        //     _onlyApprovedForAssetsOrOwner(tokenIds[i]);
+        //     unchecked {
+        //         ++i;
+        //     }
+        // }
+    }
+}

--- a/contracts/RMRK/multiasset/RMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/RMRKMultiAsset.sol
@@ -43,7 +43,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      * @dev If the caller is not the owner or approved by the owner, the execution is reverted.
      * @param tokenId ID of the token being checked
      */
-    function _onlyApprovedOrOwner(uint256 tokenId) private view {
+    function _onlyApprovedOrOwner(uint256 tokenId) internal view {
         if (!_isApprovedOrOwner(_msgSender(), tokenId))
             revert ERC721NotApprovedOrOwner();
     }
@@ -85,7 +85,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      *  given token, the execution will be reverted.
      * @param tokenId ID of the token being checked
      */
-    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) private view {
+    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) internal view {
         if (!_isApprovedForAssetsOrOwner(_msgSender(), tokenId))
             revert RMRKNotApprovedForAssetsOrOwner();
     }

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -60,7 +60,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      *  reverted.
      * @param tokenId ID of the token to check
      */
-    function _onlyApprovedOrOwner(uint256 tokenId) private view {
+    function _onlyApprovedOrOwner(uint256 tokenId) internal view {
         if (!_isApprovedOrOwner(_msgSender(), tokenId))
             revert ERC721NotApprovedOrOwner();
     }
@@ -82,7 +82,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      * @dev Used for parent-scoped transfers.
      * @param tokenId ID of the token to check.
      */
-    function _onlyApprovedOrDirectOwner(uint256 tokenId) private view {
+    function _onlyApprovedOrDirectOwner(uint256 tokenId) internal view {
         if (!_isApprovedOrDirectOwner(_msgSender(), tokenId))
             revert RMRKNotApprovedOrDirectOwner();
     }

--- a/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
+++ b/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
@@ -30,7 +30,7 @@ contract RMRKNestableMultiAsset is RMRKNestable, AbstractMultiAsset {
      *  given token, the execution will be reverted.
      * @param tokenId ID of the token being checked
      */
-    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) private view {
+    function _onlyApprovedForAssetsOrOwner(uint256 tokenId) internal view {
         if (!_isApprovedForAssetsOrOwner(_msgSender(), tokenId))
             revert RMRKNotApprovedForAssetsOrOwner();
     }

--- a/contracts/mocks/RMRKEquippableMock.sol
+++ b/contracts/mocks/RMRKEquippableMock.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.21;
 
 import "../RMRK/equippable/RMRKEquippable.sol";
 
-/* import "hardhat/console.sol"; */
-
 //Minimal public implementation of RMRKEquippable for testing.
 contract RMRKEquippableMock is RMRKEquippable {
     function mint(address to, uint256 tokenId) external {

--- a/contracts/mocks/RMRKMinifiedEquippableMock.sol
+++ b/contracts/mocks/RMRKMinifiedEquippableMock.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.21;
 
 import "../RMRK/equippable/RMRKMinifiedEquippable.sol";
 
-/* import "hardhat/console.sol"; */
-
 //Minimal public implementation of RMRKEquippable for testing.
 contract RMRKMinifiedEquippableMock is RMRKMinifiedEquippable {
     function safeMint(address to, uint256 tokenId) public {

--- a/contracts/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.sol
+++ b/contracts/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.21;
+
+import "../../../RMRK/extension/revealable/RMRKRevealable.sol";
+import "../../RMRKMultiAssetMock.sol";
+
+contract RMRKMultiAssetRevealableMock is RMRKMultiAssetMock, RMRKRevealable {
+    function supportsInterface(
+        bytes4 interfaceId
+    )
+        public
+        view
+        virtual
+        override(RMRKMultiAsset, RMRKRevealable)
+        returns (bool)
+    {
+        return
+            RMRKMultiAsset.supportsInterface(interfaceId) ||
+            RMRKRevealable.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @inheritdoc IRMRKRevealable
+     */
+    function setRevealer(address revealer) external {
+        _setRevealer(revealer);
+    }
+
+    /**
+     * @inheritdoc RMRKRevealable
+     */
+    function _addAndAcceptAssetToToken(
+        uint256 tokenId,
+        uint64 newAssetId,
+        uint64 assetToReplaceId
+    ) internal override {
+        _addAssetToToken(tokenId, newAssetId, assetToReplaceId);
+        _acceptAsset(tokenId, _pendingAssets[tokenId].length - 1, newAssetId);
+    }
+
+    /**
+     * @inheritdoc RMRKRevealable
+     */
+    function _checkRevealPermissions(
+        uint256[] memory tokenIds
+    ) internal view override {
+        uint256 length = tokenIds.length;
+        for (uint256 i; i < length; ) {
+            _onlyApprovedForAssetsOrOwner(tokenIds[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+}

--- a/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
+++ b/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.21;
+
+import "../../../RMRK/extension/revealable/IRMRKRevealer.sol";
+import "../../RMRKMultiAssetMock.sol";
+
+contract RMRKRevealerMock is IRMRKRevealer {
+    uint64 public revealedAssetId;
+
+    constructor(uint64 revealedAssetId_) {
+        revealedAssetId = revealedAssetId_;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual returns (bool) {
+        return interfaceId == type(IRMRKRevealer).interfaceId;
+    }
+
+    /**
+     * @inheritdoc IRMRKRevealer
+     */
+    function getRevealedAssets(
+        uint256[] memory tokenIds
+    )
+        external
+        view
+        returns (
+            uint64[] memory revealedAssetIds,
+            uint64[] memory assetToReplaceIds
+        )
+    {
+        uint256 length = tokenIds.length;
+        revealedAssetIds = new uint64[](length);
+        assetToReplaceIds = new uint64[](length);
+        for (uint256 i; i < length; ) {
+            uint256 tokenId = tokenIds[i];
+            uint64[] memory activeAssets = RMRKMultiAssetMock(msg.sender)
+                .getActiveAssets(tokenId);
+            // Asumes that the token has at least one asset
+            revealedAssetIds[i] = revealedAssetId;
+            assetToReplaceIds[i] = activeAssets[0];
+            unchecked {
+                ++i;
+            }
+        }
+    }
+}

--- a/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
+++ b/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
@@ -5,11 +5,17 @@ pragma solidity ^0.8.21;
 import "../../../RMRK/extension/revealable/IRMRKRevealer.sol";
 import "../../RMRKMultiAssetMock.sol";
 
-contract RMRKRevealerMock is IRMRKRevealer {
-    uint64 public revealedAssetId;
+error AlreadyRevealed(uint256 tokenId);
+error CallerIsNotRevealable();
 
-    constructor(uint64 revealedAssetId_) {
-        revealedAssetId = revealedAssetId_;
+contract RMRKRevealerMock is IRMRKRevealer {
+    uint64 private _revealedAssetId;
+    address private _revealableContract;
+    mapping(uint256 tokenId => bool revealed) private _revealed;
+
+    constructor(uint64 revealedAssetId, address revealableContract) {
+        _revealedAssetId = revealedAssetId;
+        _revealableContract = revealableContract;
     }
 
     function supportsInterface(
@@ -18,32 +24,55 @@ contract RMRKRevealerMock is IRMRKRevealer {
         return interfaceId == type(IRMRKRevealer).interfaceId;
     }
 
-    /**
+    /**-
      * @inheritdoc IRMRKRevealer
      */
-    function getRevealedAssets(
+    function getRevealableTokens(
         uint256[] memory tokenIds
-    )
-        external
-        view
-        returns (
-            uint64[] memory revealedAssetIds,
-            uint64[] memory assetToReplaceIds
-        )
-    {
+    ) external view returns (bool[] memory revealable) {
         uint256 length = tokenIds.length;
-        revealedAssetIds = new uint64[](length);
-        assetToReplaceIds = new uint64[](length);
+        revealable = new bool[](length);
         for (uint256 i; i < length; ) {
-            uint256 tokenId = tokenIds[i];
-            uint64[] memory activeAssets = RMRKMultiAssetMock(msg.sender)
-                .getActiveAssets(tokenId);
-            // Asumes that the token has at least one asset
-            revealedAssetIds[i] = revealedAssetId;
-            assetToReplaceIds[i] = activeAssets[0];
+            revealable[i] = !_revealed[tokenIds[i]];
             unchecked {
                 ++i;
             }
         }
+    }
+
+    /**-
+     * @inheritdoc IRMRKRevealer
+     */
+    function reveal(
+        uint256[] memory tokenIds
+    )
+        external
+        returns (
+            uint64[] memory revealedAssetsIds,
+            uint64[] memory assetsToReplaceIds
+        )
+    {
+        if (msg.sender != _revealableContract) {
+            revert CallerIsNotRevealable();
+        }
+        uint256 length = tokenIds.length;
+        revealedAssetsIds = new uint64[](length);
+        assetsToReplaceIds = new uint64[](length);
+        for (uint256 i; i < length; ) {
+            uint256 tokenId = tokenIds[i];
+            if (_revealed[tokenId]) {
+                revert AlreadyRevealed(tokenId);
+            }
+            _revealed[tokenId] = true;
+            uint64[] memory activeAssets = RMRKMultiAssetMock(msg.sender)
+                .getActiveAssets(tokenId);
+            // Asumes that the token has at least one asset
+            revealedAssetsIds[i] = _revealedAssetId;
+            assetsToReplaceIds[i] = activeAssets[0];
+            unchecked {
+                ++i;
+            }
+        }
+        emit Revealed(tokenIds, revealedAssetsIds, assetsToReplaceIds);
     }
 }

--- a/docs/RMRK/extension/revealable/IRMRKRevealable.md
+++ b/docs/RMRK/extension/revealable/IRMRKRevealable.md
@@ -1,0 +1,64 @@
+# IRMRKRevealable
+
+
+
+
+
+
+
+
+
+## Methods
+
+### getRevealer
+
+```solidity
+function getRevealer() external view returns (address)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### reveal
+
+```solidity
+function reveal(uint256[] tokenIds) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | undefined |
+
+### setRevealer
+
+```solidity
+function setRevealer(address revealer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| revealer | address | undefined |
+
+
+
+

--- a/docs/RMRK/extension/revealable/IRMRKRevealable.md
+++ b/docs/RMRK/extension/revealable/IRMRKRevealable.md
@@ -16,7 +16,7 @@
 function getRevealer() external view returns (address)
 ```
 
-
+Gets the `IRMRKRevealer` associated with the contract.
 
 
 
@@ -25,7 +25,7 @@ function getRevealer() external view returns (address)
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | undefined |
+| _0 | address | revealer The `IRMRKRevealer` associated with the contract |
 
 ### reveal
 
@@ -33,9 +33,9 @@ function getRevealer() external view returns (address)
 function reveal(uint256[] tokenIds) external nonpayable
 ```
 
+Reveals the asset for the given tokenIds by adding and accepting and new one.
 
-
-
+*SHOULD ask revealer which assetId should be added to the token and which asset to replace through `IRMRKRevealer.getAssetsToReveal`SHOULD be called by the owner or approved for assetsSHOULD add the new asset to each token and accept it*
 
 #### Parameters
 
@@ -49,7 +49,7 @@ function reveal(uint256[] tokenIds) external nonpayable
 function setRevealer(address revealer) external nonpayable
 ```
 
-
+Sets the `IRMRKRevealer` associated with the contract.
 
 
 
@@ -57,7 +57,7 @@ function setRevealer(address revealer) external nonpayable
 
 | Name | Type | Description |
 |---|---|---|
-| revealer | address | undefined |
+| revealer | address | The `IRMRKRevealer` to associate with the contract |
 
 
 

--- a/docs/RMRK/extension/revealable/IRMRKRevealer.md
+++ b/docs/RMRK/extension/revealable/IRMRKRevealer.md
@@ -10,29 +10,72 @@
 
 ## Methods
 
-### getRevealedAssets
+### getRevealableTokens
 
 ```solidity
-function getRevealedAssets(uint256[] tokenIds) external view returns (uint64[] revealedAssetIds, uint64[] assetToReplaceIds)
+function getRevealableTokens(uint256[] tokenIds) external view returns (bool[] revealable)
 ```
 
-Returns the assetIds to reveal for the given tokenIds
+For each `tokenId` in `tokenIds` returns whether it can be revealed or not
 
-*This method MUST only return existing assetIdsThis method MUST return the same amount of assetIds as tokenIds*
+
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenIds | uint256[] | The tokenIds to reveal |
+| tokenIds | uint256[] | The `tokenIds` to check |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| revealedAssetIds | uint64[] | The assetIds to reveal |
-| assetToReplaceIds | uint64[] | The assetIds to replace |
+| revealable | bool[] | The array of booleans indicating whether each `tokenId` can be revealed or not |
 
+### reveal
+
+```solidity
+function reveal(uint256[] tokenIds) external nonpayable returns (uint64[] revealedAssetsIds, uint64[] assetsToReplaceIds)
+```
+
+Returns the revealed `assetIds` for the given `tokenIds` and marks them as revealed.
+
+*This CAN add new assets to the original contract if necessary, in which case it SHOULD have the necessary permissionsThis method MUST only return existing `assetIds`This method MUST be called only by the contract implementing the `IRMRKRevealable` interface, during the `reveal` methodThis method MUST return the same amount of `revealedAssetsIds` and `assetsToReplaceIds`  as `tokenIds`*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | The `tokenIds` to reveal |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| revealedAssetsIds | uint64[] | The revealed `assetIds` |
+| assetsToReplaceIds | uint64[] | The `assetIds` to replace |
+
+
+
+## Events
+
+### Revealed
+
+```solidity
+event Revealed(uint256[] tokenIds, uint64[] revealedAssetsIds, uint64[] assetsToReplaceIds)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds  | uint256[] | undefined |
+| revealedAssetsIds  | uint64[] | undefined |
+| assetsToReplaceIds  | uint64[] | undefined |
 
 
 

--- a/docs/RMRK/extension/revealable/IRMRKRevealer.md
+++ b/docs/RMRK/extension/revealable/IRMRKRevealer.md
@@ -1,0 +1,38 @@
+# IRMRKRevealer
+
+
+
+
+
+
+
+
+
+## Methods
+
+### getRevealedAssets
+
+```solidity
+function getRevealedAssets(uint256[] tokenIds) external view returns (uint64[] revealedAssetIds, uint64[] assetToReplaceIds)
+```
+
+Returns the assetIds to reveal for the given tokenIds
+
+*This method MUST only return existing assetIdsThis method MUST return the same amount of assetIds as tokenIds*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | The tokenIds to reveal |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| revealedAssetIds | uint64[] | The assetIds to reveal |
+| assetToReplaceIds | uint64[] | The assetIds to replace |
+
+
+
+

--- a/docs/RMRK/extension/revealable/RMRKRevealable.md
+++ b/docs/RMRK/extension/revealable/RMRKRevealable.md
@@ -49,7 +49,7 @@ Reveals the assets for the given tokenIds
 function setRevealer(address revealer) external nonpayable
 ```
 
-
+Sets the `IRMRKRevealer` associated with the contract.
 
 
 
@@ -57,7 +57,7 @@ function setRevealer(address revealer) external nonpayable
 
 | Name | Type | Description |
 |---|---|---|
-| revealer | address | undefined |
+| revealer | address | The `IRMRKRevealer` to associate with the contract |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/revealable/RMRKRevealable.md
+++ b/docs/RMRK/extension/revealable/RMRKRevealable.md
@@ -1,0 +1,86 @@
+# RMRKRevealable
+
+*RMRK team*
+
+> IRMRKRevealable
+
+Interface smart contract of the RMRK Revealable extension. This extension simplifies the process of revealing.
+
+
+
+## Methods
+
+### getRevealer
+
+```solidity
+function getRevealer() external view returns (address)
+```
+
+Returns the address of the revealer contract
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### reveal
+
+```solidity
+function reveal(uint256[] tokenIds) external nonpayable
+```
+
+Reveals the assets for the given tokenIds
+
+*This method SHOULD be called by the owner or approved for assetsThis method SHOULD add the asset to the token and accept itThis method SHOULD get the `assetId` to add and replace from the revealer contractThis `assetId` to replace CAN be 0, meaning that the asset is added to the token without replacing anythingThe revealer contract MUST take care of ensuring the `assetId` exists on the contract implementating this interface*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | The tokenIds to reveal |
+
+### setRevealer
+
+```solidity
+function setRevealer(address revealer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| revealer | address | undefined |
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+
+
+

--- a/docs/elin/contracts/token/ERC721/extensions/ERC721Burnable.md
+++ b/docs/elin/contracts/token/ERC721/extensions/ERC721Burnable.md
@@ -1,0 +1,344 @@
+# ERC721Burnable
+
+
+
+> ERC721 Burnable Token
+
+
+
+*ERC721 Token that can be burned (destroyed).*
+
+## Methods
+
+### approve
+
+```solidity
+function approve(address to, uint256 tokenId) external nonpayable
+```
+
+
+
+*See {IERC721-approve}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+
+### balanceOf
+
+```solidity
+function balanceOf(address owner) external view returns (uint256)
+```
+
+
+
+*See {IERC721-balanceOf}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
+### burn
+
+```solidity
+function burn(uint256 tokenId) external nonpayable
+```
+
+
+
+*Burns `tokenId`. See {ERC721-_burn}. Requirements: - The caller must own `tokenId` or be an approved operator.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | undefined |
+
+### getApproved
+
+```solidity
+function getApproved(uint256 tokenId) external view returns (address)
+```
+
+
+
+*See {IERC721-getApproved}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### isApprovedForAll
+
+```solidity
+function isApprovedForAll(address owner, address operator) external view returns (bool)
+```
+
+
+
+*See {IERC721-isApprovedForAll}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | undefined |
+| operator | address | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+### name
+
+```solidity
+function name() external view returns (string)
+```
+
+
+
+*See {IERC721Metadata-name}.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined |
+
+### ownerOf
+
+```solidity
+function ownerOf(uint256 tokenId) external view returns (address)
+```
+
+
+
+*See {IERC721-ownerOf}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### safeTransferFrom
+
+```solidity
+function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
+```
+
+
+
+*See {IERC721-safeTransferFrom}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | undefined |
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+
+### safeTransferFrom
+
+```solidity
+function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
+```
+
+
+
+*See {IERC721-safeTransferFrom}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | undefined |
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+| data | bytes | undefined |
+
+### setApprovalForAll
+
+```solidity
+function setApprovalForAll(address operator, bool approved) external nonpayable
+```
+
+
+
+*See {IERC721-setApprovalForAll}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| operator | address | undefined |
+| approved | bool | undefined |
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+*See {IERC165-supportsInterface}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+### symbol
+
+```solidity
+function symbol() external view returns (string)
+```
+
+
+
+*See {IERC721Metadata-symbol}.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined |
+
+### tokenURI
+
+```solidity
+function tokenURI(uint256 tokenId) external view returns (string)
+```
+
+
+
+*See {IERC721Metadata-tokenURI}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined |
+
+### transferFrom
+
+```solidity
+function transferFrom(address from, address to, uint256 tokenId) external nonpayable
+```
+
+
+
+*See {IERC721-transferFrom}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | undefined |
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+
+
+
+## Events
+
+### Approval
+
+```solidity
+event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId)
+```
+
+
+
+*Emitted when `owner` enables `approved` to manage the `tokenId` token.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | undefined |
+| approved `indexed` | address | undefined |
+| tokenId `indexed` | uint256 | undefined |
+
+### ApprovalForAll
+
+```solidity
+event ApprovalForAll(address indexed owner, address indexed operator, bool approved)
+```
+
+
+
+*Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | undefined |
+| operator `indexed` | address | undefined |
+| approved  | bool | undefined |
+
+### Transfer
+
+```solidity
+event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
+```
+
+
+
+*Emitted when `tokenId` token is transferred from `from` to `to`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from `indexed` | address | undefined |
+| to `indexed` | address | undefined |
+| tokenId `indexed` | uint256 | undefined |
+
+
+

--- a/docs/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.md
+++ b/docs/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.md
@@ -625,7 +625,7 @@ Sets a new priority array for a given token.
 function setRevealer(address revealer) external nonpayable
 ```
 
-
+Sets the `IRMRKRevealer` associated with the contract.
 
 
 
@@ -633,7 +633,7 @@ function setRevealer(address revealer) external nonpayable
 
 | Name | Type | Description |
 |---|---|---|
-| revealer | address | undefined |
+| revealer | address | The `IRMRKRevealer` to associate with the contract |
 
 ### supportsInterface
 

--- a/docs/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.md
+++ b/docs/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.md
@@ -1,0 +1,1131 @@
+# RMRKMultiAssetRevealableMock
+
+
+
+
+
+
+
+
+
+## Methods
+
+### RMRK_INTERFACE
+
+```solidity
+function RMRK_INTERFACE() external view returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined |
+
+### VERSION
+
+```solidity
+function VERSION() external view returns (string)
+```
+
+Version of the @rmrk-team/evm-contracts package
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined |
+
+### acceptAsset
+
+```solidity
+function acceptAsset(uint256 tokenId, uint256 index, uint64 assetId) external nonpayable
+```
+
+Accepts an asset at from the pending array of given token.
+
+*Migrates the asset from the token&#39;s pending asset array to the token&#39;s active asset array.Active assets cannot be removed by anyone, but can be replaced by a new asset.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.  - `index` must be in range of the length of the pending asset array.Emits an {AssetAccepted} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token for which to accept the pending asset |
+| index | uint256 | Index of the asset in the pending array to accept |
+| assetId | uint64 | ID of the asset expected to be in the index |
+
+### addAssetEntry
+
+```solidity
+function addAssetEntry(uint64 id, string metadataURI) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| id | uint64 | undefined |
+| metadataURI | string | undefined |
+
+### addAssetToToken
+
+```solidity
+function addAssetToToken(uint256 tokenId, uint64 assetId, uint64 replacesAssetWithId) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | undefined |
+| assetId | uint64 | undefined |
+| replacesAssetWithId | uint64 | undefined |
+
+### addAssetToTokensEventTest
+
+```solidity
+function addAssetToTokensEventTest(uint256[] tokenIds, uint64 assetId, uint64 replacesAssetWithId) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | undefined |
+| assetId | uint64 | undefined |
+| replacesAssetWithId | uint64 | undefined |
+
+### approve
+
+```solidity
+function approve(address to, uint256 tokenId) external nonpayable
+```
+
+Used to grant a one-time approval to manage one&#39;s token.
+
+*Gives permission to `to` to transfer `tokenId` token to another account.The approval is cleared when the token is transferred.Only a single account can be approved at a time, so approving the zero address clears previous approvals.Requirements: - The caller must own the token or be an approved operator. - `tokenId` must exist.Emits an {Approval} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | Address receiving the approval |
+| tokenId | uint256 | ID of the token for which the approval is being granted |
+
+### approveForAssets
+
+```solidity
+function approveForAssets(address to, uint256 tokenId) external nonpayable
+```
+
+Used to grant permission to the user to manage token&#39;s assets.
+
+*This differs from transfer approvals, as approvals are not cleared when the approved party accepts or  rejects an asset, or sets asset priorities. This approval is cleared on token transfer.Only a single account can be approved at a time, so approving the `0x0` address clears previous approvals.Requirements:  - The caller must own the token or be an approved operator.  - `tokenId` must exist.Emits an {ApprovalForAssets} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | Address of the account to grant the approval to |
+| tokenId | uint256 | ID of the token for which the approval to manage the assets is granted |
+
+### balanceOf
+
+```solidity
+function balanceOf(address owner) external view returns (uint256)
+```
+
+Used to retrieve the number of tokens in ``owner``&#39;s account.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | Address of the account being checked |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | The balance of the given account |
+
+### burn
+
+```solidity
+function burn(uint256 tokenId) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | undefined |
+
+### getActiveAssetPriorities
+
+```solidity
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+```
+
+Used to retrieve the priorities of the active resoources of a given token.
+
+*Asset priorities are a non-sequential array of uint64 values with an array size equal to active asset  priorites.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token for which to retrieve the priorities of the active assets |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint64[] | An array of priorities of the active assets of the given token |
+
+### getActiveAssets
+
+```solidity
+function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+```
+
+Used to retrieve IDs of the active assets of given token.
+
+*Asset data is stored by reference, in order to access the data corresponding to the ID, call  `getAssetMetadata(tokenId, assetId)`.You can safely get 10k*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token to retrieve the IDs of the active assets |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint64[] | An array of active asset IDs of the given token |
+
+### getApproved
+
+```solidity
+function getApproved(uint256 tokenId) external view returns (address)
+```
+
+Used to retrieve the account approved to manage given token.
+
+*Requirements:  - `tokenId` must exist.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token to check for approval |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | Address of the account approved to manage the token |
+
+### getApprovedForAssets
+
+```solidity
+function getApprovedForAssets(uint256 tokenId) external view returns (address)
+```
+
+Used to retrieve the address of the account approved to manage assets of a given token.
+
+*Requirements:  - `tokenId` must exist.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token for which to retrieve the approved address |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+
+### getAssetMetadata
+
+```solidity
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+```
+
+Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
+
+*Assets are stored by reference mapping `_assets[assetId]`.Can be overriden to implement enumerate, fallback or other custom logic.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token from which to retrieve the asset metadata |
+| assetId | uint64 | Asset Id, must be in the active assets array |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+
+### getAssetReplacements
+
+```solidity
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+```
+
+Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
+
+*Asset data is stored by reference, in order to access the data corresponding to the ID, call  `getAssetMetadata(tokenId, assetId)`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token to check |
+| newAssetId | uint64 | ID of the pending asset which will be accepted |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint64 | ID of the asset which will be replaced |
+
+### getPendingAssets
+
+```solidity
+function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+```
+
+Used to retrieve IDs of the pending assets of given token.
+
+*Asset data is stored by reference, in order to access the data corresponding to the ID, call  `getAssetMetadata(tokenId, assetId)`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token to retrieve the IDs of the pending assets |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint64[] | An array of pending asset IDs of the given token |
+
+### getRevealer
+
+```solidity
+function getRevealer() external view returns (address)
+```
+
+Returns the address of the revealer contract
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | undefined |
+
+### isApprovedForAll
+
+```solidity
+function isApprovedForAll(address owner, address operator) external view returns (bool)
+```
+
+Used to check if the given address is allowed to manage the tokens of the specified address.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | Address of the owner of the tokens |
+| operator | address | Address being checked for approval |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+
+### isApprovedForAllForAssets
+
+```solidity
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+```
+
+Used to check whether the address has been granted the operator role by a given address or not.
+
+*See {setApprovalForAllForAssets}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner | address | Address of the account that we are checking for whether it has granted the operator role |
+| operator | address | Address of the account that we are checking whether it has the operator role or not |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+
+### mint
+
+```solidity
+function mint(address to, uint256 tokenId) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+
+### ownerOf
+
+```solidity
+function ownerOf(uint256 tokenId) external view returns (address)
+```
+
+Used to retrieve the owner of the given token.
+
+*Requirements:  - `tokenId` must exist.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token for which to retrieve the token for |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | address | Address of the account owning the token |
+
+### rejectAllAssets
+
+```solidity
+function rejectAllAssets(uint256 tokenId, uint256 maxRejections) external nonpayable
+```
+
+Rejects all assets from the pending array of a given token.
+
+*Effecitvely deletes the pending array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.Emits a {AssetRejected} event with assetId = 0.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token of which to clear the pending array. |
+| maxRejections | uint256 | Maximum number of expected assets to reject, used to prevent from rejecting assets which  arrive just before this operation. |
+
+### rejectAsset
+
+```solidity
+function rejectAsset(uint256 tokenId, uint256 index, uint64 assetId) external nonpayable
+```
+
+Rejects an asset from the pending array of given token.
+
+*Removes the asset from the token&#39;s pending asset array.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.  - `index` must be in range of the length of the pending asset array.Emits a {AssetRejected} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token that the asset is being rejected from |
+| index | uint256 | Index of the asset in the pending array to be rejected |
+| assetId | uint64 | ID of the asset expected to be in the index |
+
+### reveal
+
+```solidity
+function reveal(uint256[] tokenIds) external nonpayable
+```
+
+Reveals the assets for the given tokenIds
+
+*This method SHOULD be called by the owner or approved for assetsThis method SHOULD add the asset to the token and accept itThis method SHOULD get the `assetId` to add and replace from the revealer contractThis `assetId` to replace CAN be 0, meaning that the asset is added to the token without replacing anythingThe revealer contract MUST take care of ensuring the `assetId` exists on the contract implementating this interface*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | The tokenIds to reveal |
+
+### safeMint
+
+```solidity
+function safeMint(address to, uint256 tokenId, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+| data | bytes | undefined |
+
+### safeMint
+
+```solidity
+function safeMint(address to, uint256 tokenId) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+
+### safeTransferFrom
+
+```solidity
+function safeTransferFrom(address from, address to, uint256 tokenId) external nonpayable
+```
+
+Used to safely transfer a given token token from `from` to `to`.
+
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+
+### safeTransferFrom
+
+```solidity
+function safeTransferFrom(address from, address to, uint256 tokenId, bytes data) external nonpayable
+```
+
+Used to safely transfer a given token token from `from` to `to`.
+
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must exist and be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.  - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.Emits a {Transfer} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | Address to transfer the tokens from |
+| to | address | Address to transfer the tokens to |
+| tokenId | uint256 | ID of the token to transfer |
+| data | bytes | Additional data without a specified format to be sent along with the token transaction |
+
+### setApprovalForAll
+
+```solidity
+function setApprovalForAll(address operator, bool approved) external nonpayable
+```
+
+Used to approve or remove `operator` as an operator for the caller.
+
+*Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.Requirements: - The `operator` cannot be the caller.Emits an {ApprovalForAll} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| operator | address | Address of the operator being managed |
+| approved | bool | A boolean value signifying whether the approval is being granted (`true`) or (`revoked`) |
+
+### setApprovalForAllForAssets
+
+```solidity
+function setApprovalForAllForAssets(address operator, bool approved) external nonpayable
+```
+
+Used to add or remove an operator of assets for the caller.
+
+*Operators can call {acceptAsset}, {rejectAsset}, {rejectAllAssets} or {setPriority} for any token  owned by the caller.Requirements:  - The `operator` cannot be the caller.Emits an {ApprovalForAllForAssets} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| operator | address | Address of the account to which the operator role is granted or revoked from |
+| approved | bool | The boolean value indicating whether the operator role is being granted (`true`) or revoked  (`false`) |
+
+### setPriority
+
+```solidity
+function setPriority(uint256 tokenId, uint64[] priorities) external nonpayable
+```
+
+Sets a new priority array for a given token.
+
+*The priority array is a non-sequential list of `uint64`s, where the lowest value is considered highest  priority.Value `0` of a priority is a special case equivalent to unitialized.Requirements:  - The caller must own the token or be approved to manage the token&#39;s assets  - `tokenId` must exist.  - The length of `priorities` must be equal the length of the active assets array.Emits a {AssetPrioritySet} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | ID of the token to set the priorities for |
+| priorities | uint64[] | An array of priorities of active assets. The succesion of items in the priorities array  matches that of the succesion of items in the active array |
+
+### setRevealer
+
+```solidity
+function setRevealer(address revealer) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| revealer | address | undefined |
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+### transfer
+
+```solidity
+function transfer(address to, uint256 tokenId) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | undefined |
+| tokenId | uint256 | undefined |
+
+### transferFrom
+
+```solidity
+function transferFrom(address from, address to, uint256 tokenId) external nonpayable
+```
+
+Transfers a given token from `from` to `to`.
+
+*Requirements:  - `from` cannot be the zero address.  - `to` cannot be the zero address.  - `tokenId` token must be owned by `from`.  - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.Emits a {Transfer} event.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | Address from which to transfer the token from |
+| to | address | Address to which to transfer the token to |
+| tokenId | uint256 | ID of the token to transfer |
+
+
+
+## Events
+
+### Approval
+
+```solidity
+event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId)
+```
+
+
+
+*Emitted when `owner` enables `approved` to manage the `tokenId` token.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | undefined |
+| approved `indexed` | address | undefined |
+| tokenId `indexed` | uint256 | undefined |
+
+### ApprovalForAll
+
+```solidity
+event ApprovalForAll(address indexed owner, address indexed operator, bool approved)
+```
+
+
+
+*Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | undefined |
+| operator `indexed` | address | undefined |
+| approved  | bool | undefined |
+
+### ApprovalForAllForAssets
+
+```solidity
+event ApprovalForAllForAssets(address indexed owner, address indexed operator, bool approved)
+```
+
+Used to notify listeners that owner has granted approval to the user to manage assets of all of their  tokens.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | Address of the account that has granted the approval for all assets on all of their tokens |
+| operator `indexed` | address | Address of the account that has been granted the approval to manage the token&#39;s assets on all of  the tokens |
+| approved  | bool | Boolean value signifying whether the permission has been granted (`true`) or revoked (`false`) |
+
+### ApprovalForAssets
+
+```solidity
+event ApprovalForAssets(address indexed owner, address indexed approved, uint256 indexed tokenId)
+```
+
+Used to notify listeners that owner has granted an approval to the user to manage the assets of a  given token.
+
+*Approvals must be cleared on transfer*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | Address of the account that has granted the approval for all token&#39;s assets |
+| approved `indexed` | address | Address of the account that has been granted approval to manage the token&#39;s assets |
+| tokenId `indexed` | uint256 | ID of the token on which the approval was granted |
+
+### AssetAccepted
+
+```solidity
+event AssetAccepted(uint256 indexed tokenId, uint64 indexed assetId, uint64 indexed replacesId)
+```
+
+Used to notify listeners that an asset object at `assetId` is accepted by the token and migrated  from token&#39;s pending assets array to active assets array of the token.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId `indexed` | uint256 | ID of the token that had a new asset accepted |
+| assetId `indexed` | uint64 | ID of the asset that was accepted |
+| replacesId `indexed` | uint64 | ID of the asset that was replaced |
+
+### AssetAddedToTokens
+
+```solidity
+event AssetAddedToTokens(uint256[] tokenIds, uint64 indexed assetId, uint64 indexed replacesId)
+```
+
+Used to notify listeners that an asset object at `assetId` is added to token&#39;s pending asset  array.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds  | uint256[] | An array of token IDs that received a new pending asset |
+| assetId `indexed` | uint64 | ID of the asset that has been added to the token&#39;s pending assets array |
+| replacesId `indexed` | uint64 | ID of the asset that would be replaced |
+
+### AssetPrioritySet
+
+```solidity
+event AssetPrioritySet(uint256 indexed tokenId)
+```
+
+Used to notify listeners that token&#39;s prioritiy array is reordered.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId `indexed` | uint256 | ID of the token that had the asset priority array updated |
+
+### AssetRejected
+
+```solidity
+event AssetRejected(uint256 indexed tokenId, uint64 indexed assetId)
+```
+
+Used to notify listeners that an asset object at `assetId` is rejected from token and is dropped  from the pending assets array of the token.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId `indexed` | uint256 | ID of the token that had an asset rejected |
+| assetId `indexed` | uint64 | ID of the asset that was rejected |
+
+### AssetSet
+
+```solidity
+event AssetSet(uint64 indexed assetId)
+```
+
+Used to notify listeners that an asset object is initialized at `assetId`.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| assetId `indexed` | uint64 | ID of the asset that was initialized |
+
+### Transfer
+
+```solidity
+event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)
+```
+
+
+
+*Emitted when `tokenId` token is transferred from `from` to `to`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from `indexed` | address | undefined |
+| to `indexed` | address | undefined |
+| tokenId `indexed` | uint256 | undefined |
+
+
+
+## Errors
+
+### ERC721AddressZeroIsNotaValidOwner
+
+```solidity
+error ERC721AddressZeroIsNotaValidOwner()
+```
+
+Attempting to grant the token to 0x0 address
+
+
+
+
+### ERC721ApprovalToCurrentOwner
+
+```solidity
+error ERC721ApprovalToCurrentOwner()
+```
+
+Attempting to grant approval to the current owner of the token
+
+
+
+
+### ERC721ApproveCallerIsNotOwnerNorApprovedForAll
+
+```solidity
+error ERC721ApproveCallerIsNotOwnerNorApprovedForAll()
+```
+
+Attempting to grant approval when not being owner or approved for all should not be permitted
+
+
+
+
+### ERC721ApproveToCaller
+
+```solidity
+error ERC721ApproveToCaller()
+```
+
+Attempting to grant approval to self
+
+
+
+
+### ERC721InvalidTokenId
+
+```solidity
+error ERC721InvalidTokenId()
+```
+
+Attempting to use an invalid token ID
+
+
+
+
+### ERC721MintToTheZeroAddress
+
+```solidity
+error ERC721MintToTheZeroAddress()
+```
+
+Attempting to mint to 0x0 address
+
+
+
+
+### ERC721NotApprovedOrOwner
+
+```solidity
+error ERC721NotApprovedOrOwner()
+```
+
+Attempting to manage a token without being its owner or approved by the owner
+
+
+
+
+### ERC721TokenAlreadyMinted
+
+```solidity
+error ERC721TokenAlreadyMinted()
+```
+
+Attempting to mint an already minted token
+
+
+
+
+### ERC721TransferFromIncorrectOwner
+
+```solidity
+error ERC721TransferFromIncorrectOwner()
+```
+
+Attempting to transfer the token from an address that is not the owner
+
+
+
+
+### ERC721TransferToNonReceiverImplementer
+
+```solidity
+error ERC721TransferToNonReceiverImplementer()
+```
+
+Attempting to safe transfer to an address that is unable to receive the token
+
+
+
+
+### ERC721TransferToTheZeroAddress
+
+```solidity
+error ERC721TransferToTheZeroAddress()
+```
+
+Attempting to transfer the token to a 0x0 address
+
+
+
+
+### RMRKApprovalForAssetsToCurrentOwner
+
+```solidity
+error RMRKApprovalForAssetsToCurrentOwner()
+```
+
+Attempting to grant approval of assets to their current owner
+
+
+
+
+### RMRKApproveForAssetsCallerIsNotOwnerNorApprovedForAll
+
+```solidity
+error RMRKApproveForAssetsCallerIsNotOwnerNorApprovedForAll()
+```
+
+Attempting to grant approval of assets without being the caller or approved for all
+
+
+
+
+### RMRKAssetAlreadyExists
+
+```solidity
+error RMRKAssetAlreadyExists()
+```
+
+Attempting to add an asset using an ID that has already been used
+
+
+
+
+### RMRKBadPriorityListLength
+
+```solidity
+error RMRKBadPriorityListLength()
+```
+
+Attempting to set the priorities with an array of length that doesn&#39;t match the length of active assets array
+
+
+
+
+### RMRKIdZeroForbidden
+
+```solidity
+error RMRKIdZeroForbidden()
+```
+
+Attempting to use ID 0, which is not supported
+
+*The ID 0 in RMRK suite is reserved for empty values. Guarding against its use ensures the expected operation*
+
+
+### RMRKIndexOutOfRange
+
+```solidity
+error RMRKIndexOutOfRange()
+```
+
+Attempting to interact with an asset, using index greater than number of assets
+
+
+
+
+### RMRKMaxPendingAssetsReached
+
+```solidity
+error RMRKMaxPendingAssetsReached()
+```
+
+Attempting to add a pending asset after the number of pending assets has reached the limit (default limit is  128)
+
+
+
+
+### RMRKNoAssetMatchingId
+
+```solidity
+error RMRKNoAssetMatchingId()
+```
+
+Attempting to interact with an asset that can not be found
+
+
+
+
+### RMRKNotApprovedForAssetsOrOwner
+
+```solidity
+error RMRKNotApprovedForAssetsOrOwner()
+```
+
+Attempting to manage an asset without owning it or having been granted permission by the owner to do so
+
+
+
+
+### RMRKTokenDoesNotHaveAsset
+
+```solidity
+error RMRKTokenDoesNotHaveAsset()
+```
+
+Attempting to compose a NFT of a token without active assets
+
+
+
+
+### RMRKUnexpectedAssetId
+
+```solidity
+error RMRKUnexpectedAssetId()
+```
+
+Attempting to accept or reject an asset which does not match the one at the specified index
+
+
+
+
+### RMRKUnexpectedNumberOfAssets
+
+```solidity
+error RMRKUnexpectedNumberOfAssets()
+```
+
+Attempting to reject all pending assets but more assets than expected are pending
+
+
+
+
+

--- a/docs/mocks/extensions/revealable/RMRKRevealerMock.md
+++ b/docs/mocks/extensions/revealable/RMRKRevealerMock.md
@@ -1,0 +1,77 @@
+# RMRKRevealerMock
+
+
+
+
+
+
+
+
+
+## Methods
+
+### getRevealedAssets
+
+```solidity
+function getRevealedAssets(uint256[] tokenIds) external view returns (uint64[] revealedAssetIds, uint64[] assetToReplaceIds)
+```
+
+Returns the assetIds to reveal for the given tokenIds
+
+*This method MUST only return existing assetIdsThis method MUST return the same amount of assetIds as tokenIds*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | The tokenIds to reveal |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| revealedAssetIds | uint64[] | The assetIds to reveal |
+| assetToReplaceIds | uint64[] | The assetIds to replace |
+
+### revealedAssetId
+
+```solidity
+function revealedAssetId() external view returns (uint64)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint64 | undefined |
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined |
+
+
+
+

--- a/docs/mocks/extensions/revealable/RMRKRevealerMock.md
+++ b/docs/mocks/extensions/revealable/RMRKRevealerMock.md
@@ -10,45 +10,50 @@
 
 ## Methods
 
-### getRevealedAssets
+### getRevealableTokens
 
 ```solidity
-function getRevealedAssets(uint256[] tokenIds) external view returns (uint64[] revealedAssetIds, uint64[] assetToReplaceIds)
+function getRevealableTokens(uint256[] tokenIds) external view returns (bool[] revealable)
 ```
 
-Returns the assetIds to reveal for the given tokenIds
+-
 
-*This method MUST only return existing assetIdsThis method MUST return the same amount of assetIds as tokenIds*
+
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenIds | uint256[] | The tokenIds to reveal |
+| tokenIds | uint256[] | The `tokenIds` to check |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| revealedAssetIds | uint64[] | The assetIds to reveal |
-| assetToReplaceIds | uint64[] | The assetIds to replace |
+| revealable | bool[] | The array of booleans indicating whether each `tokenId` can be revealed or not |
 
-### revealedAssetId
+### reveal
 
 ```solidity
-function revealedAssetId() external view returns (uint64)
+function reveal(uint256[] tokenIds) external nonpayable returns (uint64[] revealedAssetsIds, uint64[] assetsToReplaceIds)
 ```
 
+-
 
+*This CAN add new assets to the original contract if necessary, in which case it SHOULD have the necessary permissionsThis method MUST only return existing `assetIds`This method MUST be called only by the contract implementing the `IRMRKRevealable` interface, during the `reveal` methodThis method MUST return the same amount of `revealedAssetsIds` and `assetsToReplaceIds`  as `tokenIds`*
 
+#### Parameters
 
-
+| Name | Type | Description |
+|---|---|---|
+| tokenIds | uint256[] | The `tokenIds` to reveal |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | undefined |
+| revealedAssetsIds | uint64[] | The revealed `assetIds` |
+| assetsToReplaceIds | uint64[] | The `assetIds` to replace |
 
 ### supportsInterface
 
@@ -71,6 +76,57 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | undefined |
+
+
+
+## Events
+
+### Revealed
+
+```solidity
+event Revealed(uint256[] tokenIds, uint64[] revealedAssetsIds, uint64[] assetsToReplaceIds)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenIds  | uint256[] | undefined |
+| revealedAssetsIds  | uint64[] | undefined |
+| assetsToReplaceIds  | uint64[] | undefined |
+
+
+
+## Errors
+
+### AlreadyRevealed
+
+```solidity
+error AlreadyRevealed(uint256 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | uint256 | undefined |
+
+### CallerIsNotRevealable
+
+```solidity
+error CallerIsNotRevealable()
+```
+
+
+
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rmrk-team/evm-contracts",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "files": [
     "contracts/RMRK/*",

--- a/test/extensions/revealable.ts
+++ b/test/extensions/revealable.ts
@@ -2,7 +2,7 @@ import { ethers } from 'hardhat';
 import { expect } from 'chai';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { IOtherInterface, IRMRKRevealer } from '../interfaces';
+import { IOtherInterface, IRMRKRevealable, IRMRKRevealer, IERC5773 } from '../interfaces';
 import { RMRKMultiAssetRevealableMock, RMRKRevealerMock } from '../../typechain-types';
 import { bn } from '../utils';
 
@@ -76,11 +76,23 @@ describe('RMRKTokenPropertiesMock', async function () {
     expect(await revealable.getRevealer()).to.eql(revealer.address);
   });
 
-  it('supports revealer interface', async function () {
-    expect(await revealable.supportsInterface(IRMRKRevealer)).to.be.true;
+  it('supports revealable interface', async function () {
+    expect(await revealable.supportsInterface(IRMRKRevealable)).to.be.true;
+  });
+
+  it('supports multiasset interface', async function () {
+    expect(await revealable.supportsInterface(IERC5773)).to.be.true;
   });
 
   it('does not support random interfaces', async function () {
     expect(await revealable.supportsInterface(IOtherInterface)).to.be.false;
+  });
+
+  it('supports revealer interface', async function () {
+    expect(await revealer.supportsInterface(IRMRKRevealer)).to.be.true;
+  });
+
+  it('does not support random interfaces', async function () {
+    expect(await revealer.supportsInterface(IOtherInterface)).to.be.false;
   });
 });

--- a/test/extensions/revealable.ts
+++ b/test/extensions/revealable.ts
@@ -1,0 +1,86 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { IOtherInterface, IRMRKRevealer } from '../interfaces';
+import { RMRKMultiAssetRevealableMock, RMRKRevealerMock } from '../../typechain-types';
+import { bn } from '../utils';
+
+const UNREVEALED_ASSET_ID = 1;
+const REVEALED_ASSET_ID = 2;
+
+async function revealableFixture(): Promise<{
+  revealable: RMRKMultiAssetRevealableMock;
+  revealer: RMRKRevealerMock;
+  deployer: SignerWithAddress;
+  user1: SignerWithAddress;
+  user2: SignerWithAddress;
+}> {
+  const [deployer, user1, user2] = await ethers.getSigners();
+  const revealableFactory = await ethers.getContractFactory('RMRKMultiAssetRevealableMock');
+  const revealerFactory = await ethers.getContractFactory('RMRKRevealerMock');
+  const revealable = await revealableFactory.deploy();
+  await revealable.deployed();
+
+  const revealer = await revealerFactory.deploy(REVEALED_ASSET_ID);
+  await revealer.deployed();
+
+  await revealable.setRevealer(revealer.address);
+
+  await revealable.mint(user1.address, 1);
+  await revealable.mint(user1.address, 2);
+  await revealable.mint(user2.address, 3);
+
+  await revealable.addAssetEntry(UNREVEALED_ASSET_ID, 'ipfs://unrevealed');
+  await revealable.addAssetEntry(REVEALED_ASSET_ID, 'ipfs://revealed');
+
+  await revealable.addAssetToToken(1, UNREVEALED_ASSET_ID, 0);
+  await revealable.addAssetToToken(2, UNREVEALED_ASSET_ID, 0);
+  await revealable.addAssetToToken(3, REVEALED_ASSET_ID, 0);
+
+  await revealable.connect(user1).acceptAsset(1, 0, UNREVEALED_ASSET_ID);
+  await revealable.connect(user1).acceptAsset(2, 0, UNREVEALED_ASSET_ID);
+  await revealable.connect(user2).acceptAsset(3, 0, REVEALED_ASSET_ID);
+
+  return { revealable, revealer, deployer, user1, user2 };
+}
+
+// --------------- TESTS -----------------------
+
+describe('RMRKTokenPropertiesMock', async function () {
+  let revealable: RMRKMultiAssetRevealableMock;
+  let revealer: RMRKRevealerMock;
+  let deployer: SignerWithAddress;
+  let user1: SignerWithAddress;
+  let user2: SignerWithAddress;
+
+  beforeEach(async function () {
+    ({ revealable, revealer, deployer, user1, user2 } = await loadFixture(revealableFixture));
+  });
+
+  it('can reveal an asset if it holds it', async function () {
+    expect(await revealable.getActiveAssets(1)).to.eql([bn(UNREVEALED_ASSET_ID)]);
+    await revealable.connect(user1).reveal([1, 2]);
+    expect(await revealable.getActiveAssets(1)).to.eql([bn(REVEALED_ASSET_ID)]);
+    expect(await revealable.getActiveAssets(2)).to.eql([bn(REVEALED_ASSET_ID)]);
+  });
+
+  it('cannot reveal an asset from another user', async function () {
+    await expect(revealable.connect(user2).reveal([1, 2])).to.be.revertedWithCustomError(
+      revealable,
+      'RMRKNotApprovedForAssetsOrOwner',
+    );
+  });
+
+  it('can get revealer address', async function () {
+    expect(await revealable.getRevealer()).to.eql(revealer.address);
+  });
+
+  it('supports revealer interface', async function () {
+    expect(await revealable.supportsInterface(IRMRKRevealer)).to.be.true;
+  });
+
+  it('does not support random interfaces', async function () {
+    expect(await revealable.supportsInterface(IOtherInterface)).to.be.false;
+  });
+});

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -17,7 +17,8 @@ const IRMRKTokenProperties = '0x6a49fd01';
 const IERC7508 = '0x07cd44c7';
 const IRMRKTypedMultiAsset = '0x7f7bb665';
 const IRMRKImplementation = '0x524D524B'; // "RMRK" in ASCII hex
-const IRMRKRevealer = '0x4be9cc42'; // "RMRK" in ASCII hex
+const IRMRKRevealable = '0x4be9cc42';
+const IRMRKRevealer = '0xfeacbfa3';
 
 export {
   IERC165,
@@ -39,5 +40,6 @@ export {
   IERC7508,
   IRMRKTokenProperties,
   IRMRKImplementation,
+  IRMRKRevealable,
   IRMRKRevealer,
 };

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -18,7 +18,7 @@ const IERC7508 = '0x07cd44c7';
 const IRMRKTypedMultiAsset = '0x7f7bb665';
 const IRMRKImplementation = '0x524D524B'; // "RMRK" in ASCII hex
 const IRMRKRevealable = '0x4be9cc42';
-const IRMRKRevealer = '0xfeacbfa3';
+const IRMRKRevealer = '0xf9296b16';
 
 export {
   IERC165,

--- a/test/interfaces.ts
+++ b/test/interfaces.ts
@@ -17,6 +17,7 @@ const IRMRKTokenProperties = '0x6a49fd01';
 const IERC7508 = '0x07cd44c7';
 const IRMRKTypedMultiAsset = '0x7f7bb665';
 const IRMRKImplementation = '0x524D524B'; // "RMRK" in ASCII hex
+const IRMRKRevealer = '0x4be9cc42'; // "RMRK" in ASCII hex
 
 export {
   IERC165,
@@ -38,4 +39,5 @@ export {
   IERC7508,
   IRMRKTokenProperties,
   IRMRKImplementation,
+  IRMRKRevealer,
 };


### PR DESCRIPTION
# Description

Adds Revealable/Revealer extensions with abstract impl for the first.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Bump version from 2.1.1 to 2.2.0 in package.json
- Update CODEOWNERS file
- Update VERSION constant in RMRKCore.sol
- Update imports and functions in RMRKEquippableMock.sol and RMRKMinifiedEquippableMock.sol
- Add new interfaces IRMRKRevealable and IRMRKRevealer
- Change visibility of certain functions in RMRKNestableMultiAsset.sol, RMRKEquippable.sol, RMRKNestable.sol, RMRKMultiAsset.sol, RMRKMinifiedEquippable.sol
- Update CHANGELOG.md
- Update env.example file
- Update visibility of functions in RMRKMultiAsset.sol
- Add new documentation files IRMRKRevealable.md and RMRKRevealable.md
- Update visibility of functions in RMRKMinifiedEquippable.sol
- Add new contract RMRKMultiAssetRevealableMock.sol
- Add new interface IRMRKRevealer.sol
- Add new documentation file RMRKRevealable.md

> The following files were skipped due to too many changes: `docs/RMRK/extension/revealable/RMRKRevealable.md`, `docs/RMRK/extension/revealable/IRMRKRevealer.md`, `contracts/mocks/extensions/revealable/RMRKRevealerMock.sol`, `docs/mocks/extensions/revealable/RMRKRevealerMock.md`, `contracts/RMRK/extension/revealable/RMRKRevealable.sol`, `test/extensions/revealable.ts`, `docs/elin/contracts/token/ERC721/extensions/ERC721Burnable.md`, `docs/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->