### PR TITLE
Uses contractURI instead of collectionMetadata

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ typechain-types
 cache
 coverage*
 gasReporterOutput.json
+CHANGELOG.md

--- a/contracts/RMRK/utils/IRMRKCollectionData.sol
+++ b/contracts/RMRK/utils/IRMRKCollectionData.sol
@@ -18,4 +18,6 @@ interface IRMRKCollectionData {
     function symbol() external view returns (string memory);
 
     function collectionMetadata() external view returns (string memory);
+
+    function contractURI() external view returns (string memory);
 }

--- a/contracts/RMRK/utils/RMRKCollectionUtils.sol
+++ b/contracts/RMRK/utils/RMRKCollectionUtils.sol
@@ -85,7 +85,13 @@ contract RMRKCollectionUtils {
             string memory collectionMetadata
         ) {
             data.collectionMetadata = collectionMetadata;
-        } catch {}
+        } catch {
+            try target.contractURI() returns (
+                string memory collectionMetadata
+            ) {
+                data.collectionMetadata = collectionMetadata;
+            } catch {}
+        }
     }
 
     /**

--- a/contracts/implementations/utils/RMRKImplementationBase.sol
+++ b/contracts/implementations/utils/RMRKImplementationBase.sol
@@ -72,7 +72,7 @@ abstract contract RMRKImplementationBase is RMRKRoyalties, Ownable {
      * @notice Used to retrieve the metadata of the collection.
      * @return string The metadata URI of the collection
      */
-    function collectionMetadata() public view virtual returns (string memory) {
+    function contractURI() public view virtual returns (string memory) {
         return _collectionMetadata;
     }
 

--- a/test/behavior/metadata.ts
+++ b/test/behavior/metadata.ts
@@ -17,7 +17,7 @@ async function shouldHaveMetadata(
   });
 
   it('can get collection meta', async function () {
-    expect(await this.token.collectionMetadata()).to.eql('ipfs://collection-meta');
+    expect(await this.token.contractURI()).to.eql('ipfs://collection-meta');
   });
 }
 


### PR DESCRIPTION
# Description

This is to follow the recommended practice by OpenSea.
CollectionUtils contract will try both.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
