### PR TITLE
Refresh metadata

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ typechain-types
 cache
 coverage*
 gasReporterOutput.json
+CHANGELOG.md

--- a/contracts/RMRK/utils/RMRKCollectionUtils.sol
+++ b/contracts/RMRK/utils/RMRKCollectionUtils.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.21;
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 import "../equippable/IERC6220.sol";
 import "../nestable/IERC7401.sol";
 import "../extension/soulbound/IERC6454.sol";
@@ -17,6 +18,14 @@ import "./IRMRKCollectionData.sol";
  * @dev Extra utility functions for RMRK contracts.
  */
 contract RMRKCollectionUtils {
+    using Address for address;
+
+    event CollectionTokensMetadataRefreshTriggered(address indexed collection);
+    event TokenMetadataRefreshTriggered(
+        address indexed collection,
+        uint256 indexed tokenId
+    );
+
     /**
      * notice Structure used to represent the collection data.
      * @return totalSupply The total supply of the collection
@@ -174,5 +183,35 @@ contract RMRKCollectionUtils {
                 ++i;
             }
         }
+    }
+
+    /**
+     * @notice Triggers an event to refresh the collection metadata.
+     * @dev It will do nothing if the given collection address is not a contract.
+     * @param collectionAddress Address of the collection to refresh the metadata from
+     */
+    function refreshCollectionTokensMetadata(address collectionAddress) public {
+        // To avoid some spam
+        if (!collectionAddress.isContract()) {
+            return;
+        }
+        emit CollectionTokensMetadataRefreshTriggered(collectionAddress);
+    }
+
+    /**
+     * @notice Triggers an event to refresh the token metadata.
+     * @dev It will do nothing if the given collection address is not a contract.
+     * @param collectionAddress Address of the collection to refresh the metadata from
+     * @param tokenId ID of the token to refresh the metadata from
+     */
+    function refreshTokenMetadata(
+        address collectionAddress,
+        uint256 tokenId
+    ) public {
+        // To avoid some spam
+        if (!collectionAddress.isContract()) {
+            return;
+        }
+        emit TokenMetadataRefreshTriggered(collectionAddress, tokenId);
     }
 }

--- a/docs/RMRK/utils/RMRKCollectionUtils.md
+++ b/docs/RMRK/utils/RMRKCollectionUtils.md
@@ -83,6 +83,75 @@ Used to get a list of existing token IDs in the range between `pageStart` and `p
 |---|---|---|
 | page | uint256[] | An array of IDs of the existing tokens |
 
+### refreshCollectionTokensMetadata
+
+```solidity
+function refreshCollectionTokensMetadata(address collectionAddress) external nonpayable
+```
+
+Triggers an event to refresh the collection metadata.
+
+*It will do nothing if the given collection address is not a contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collectionAddress | address | Address of the collection to refresh the metadata from |
+
+### refreshTokenMetadata
+
+```solidity
+function refreshTokenMetadata(address collectionAddress, uint256 tokenId) external nonpayable
+```
+
+Triggers an event to refresh the token metadata.
+
+*It will do nothing if the given collection address is not a contract.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collectionAddress | address | Address of the collection to refresh the metadata from |
+| tokenId | uint256 | ID of the token to refresh the metadata from |
+
+
+
+## Events
+
+### CollectionTokensMetadataRefreshTriggered
+
+```solidity
+event CollectionTokensMetadataRefreshTriggered(address indexed collection)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection `indexed` | address | undefined |
+
+### TokenMetadataRefreshTriggered
+
+```solidity
+event TokenMetadataRefreshTriggered(address indexed collection, uint256 indexed tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection `indexed` | address | undefined |
+| tokenId `indexed` | uint256 | undefined |
 
 
 

--- a/test/collectionUtils.ts
+++ b/test/collectionUtils.ts
@@ -218,4 +218,28 @@ describe('Collection Utils', function () {
       bn(9),
     ]);
   });
+
+  it('can trigger collection metadata update', async function () {
+    await expect(
+      collectionUtils.connect(issuer).refreshCollectionTokensMetadata(multiAsset.address),
+    )
+      .to.emit(collectionUtils, 'CollectionTokensMetadataRefreshTriggered')
+      .withArgs(multiAsset.address);
+  });
+
+  it('can trigger token metadata update', async function () {
+    await expect(collectionUtils.connect(issuer).refreshTokenMetadata(multiAsset.address, 1))
+      .to.emit(collectionUtils, 'TokenMetadataRefreshTriggered')
+      .withArgs(multiAsset.address, 1);
+  });
+
+  it('does not emit event if contract address is not a contract', async function () {
+    await expect(
+      collectionUtils.connect(issuer).refreshCollectionTokensMetadata(ADDRESS_ZERO),
+    ).to.not.emit(collectionUtils, 'CollectionTokensMetadataRefreshTriggered');
+    await expect(collectionUtils.connect(issuer).refreshTokenMetadata(ADDRESS_ZERO, 1)).to.not.emit(
+      collectionUtils,
+      'TokenMetadataRefreshTriggered',
+    );
+  });
 });


### PR DESCRIPTION
# Description

Adds utils to trigger token metadata refresh events.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
This PR adds two new functions to the `RMRKCollectionUtils` contract: `refreshCollectionTokensMetadata` and `refreshTokenMetadata`. These functions trigger events to refresh the metadata of a collection and a token, respectively. The events are only triggered if the given collection address is a contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->