### PR TITLE
Upgrades OpenZeppelin to v5 and replaces isContract calls.

### DIFF
--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -390,9 +390,7 @@ contract RMRKMinifiedEquippable is
         uint256 destinationId,
         bytes memory data
     ) internal virtual {
-        // It seems redundant, but otherwise it would revert with no error
         _checkDestination(to);
-
         _innerMint(to, tokenId, destinationId, data);
         _sendToNFT(address(0), to, 0, destinationId, tokenId, data);
     }
@@ -2066,7 +2064,7 @@ contract RMRKMinifiedEquippable is
      * @param to Address of the destination
      */
     function _checkDestination(address to) internal view {
-        // It seems redundant, but otherwise it would revert with no error
+        // Checking if it is a contract before calling it seems redundant, but otherwise it would revert with no error
         if (to.code.length == 0) revert RMRKIsNotContract();
         if (!IERC165(to).supportsInterface(type(IERC7401).interfaceId))
             revert RMRKNestableTransferToNonRMRKNestableImplementer();

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -84,8 +84,6 @@ error RMRKMaxPendingAssetsReached();
 error RMRKMaxRecursiveBurnsReached(address childContract, uint256 childId);
 /// Attempting to mint a number of tokens that would cause the total supply to be greater than maximum supply
 error RMRKMintOverMax();
-/// Attempting to mint a nested token to a smart contract that doesn't support nesting
-error RMRKMintToNonRMRKNestableImplementer();
 /// Attempting to mint zero tokens
 error RMRKMintZero();
 /// Attempting to pass complementary arrays of different lengths

--- a/contracts/RMRK/multiasset/RMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/RMRKMultiAsset.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.21;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "./AbstractMultiAsset.sol";
 import "../core/RMRKCore.sol";
@@ -17,8 +16,6 @@ import "../library/RMRKErrors.sol";
  * @notice Smart contract of the RMRK Multi asset module.
  */
 contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
-    using Address for address;
-
     // Mapping from token ID to owner address
     mapping(uint256 => address) private _owners;
 
@@ -490,7 +487,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
         uint256 tokenId,
         bytes memory data
     ) private returns (bool) {
-        if (to.isContract()) {
+        if (to.code.length != 0) {
             try
                 IERC721Receiver(to).onERC721Received(
                     _msgSender(),

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -444,9 +444,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
         uint256 destinationId,
         bytes memory data
     ) internal virtual {
-        // It seems redundant, but otherwise it would revert with no error
         _checkDestination(to);
-
         _innerMint(to, tokenId, destinationId, data);
         _sendToNFT(address(0), to, 0, destinationId, tokenId, data);
     }
@@ -1175,7 +1173,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      * @param to Address of the destination
      */
     function _checkDestination(address to) internal view {
-        // It seems redundant, but otherwise it would revert with no error
+        // Checking if it is a contract before calling it seems redundant, but otherwise it would revert with no error
         if (to.code.length == 0) revert RMRKIsNotContract();
         if (!IERC165(to).supportsInterface(type(IERC7401).interfaceId))
             revert RMRKNestableTransferToNonRMRKNestableImplementer();

--- a/contracts/RMRK/utils/RMRKCollectionUtils.sol
+++ b/contracts/RMRK/utils/RMRKCollectionUtils.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.21;
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 import "../equippable/IERC6220.sol";
 import "../nestable/IERC7401.sol";
 import "../extension/soulbound/IERC6454.sol";
@@ -18,8 +17,6 @@ import "./IRMRKCollectionData.sol";
  * @dev Extra utility functions for RMRK contracts.
  */
 contract RMRKCollectionUtils {
-    using Address for address;
-
     event CollectionTokensMetadataRefreshTriggered(address indexed collection);
     event TokenMetadataRefreshTriggered(
         address indexed collection,
@@ -198,7 +195,7 @@ contract RMRKCollectionUtils {
      */
     function refreshCollectionTokensMetadata(address collectionAddress) public {
         // To avoid some spam
-        if (!collectionAddress.isContract()) {
+        if (collectionAddress.code.length == 0) {
             return;
         }
         emit CollectionTokensMetadataRefreshTriggered(collectionAddress);
@@ -215,7 +212,7 @@ contract RMRKCollectionUtils {
         uint256 tokenId
     ) public {
         // To avoid some spam
-        if (!collectionAddress.isContract()) {
+        if (collectionAddress.code.length == 0) {
             return;
         }
         emit TokenMetadataRefreshTriggered(collectionAddress, tokenId);

--- a/docs/RMRK/access/Ownable.md
+++ b/docs/RMRK/access/Ownable.md
@@ -4,7 +4,7 @@
 
 > Ownable
 
-A minimal ownable smart contractf or owner and contributors.
+A minimal ownable smart contract or owner and contributors.
 
 *This smart contract is based on &quot;openzeppelin&#39;s access/Ownable.sol&quot;.*
 

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
@@ -2015,17 +2015,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
@@ -2050,17 +2050,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.md
@@ -1269,17 +1269,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.md
@@ -1304,17 +1304,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
@@ -1757,17 +1757,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
@@ -1792,17 +1792,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
@@ -1997,17 +1997,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
@@ -2032,17 +2032,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
@@ -1251,17 +1251,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
@@ -1286,17 +1286,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
@@ -1739,17 +1739,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
@@ -1774,17 +1774,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/premint/RMRKEquippablePreMint.md
+++ b/docs/implementations/premint/RMRKEquippablePreMint.md
@@ -1965,17 +1965,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
@@ -2000,17 +2000,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
@@ -1707,17 +1707,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
@@ -1742,17 +1742,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestablePreMint.md
+++ b/docs/implementations/premint/RMRKNestablePreMint.md
@@ -1219,17 +1219,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestablePreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKNestablePreMintSoulbound.md
@@ -1254,17 +1254,6 @@ Attempting to mint a number of tokens that would cause the total supply to be gr
 
 
 
-### RMRKMintToNonRMRKNestableImplementer
-
-```solidity
-error RMRKMintToNonRMRKNestableImplementer()
-```
-
-Attempting to mint a nested token to a smart contract that doesn&#39;t support nesting
-
-
-
-
 ### RMRKMintZero
 
 ```solidity

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.6.0"
+    "@openzeppelin/contracts": "^5.0.0"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.3.4",

--- a/test/behavior/nestable.ts
+++ b/test/behavior/nestable.ts
@@ -85,7 +85,7 @@ async function shouldBehaveLikeNestable(
 
       await expect(nestMint(child, nonReceiver.address, parentId)).to.be.revertedWithCustomError(
         child,
-        'RMRKMintToNonRMRKNestableImplementer',
+        'RMRKNestableTransferToNonRMRKNestableImplementer',
       );
     });
 
@@ -1037,7 +1037,7 @@ async function shouldBehaveLikeNestable(
     it('cannot nest tranfer to address 0', async function () {
       await expect(
         nestTransfer(child, firstOwner, ADDRESS_ZERO, childId, parentId),
-      ).to.be.revertedWithCustomError(child, 'ERC721TransferToTheZeroAddress');
+      ).to.be.revertedWithCustomError(child, 'RMRKIsNotContract');
     });
 
     it('cannot nest tranfer to a non contract', async function () {

--- a/test/implementations/lazyMintErc20Pay.ts
+++ b/test/implementations/lazyMintErc20Pay.ts
@@ -117,8 +117,9 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
 
     await erc20.mint(addrs[0].address, ONE_ETH);
     await erc20.approve(this.token.address, HALF_ETH);
-    await expect(this.token.mint(addrs[0].address, 1)).to.be.revertedWith(
-      'ERC20: insufficient allowance',
+    await expect(this.token.mint(addrs[0].address, 1)).to.be.revertedWithCustomError(
+      erc20,
+      'ERC20InsufficientAllowance',
     );
   });
 
@@ -179,9 +180,9 @@ async function shouldControlValidMintingErc20Pay(): Promise<void> {
     expect(await this.token.totalSupply()).to.equal(10);
     expect(await this.token.balanceOf(addrs[0].address)).to.equal(10);
 
-    await expect(this.token.connect(addrs[0]).mint(addrs[0].address, 1)).to.be.revertedWith(
-      'ERC20: insufficient allowance',
-    );
+    await expect(
+      this.token.connect(addrs[0]).mint(addrs[0].address, 1),
+    ).to.be.revertedWithCustomError(erc20, 'ERC20InsufficientAllowance');
   });
 
   describe('Nest minting', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,10 +988,10 @@
     find-up "^4.1.0"
     fs-extra "^8.1.0"
 
-"@openzeppelin/contracts@^4.6.0":
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.0.tgz#6854c37df205dd2c056bdfa1b853f5d732109109"
-  integrity sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw==
+"@openzeppelin/contracts@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.0.tgz#ee0e4b4564f101a5c4ee398cd4d73c0bd92b289c"
+  integrity sha512-bv2sdS6LKqVVMLI5+zqnNrNU/CA+6z6CmwFXm/MzmOPBRSO5reEJN7z0Gbzvs0/bv/MZZXNklubpwy3v2+azsw==
 
 "@openzeppelin/test-helpers@^0.5.16":
   version "0.5.16"


### PR DESCRIPTION
# Description

Describe the additions/improvements this PR contains.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR updates dependencies, fixes typos in documentation, and makes improvements to error handling and contract functionality.

### Detailed summary:
- Updated dependency "@openzeppelin/contracts" from version 4.6.0 to 5.0.0
- Fixed typos in documentation files
- Improved error handling for minting and transfer functions in various contracts
- Removed unnecessary usage of the `Address` library in some contracts

> The following files were skipped due to too many changes: `contracts/RMRK/equippable/RMRKMinifiedEquippable.sol`, `contracts/RMRK/nestable/RMRKNestable.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->