### PR TITLE
Royalties splitter

### DIFF
--- a/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
+++ b/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.21;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+error InvalidInput();
+error FailedToSend();
+
+/**
+ * @title RMRKRoyaltiesSplitter
+ * @author RMRK team
+ * @notice Smart contract of the RMRK Royalties Spliter module.
+ * @dev This smart contract provides a simple way to share royalties from either native or erc20 payments.
+ */
+contract RMRKRoyaltiesSplitter {
+    event NativePaymentDistributed(address indexed sender, uint256 amount);
+    event ERCPaymentDistributed(
+        address indexed sender,
+        address indexed currency,
+        uint256 amount
+    );
+
+    uint256 constant MAX_BPS = 10000;
+    address[] private _beneficiaries;
+    mapping(address => uint256) private _sharesBps;
+
+    constructor(address[] memory beneficiaries, uint256[] memory sharesBps) {
+        uint256 length = beneficiaries.length;
+        if (length != sharesBps.length) revert InvalidInput();
+        uint256 totalShares = 0;
+
+        for (uint256 i; i < length; ) {
+            _beneficiaries.push(beneficiaries[i]);
+            _sharesBps[beneficiaries[i]] = sharesBps[i];
+            totalShares += sharesBps[i];
+            unchecked {
+                ++i;
+            }
+        }
+        if (totalShares != MAX_BPS) revert InvalidInput();
+    }
+
+    receive() external payable {
+        uint256 length = _beneficiaries.length;
+        uint256 totalDistribution;
+
+        for (uint256 i; i < length; ) {
+            uint256 share;
+            if (i == length - 1) {
+                share = msg.value - totalDistribution; // leftover to last beneficiary
+            } else {
+                share = (msg.value * _sharesBps[_beneficiaries[i]]) / MAX_BPS;
+            }
+            (bool success, ) = _beneficiaries[i].call{value: share}("");
+            if (!success) revert FailedToSend();
+            unchecked {
+                totalDistribution += share;
+                ++i;
+            }
+        }
+
+        emit NativePaymentDistributed(msg.sender, msg.value);
+    }
+
+    function distributeERC20(address currency, uint256 amount) external {
+        uint256 length = _beneficiaries.length;
+        uint256 totalDistribution;
+
+        for (uint256 i; i < length; ) {
+            uint256 share;
+            if (i == length - 1) {
+                share = amount - totalDistribution; // leftover to last beneficiary
+            } else {
+                share = (amount * _sharesBps[_beneficiaries[i]]) / MAX_BPS;
+            }
+            IERC20(currency).transfer(_beneficiaries[i], share);
+
+            unchecked {
+                totalDistribution += share;
+                ++i;
+            }
+        }
+
+        emit ERCPaymentDistributed(msg.sender, currency, amount);
+    }
+}

--- a/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
+++ b/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 error InvalidInput();
 error FailedToSend();
+error OnlyBeneficiary();
 
 /**
  * @title RMRKRoyaltiesSplitter
@@ -81,6 +82,18 @@ contract RMRKRoyaltiesSplitter {
     function distributeERC20(address currency, uint256 amount) external {
         uint256 length = _beneficiaries.length;
         uint256 totalDistribution;
+
+        bool callerIsBeneficiary;
+        for (uint256 i; i < length; ) {
+            if (_beneficiaries[i] == msg.sender) {
+                callerIsBeneficiary = true;
+                break;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (!callerIsBeneficiary) revert OnlyBeneficiary();
 
         for (uint256 i; i < length; ) {
             uint256 share;

--- a/docs/implementations/utils/RMRKRoyaltiesSplitter.md
+++ b/docs/implementations/utils/RMRKRoyaltiesSplitter.md
@@ -1,0 +1,95 @@
+# RMRKRoyaltiesSplitter
+
+*RMRK team*
+
+> RMRKRoyaltiesSplitter
+
+Smart contract of the RMRK Royalties Spliter module.
+
+*This smart contract provides a simple way to share royalties from either native or erc20 payments.*
+
+## Methods
+
+### distributeERC20
+
+```solidity
+function distributeERC20(address currency, uint256 amount) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| currency | address | undefined |
+| amount | uint256 | undefined |
+
+
+
+## Events
+
+### ERCPaymentDistributed
+
+```solidity
+event ERCPaymentDistributed(address indexed sender, address indexed currency, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| sender `indexed` | address | undefined |
+| currency `indexed` | address | undefined |
+| amount  | uint256 | undefined |
+
+### NativePaymentDistributed
+
+```solidity
+event NativePaymentDistributed(address indexed sender, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| sender `indexed` | address | undefined |
+| amount  | uint256 | undefined |
+
+
+
+## Errors
+
+### FailedToSend
+
+```solidity
+error FailedToSend()
+```
+
+
+
+
+
+
+### InvalidInput
+
+```solidity
+error InvalidInput()
+```
+
+
+
+
+
+
+

--- a/docs/implementations/utils/RMRKRoyaltiesSplitter.md
+++ b/docs/implementations/utils/RMRKRoyaltiesSplitter.md
@@ -16,16 +16,34 @@ Smart contract of the RMRK Royalties Spliter module.
 function distributeERC20(address currency, uint256 amount) external nonpayable
 ```
 
+Distributes an ERC20 payment to the beneficiaries.
 
-
-
+*The payment is distributed according to the shares specified in the constructor.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| currency | address | undefined |
-| amount | uint256 | undefined |
+| currency | address | The address of the ERC20 token. |
+| amount | uint256 | The amount of tokens to distribute. |
+
+### getBenefiariesAndShares
+
+```solidity
+function getBenefiariesAndShares() external view returns (address[] beneficiaries, uint256[] shares)
+```
+
+Returns the list of beneficiaries and their shares.
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| beneficiaries | address[] | The list of beneficiaries. |
+| shares | uint256[] | The list of shares. |
 
 
 

--- a/test/royaltiesSplitter.ts
+++ b/test/royaltiesSplitter.ts
@@ -26,6 +26,13 @@ describe('RMRKRoyaltiesSplitter', () => {
     await royaltiesSplitter.deployed();
   });
 
+  it('can get beneficiaries and shares', async () => {
+    expect(await royaltiesSplitter.getBenefiariesAndShares()).to.deep.equal([
+      beneficiaries.map((b) => b.address),
+      SHARES_BPS,
+    ]);
+  });
+
   it('should distribute native payment correctly', async () => {
     const amount = ethers.utils.parseEther('1');
     await expect(() => sender.sendTransaction({ to: royaltiesSplitter.address, value: amount }))

--- a/test/royaltiesSplitter.ts
+++ b/test/royaltiesSplitter.ts
@@ -1,0 +1,87 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { RMRKRoyaltiesSplitter } from '../typechain-types';
+
+describe('RMRKRoyaltiesSplitter', () => {
+  let royaltiesSplitter: RMRKRoyaltiesSplitter;
+  let sender: SignerWithAddress;
+  let beneficiary1: SignerWithAddress;
+  let beneficiary2: SignerWithAddress;
+  let beneficiary3: SignerWithAddress;
+
+  let beneficiaries: SignerWithAddress[];
+
+  const SHARES_BPS = [2500, 2500, 5000]; // 50% for each beneficiary
+
+  beforeEach(async () => {
+    [sender, beneficiary1, beneficiary2, beneficiary3] = await ethers.getSigners();
+    beneficiaries = [beneficiary1, beneficiary2, beneficiary3];
+
+    const royaltiesSplitterFactory = await ethers.getContractFactory('RMRKRoyaltiesSplitter');
+    royaltiesSplitter = await royaltiesSplitterFactory.deploy(
+      beneficiaries.map((b) => b.address),
+      SHARES_BPS,
+    );
+    await royaltiesSplitter.deployed();
+  });
+
+  it('should distribute native payment correctly', async () => {
+    const amount = ethers.utils.parseEther('1');
+    await expect(() => sender.sendTransaction({ to: royaltiesSplitter.address, value: amount }))
+      .to.emit(royaltiesSplitter, 'NativePaymentDistributed')
+      .withArgs(sender.address, amount)
+      .to.changeEtherBalance(beneficiary1, amount.mul(2500).div(10000))
+      .and.changeEtherBalance(beneficiary2, amount.mul(2500).div(10000))
+      .and.changeEtherBalance(beneficiary3, amount.mul(5000).div(10000));
+  });
+
+  it('should distribute ERC20 payment correctly', async () => {
+    const erc20MockFactory = await ethers.getContractFactory('ERC20Mock');
+    const erc20Token = await erc20MockFactory.deploy();
+    await erc20Token.deployed();
+
+    const amount = ethers.utils.parseUnits('100', 18);
+    await erc20Token.mint(sender.address, amount);
+    await erc20Token.connect(sender).transfer(royaltiesSplitter.address, amount);
+
+    expect(await royaltiesSplitter.distributeERC20(erc20Token.address, amount))
+      .to.emit(royaltiesSplitter, 'ERCPaymentDistributed')
+      .withArgs(sender.address, erc20Token.address, amount);
+    expect(await erc20Token.balanceOf(beneficiary1.address)).to.equal(amount.mul(2500).div(10000));
+    expect(await erc20Token.balanceOf(beneficiary2.address)).to.equal(amount.mul(2500).div(10000));
+    expect(await erc20Token.balanceOf(beneficiary3.address)).to.equal(amount.mul(5000).div(10000));
+  });
+
+  it('cannot create with invalid configuration', async () => {
+    const royaltiesSplitterFactory = await ethers.getContractFactory('RMRKRoyaltiesSplitter');
+    // Missmatch in length
+    await expect(
+      royaltiesSplitterFactory.deploy(
+        beneficiaries.map((b) => b.address),
+        SHARES_BPS.slice(0, 2),
+      ),
+    ).to.be.reverted;
+    // Missmatch in length
+    await expect(
+      royaltiesSplitterFactory.deploy(
+        beneficiaries.slice(0, 2).map((b) => b.address),
+        SHARES_BPS,
+      ),
+    ).to.be.reverted;
+    // Shares below 10000
+    await expect(
+      royaltiesSplitterFactory.deploy(
+        beneficiaries.map((b) => b.address),
+        [2500, 2500, 2500],
+      ),
+    ).to.be.reverted;
+    // Shares over 10000
+    await expect(
+      royaltiesSplitterFactory.deploy(
+        beneficiaries.map((b) => b.address),
+        [2500, 2500, 5001],
+      ),
+    ).to.be.reverted;
+  });
+});


### PR DESCRIPTION
# Description

Adds RoyaltiesSplitter contract.
Beneficiaries and shares are set on creation and cannot be further changed.
Native tokens received are immediately distributed.
ERC20 tokens do not notify the receiver, so they must be manually claimed. To simplify the logic, the distribute method can be called by anyone and it will distribute to all beneficiaries according to the shares.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `RMRKRoyaltiesSplitter` smart contract for sharing royalties from native or ERC20 payments.
- Added `distributeERC20` function to distribute ERC20 payments to beneficiaries.
- Added `getBenefiariesAndShares` function to get the list of beneficiaries and their shares.
- Added `ERCPaymentDistributed` and `NativePaymentDistributed` events.
- Added error types `InvalidInput`, `FailedToSend`, and `OnlyBeneficiary`.
- Added tests for the `RMRKRoyaltiesSplitter` contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->