### PR TITLE
Defender improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,20 @@
 # Testing networks
-MOONBASE_URL=https://moonbase-alpha.blastapi.io/<YOUR ALCHEMY KEY>
-SEPOLIA_URL=https://eth-sepolia.g.alchemy.com/v2/<YOUR ALCHEMY KEY>
-MUMBAI_URL=https://polygon-mumbai.g.alchemy.com/v2/<YOUR API KEY>
-BASE_GOERLI_URL=https://base-goerli.g.alchemy.com/v2/<YOUR API KEY>
+MOONBASE_URL=
+SEPOLIA_URL=
+MUMBAI_URL=
+BASE_GOERLI_URL=
 SHIBUYA_URL=
 ZKATANA_URL=
+IMMUTABLE_TEST_URL=
 
 # Mainnet networks
-MOONRIVER_URL=https://moonriver.blastapi.io/<YOUR ALCHEMY KEY>
-MOONBEAM_URL=https://moonbeam.blastapi.io/<YOUR ALCHEMY KEY>
-ETHEREUM_URL=https://eth-mainnet.g.alchemy.com/v2/<YOUR ALCHEMY KEY>
-POLYGON_URL=https://polygon-mainnet.g.alchemy.com/v2/<YOUR API KEY>
-BASE_URL=https://base-mainnet.g.alchemy.com/v2/<YOUR API KEY>
+MOONRIVER_URL=
+MOONBEAM_URL=
+ETHEREUM_URL=
+POLYGON_URL=
+BASE_URL=
 ASTAR_URL=
+BSC_URL=
 
 # To verify contracts
 ETHERSCAN_API_KEY=ABC123
@@ -21,6 +23,8 @@ POLYGONSCAN_API_KEY=ABC123
 BASESCAN_API_KEY=ABC123
 ASTAR_BLOCKSCOUT_API_KEY=ABC123
 ZKATANA_BLOCKSCOUT_API_KEY=ABC123
+BSCSCAN_API_KEY=ABC123
+IMMUTABLE_BLOCKSCOUT_API_KEY=ABC123
 
 # To report gas
 REPORT_GAS=

--- a/contracts/RMRK/access/Ownable.sol
+++ b/contracts/RMRK/access/Ownable.sol
@@ -59,10 +59,10 @@ contract Ownable is Context {
 
     /**
      * @notice Returns the address of the current owner.
-     * @return Address of the current owner
+     * @return owner_ Address of the current owner
      */
-    function owner() public view virtual returns (address) {
-        return _owner;
+    function owner() public view virtual returns (address owner_) {
+        owner_ = _owner;
     }
 
     /**
@@ -119,10 +119,12 @@ contract Ownable is Context {
     /**
      * @notice Used to check if the address is one of the contributors.
      * @param contributor Address of the contributor whose status we are checking
-     * @return Boolean value indicating whether the address is a contributor or not
+     * @return isContributor_ Boolean value indicating whether the address is a contributor or not
      */
-    function isContributor(address contributor) public view returns (bool) {
-        return _contributors[contributor] == 1;
+    function isContributor(
+        address contributor
+    ) public view returns (bool isContributor_) {
+        isContributor_ = _contributors[contributor] == 1;
     }
 
     /**

--- a/contracts/RMRK/access/Ownable.sol
+++ b/contracts/RMRK/access/Ownable.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/Context.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/access/OwnableLock.sol
+++ b/contracts/RMRK/access/OwnableLock.sol
@@ -38,10 +38,10 @@ contract OwnableLock is Ownable {
 
     /**
      * @notice Used to retrieve the status of a lockable smart contract.
-     * @return A boolean value signifying whether the smart contract has been locked
+     * @return isLocked A boolean value signifying whether the smart contract has been locked
      */
-    function getLock() public view returns (bool) {
-        return _lock == 1;
+    function getLock() public view returns (bool isLocked) {
+        isLocked = _lock == 1;
     }
 
     /**

--- a/contracts/RMRK/access/OwnableLock.sol
+++ b/contracts/RMRK/access/OwnableLock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "./Ownable.sol";
+import {Ownable} from "./Ownable.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/catalog/IRMRKCatalog.sol
+++ b/contracts/RMRK/catalog/IRMRKCatalog.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IRMRKCatalog

--- a/contracts/RMRK/catalog/IRMRKCatalog.sol
+++ b/contracts/RMRK/catalog/IRMRKCatalog.sol
@@ -125,34 +125,36 @@ interface IRMRKCatalog is IERC165 {
      * @dev Returns true if a collection may equip asset with `partId`.
      * @param partId The ID of the part that we are checking
      * @param targetAddress The address that we are checking for whether the part can be equipped into it or not
-     * @return The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not
+     * @return isEquippable The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not
      */
     function checkIsEquippable(
         uint64 partId,
         address targetAddress
-    ) external view returns (bool);
+    ) external view returns (bool isEquippable);
 
     /**
      * @notice Used to check if the part is equippable by all addresses.
      * @dev Returns true if part is equippable to all.
      * @param partId ID of the part that we are checking
-     * @return The status indicating whether the part with `partId` can be equipped by any address or not
+     * @return isEquippableToAll The status indicating whether the part with `partId` can be equipped by any address or not
      */
-    function checkIsEquippableToAll(uint64 partId) external view returns (bool);
+    function checkIsEquippableToAll(
+        uint64 partId
+    ) external view returns (bool isEquippableToAll);
 
     /**
      * @notice Used to retrieve a `Part` with id `partId`
      * @param partId ID of the part that we are retrieving
-     * @return The `Part` struct associated with given `partId`
+     * @return part The `Part` struct associated with given `partId`
      */
-    function getPart(uint64 partId) external view returns (Part memory);
+    function getPart(uint64 partId) external view returns (Part memory part);
 
     /**
      * @notice Used to retrieve multiple parts at the same time.
      * @param partIds An array of part IDs that we want to retrieve
-     * @return An array of `Part` structs associated with given `partIds`
+     * @return part An array of `Part` structs associated with given `partIds`
      */
     function getParts(
         uint64[] memory partIds
-    ) external view returns (Part[] memory);
+    ) external view returns (Part[] memory part);
 }

--- a/contracts/RMRK/catalog/RMRKCatalog.sol
+++ b/contracts/RMRK/catalog/RMRKCatalog.sol
@@ -220,8 +220,10 @@ contract RMRKCatalog is IRMRKCatalog {
     /**
      * @inheritdoc IRMRKCatalog
      */
-    function checkIsEquippableToAll(uint64 partId) public view returns (bool) {
-        return _isEquippableToAll[partId];
+    function checkIsEquippableToAll(
+        uint64 partId
+    ) public view returns (bool isEquippable) {
+        isEquippable = _isEquippableToAll[partId];
     }
 
     /**
@@ -230,9 +232,9 @@ contract RMRKCatalog is IRMRKCatalog {
     function checkIsEquippable(
         uint64 partId,
         address targetAddress
-    ) public view returns (bool) {
+    ) public view returns (bool isEquippable) {
         // If this is equippable to all, we're good
-        bool isEquippable = _isEquippableToAll[partId];
+        isEquippable = _isEquippableToAll[partId];
 
         // Otherwise, must check against each of the equippable for the part
         if (!isEquippable && _parts[partId].itemType == ItemType.Slot) {
@@ -248,14 +250,13 @@ contract RMRKCatalog is IRMRKCatalog {
                 }
             }
         }
-        return isEquippable;
     }
 
     /**
      * @inheritdoc IRMRKCatalog
      */
-    function getPart(uint64 partId) public view returns (Part memory) {
-        return (_parts[partId]);
+    function getPart(uint64 partId) public view returns (Part memory part) {
+        part = (_parts[partId]);
     }
 
     /**
@@ -263,9 +264,9 @@ contract RMRKCatalog is IRMRKCatalog {
      */
     function getParts(
         uint64[] memory partIds
-    ) public view returns (Part[] memory) {
+    ) public view returns (Part[] memory parts) {
         uint256 numParts = partIds.length;
-        Part[] memory parts = new Part[](numParts);
+        parts = new Part[](numParts);
 
         for (uint256 i; i < numParts; ) {
             uint64 partId = partIds[i];
@@ -274,7 +275,5 @@ contract RMRKCatalog is IRMRKCatalog {
                 ++i;
             }
         }
-
-        return parts;
     }
 }

--- a/contracts/RMRK/catalog/RMRKCatalog.sol
+++ b/contracts/RMRK/catalog/RMRKCatalog.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-import "./IRMRKCatalog.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
+import {IRMRKCatalog, IERC165} from "./IRMRKCatalog.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/emotable/IERC7409.sol
+++ b/contracts/RMRK/emotable/IERC7409.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 interface IERC7409 is IERC165 {
     /**

--- a/contracts/RMRK/emotable/RMRKEmotesRepository.sol
+++ b/contracts/RMRK/emotable/RMRKEmotesRepository.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "./IERC7409.sol";
+import {IERC7409, IERC165} from "./IERC7409.sol";
 
 error BulkParametersOfUnequalLength();
 error ExpiredPresignedEmote();

--- a/contracts/RMRK/equippable/IERC6220.sol
+++ b/contracts/RMRK/equippable/IERC6220.sol
@@ -127,13 +127,13 @@ interface IERC6220 is IERC5773 {
      * @param tokenId ID of the parent token for which we are querying for
      * @param childAddress Address of the child token's smart contract
      * @param childId ID of the child token
-     * @return A boolean value indicating whether the child token is equipped into the given token or not
+     * @return isEquipped A boolean value indicating whether the child token is equipped into the given token or not
      */
     function isChildEquipped(
         uint256 tokenId,
         address childAddress,
         uint256 childId
-    ) external view returns (bool);
+    ) external view returns (bool isEquipped);
 
     /**
      * @notice Used to verify whether a token can be equipped into a given parent's slot.
@@ -141,14 +141,14 @@ interface IERC6220 is IERC5773 {
      * @param tokenId ID of the token we want to equip
      * @param assetId ID of the asset associated with the token we want to equip
      * @param slotId ID of the slot that we want to equip the token into
-     * @return A boolean indicating whether the token with the given asset can be equipped into the desired slot
+     * @return canBeEquipped A boolean indicating whether the token with the given asset can be equipped into the desired slot
      */
     function canTokenBeEquippedWithAssetIntoSlot(
         address parent,
         uint256 tokenId,
         uint64 assetId,
         uint64 slotId
-    ) external view returns (bool);
+    ) external view returns (bool canBeEquipped);
 
     /**
      * @notice Used to get the Equipment object equipped into the specified slot of the desired token.

--- a/contracts/RMRK/equippable/IERC6220.sol
+++ b/contracts/RMRK/equippable/IERC6220.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../multiasset/IERC5773.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
 
 /**
  * @title IERC6220

--- a/contracts/RMRK/equippable/IERC6220.sol
+++ b/contracts/RMRK/equippable/IERC6220.sol
@@ -162,13 +162,13 @@ interface IERC6220 is IERC5773 {
      * @param tokenId ID of the token for which we are retrieving the equipped object
      * @param targetCatalogAddress Address of the `Catalog` associated with the `Slot` part of the token
      * @param slotPartId ID of the `Slot` part that we are checking for equipped objects
-     * @return The `Equipment` struct containing data about the equipped object
+     * @return equipment The `Equipment` struct containing data about the equipped object
      */
     function getEquipment(
         uint256 tokenId,
         address targetCatalogAddress,
         uint64 slotPartId
-    ) external view returns (Equipment memory);
+    ) external view returns (Equipment memory equipment);
 
     /**
      * @notice Used to get the asset and equippable data associated with given `assetId`.

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -229,16 +229,13 @@ contract RMRKEquippable is
     }
 
     /**
-     * @notice Used to get the address of the user that is approved to manage the specified token from the current
-     *  owner.
-     * @param tokenId ID of the token we are checking
-     * @return Address of the account that is approved to manage the token
+     * @inheritdoc IERC5773
      */
     function getApprovedForAssets(
         uint256 tokenId
-    ) public view virtual returns (address) {
+    ) public view virtual returns (address approved) {
         _requireMinted(tokenId);
-        return _tokenApprovalsForAssets[tokenId][ownerOf(tokenId)];
+        approved = _tokenApprovalsForAssets[tokenId][ownerOf(tokenId)];
     }
 
     /**
@@ -460,8 +457,8 @@ contract RMRKEquippable is
         uint256 tokenId,
         address childAddress,
         uint256 childId
-    ) public view virtual returns (bool) {
-        return _equipCountPerChild[tokenId][childAddress][childId] != 0;
+    ) public view virtual returns (bool isEquipped) {
+        isEquipped = _equipCountPerChild[tokenId][childAddress][childId] != 0;
     }
 
     // --------------------- ADMIN VALIDATION ---------------------
@@ -497,14 +494,13 @@ contract RMRKEquippable is
         uint256 tokenId,
         uint64 assetId,
         uint64 slotId
-    ) public view virtual returns (bool) {
+    ) public view virtual returns (bool canBeEquipped) {
         uint64 equippableGroupId = _equippableGroupIds[assetId];
         uint64 equippableSlot = _validParentSlots[equippableGroupId][parent];
         if (equippableSlot == slotId) {
             (, bool found) = getActiveAssets(tokenId).indexOf(assetId);
-            return found;
+            canBeEquipped = found;
         }
-        return false;
     }
 
     // --------------------- Getting Extended Assets ---------------------
@@ -519,14 +515,17 @@ contract RMRKEquippable is
         public
         view
         virtual
-        returns (string memory, uint64, address, uint64[] memory)
+        returns (
+            string memory metadataURI,
+            uint64 equippableGroupId,
+            address catalogAddress,
+            uint64[] memory partIds
+        )
     {
-        return (
-            getAssetMetadata(tokenId, assetId),
-            _equippableGroupIds[assetId],
-            _catalogAddresses[assetId],
-            _partIds[assetId]
-        );
+        metadataURI = getAssetMetadata(tokenId, assetId);
+        equippableGroupId = _equippableGroupIds[assetId];
+        catalogAddress = _catalogAddresses[assetId];
+        partIds = _partIds[assetId];
     }
 
     ////////////////////////////////////////
@@ -540,8 +539,8 @@ contract RMRKEquippable is
         uint256 tokenId,
         address targetCatalogAddress,
         uint64 slotPartId
-    ) public view virtual returns (Equipment memory) {
-        return _equipments[tokenId][targetCatalogAddress][slotPartId];
+    ) public view virtual returns (Equipment memory equipment) {
+        equipment = _equipments[tokenId][targetCatalogAddress][slotPartId];
     }
 
     // HOOKS

--- a/contracts/RMRK/equippable/RMRKEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKEquippable.sol
@@ -4,12 +4,16 @@
 
 pragma solidity ^0.8.21;
 
-import "../catalog/IRMRKCatalog.sol";
-import "../library/RMRKLib.sol";
-import "../multiasset/AbstractMultiAsset.sol";
-import "../nestable/RMRKNestable.sol";
-import "../security/ReentrancyGuard.sol";
-import "./IERC6220.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {IERC6220} from "./IERC6220.sol";
+import {IERC7401} from "../nestable/IERC7401.sol";
+import {IRMRKCatalog} from "../catalog/IRMRKCatalog.sol";
+import {RMRKLib} from "../library/RMRKLib.sol";
+import {AbstractMultiAsset} from "../multiasset/AbstractMultiAsset.sol";
+import {RMRKNestable} from "../nestable/RMRKNestable.sol";
+import {ReentrancyGuard} from "../security/ReentrancyGuard.sol";
+import "../library/RMRKErrors.sol";
 
 /**
  * @title RMRKEquippable

--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -2,18 +2,18 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-
-import "../catalog/IRMRKCatalog.sol";
-import "../core/RMRKCore.sol";
-import "../equippable/IERC6220.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {IERC6220} from "../equippable/IERC6220.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC7401} from "../nestable/IERC7401.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {IRMRKCatalog} from "../catalog/IRMRKCatalog.sol";
+import {RMRKCore} from "../core/RMRKCore.sol";
+import {RMRKLib} from "../library/RMRKLib.sol";
+import {ReentrancyGuard} from "../security/ReentrancyGuard.sol";
 import "../library/RMRKErrors.sol";
-import "../library/RMRKLib.sol";
-import "../nestable/IERC7401.sol";
-import "../security/ReentrancyGuard.sol";
 
 /**
  * @title RMRKMinifiedEquippable

--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -469,7 +469,9 @@ contract RMRKMinifiedEquippable is
         DirectOwner memory owner = _RMRKOwners[tokenId];
         if (owner.ownerAddress == address(0)) revert ERC721InvalidTokenId();
 
-        return (owner.ownerAddress, owner.tokenId, owner.tokenId != 0);
+        owner_ = owner.ownerAddress;
+        parentId = owner.tokenId;
+        isNFT = owner.tokenId != 0;
     }
 
     ////////////////////////////////////////
@@ -563,8 +565,6 @@ contract RMRKMinifiedEquippable is
             tokenId,
             ""
         );
-
-        return burnedChildren;
     }
 
     ////////////////////////////////////////
@@ -694,10 +694,12 @@ contract RMRKMinifiedEquippable is
      * @notice Used to check whether the given token exists.
      * @dev Tokens start existing when they are minted (`_mint`) and stop existing when they are burned (`_burn`).
      * @param tokenId ID of the token being checked
-     * @return A boolean value signifying whether the token exists
+     * @return exists A boolean value signifying whether the token exists
      */
-    function _exists(uint256 tokenId) internal view virtual returns (bool) {
-        return _RMRKOwners[tokenId].ownerAddress != address(0);
+    function _exists(
+        uint256 tokenId
+    ) internal view virtual returns (bool exists) {
+        exists = _RMRKOwners[tokenId].ownerAddress != address(0);
     }
 
     /**
@@ -707,14 +709,14 @@ contract RMRKMinifiedEquippable is
      * @param to Yarget address that will receive the tokens
      * @param tokenId ID of the token to be transferred
      * @param data Optional data to send along with the call
-     * @return Boolean value signifying whether the call correctly returned the expected magic value
+     * @return valid Boolean value signifying whether the call correctly returned the expected magic value
      */
     function _checkOnERC721Received(
         address from,
         address to,
         uint256 tokenId,
         bytes memory data
-    ) private returns (bool) {
+    ) private returns (bool valid) {
         if (to.code.length != 0) {
             try
                 IERC721Receiver(to).onERC721Received(
@@ -724,7 +726,7 @@ contract RMRKMinifiedEquippable is
                     data
                 )
             returns (bytes4 retval) {
-                return retval == IERC721Receiver.onERC721Received.selector;
+                valid = retval == IERC721Receiver.onERC721Received.selector;
             } catch (bytes memory reason) {
                 if (reason.length == uint256(0)) {
                     revert ERC721TransferToNonReceiverImplementer();
@@ -736,7 +738,7 @@ contract RMRKMinifiedEquippable is
                 }
             }
         } else {
-            return true;
+            valid = true;
         }
     }
 

--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -458,7 +458,12 @@ contract RMRKMinifiedEquippable is
      */
     function directOwnerOf(
         uint256 tokenId
-    ) public view virtual returns (address, uint256, bool) {
+    )
+        public
+        view
+        virtual
+        returns (address owner, uint256 parentId, bool isNFT)
+    {
         DirectOwner memory owner = _RMRKOwners[tokenId];
         if (owner.ownerAddress == address(0)) revert ERC721InvalidTokenId();
 

--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -240,7 +240,7 @@ contract RMRKMinifiedEquippable is
 
     /**
      * @notice Used to transfer the token from `from` to `to`.
-     * @dev As opposed to {transferFrom}, this imposes no restrictions on msg.sender.
+     * @dev As opposed to {transferFrom}, this imposes no restrictions on _msgSender()
      * @dev Requirements:
      *
      *  - `to` cannot be the zero address.

--- a/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
+++ b/contracts/RMRK/equippable/RMRKMinifiedEquippable.sol
@@ -240,7 +240,7 @@ contract RMRKMinifiedEquippable is
 
     /**
      * @notice Used to transfer the token from `from` to `to`.
-     * @dev As opposed to {transferFrom}, this imposes no restrictions on _msgSender()
+     * @dev As opposed to {transferFrom}, this imposes no restrictions on msg.sender
      * @dev Requirements:
      *
      *  - `to` cannot be the zero address.

--- a/contracts/RMRK/extension/RMRKRoyalties.sol
+++ b/contracts/RMRK/extension/RMRKRoyalties.sol
@@ -48,18 +48,28 @@ abstract contract RMRKRoyalties {
 
     /**
      * @notice Used to retrieve the recipient of royalties.
-     * @return Address of the recipient of royalties
+     * @return recipient Address of the recipient of royalties
      */
-    function getRoyaltyRecipient() public view virtual returns (address) {
-        return _royaltyRecipient;
+    function getRoyaltyRecipient()
+        public
+        view
+        virtual
+        returns (address recipient)
+    {
+        recipient = _royaltyRecipient;
     }
 
     /**
      * @notice Used to retrieve the specified royalty percentage.
-     * @return The royalty percentage expressed in the basis points
+     * @return royaltyPercentageBps The royalty percentage expressed in the basis points
      */
-    function getRoyaltyPercentage() public view virtual returns (uint256) {
-        return _royaltyPercentageBps;
+    function getRoyaltyPercentage()
+        public
+        view
+        virtual
+        returns (uint256 royaltyPercentageBps)
+    {
+        royaltyPercentageBps = _royaltyPercentageBps;
     }
 
     /**
@@ -74,6 +84,7 @@ abstract contract RMRKRoyalties {
         uint256 tokenId,
         uint256 salePrice
     ) external view virtual returns (address receiver, uint256 royaltyAmount) {
+        // tokenId is ignored as the royalty is the same for all tokens
         receiver = _royaltyRecipient;
         royaltyAmount = (salePrice * _royaltyPercentageBps) / 10000;
     }

--- a/contracts/RMRK/extension/RMRKRoyalties.sol
+++ b/contracts/RMRK/extension/RMRKRoyalties.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../../multiasset/IERC5773.sol";
+import {IERC5773} from "../../multiasset/IERC5773.sol";
 
 /**
  * @title RMRKMultiAssetAutoIndex

--- a/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
+++ b/contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./IRMRKMultiAssetAutoIndex.sol";
-import "../../multiasset/RMRKMultiAsset.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IRMRKMultiAssetAutoIndex} from "./IRMRKMultiAssetAutoIndex.sol";
+import {RMRKMultiAsset} from "../../multiasset/RMRKMultiAsset.sol";
+import {AbstractMultiAsset} from "../../multiasset/AbstractMultiAsset.sol";
 
 /**
  * @title RMRKMultiAssetAutoIndex

--- a/contracts/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.sol
+++ b/contracts/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../../nestable/IERC7401.sol";
+import {IERC7401} from "../../nestable/IERC7401.sol";
 
 /**
  * @title RMRKNestableAutoIndex

--- a/contracts/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.sol
+++ b/contracts/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./IRMRKNestableAutoIndex.sol";
-import "../../nestable/RMRKNestable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC7401} from "../../nestable/IERC7401.sol";
+import {IRMRKNestableAutoIndex} from "./IRMRKNestableAutoIndex.sol";
+import {RMRKNestable} from "../../nestable/RMRKNestable.sol";
 
 /**
  * @title RMRKNestableAutoIndex

--- a/contracts/RMRK/extension/reclaimableChild/IRMRKReclaimableChild.sol
+++ b/contracts/RMRK/extension/reclaimableChild/IRMRKReclaimableChild.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IRMRKReclaimableChild

--- a/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
+++ b/contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol
@@ -2,8 +2,12 @@
 
 pragma solidity ^0.8.21;
 
-import "../../nestable/RMRKNestable.sol";
-import "./IRMRKReclaimableChild.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC7401} from "../../nestable/IERC7401.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {RMRKNestable} from "../../nestable/RMRKNestable.sol";
+import {IRMRKReclaimableChild} from "./IRMRKReclaimableChild.sol";
+import "../../library/RMRKErrors.sol";
 
 /**
  * @title RMRKReclaimableChild

--- a/contracts/RMRK/extension/revealable/IRMRKRevealable.sol
+++ b/contracts/RMRK/extension/revealable/IRMRKRevealable.sol
@@ -7,7 +7,7 @@ interface IRMRKRevealable {
      * @notice Gets the `IRMRKRevealer` associated with the contract.
      * @return revealer The `IRMRKRevealer` associated with the contract
      */
-    function getRevealer() external view returns (address);
+    function getRevealer() external view returns (address revealer);
 
     /**
      * @notice Sets the `IRMRKRevealer` associated with the contract.

--- a/contracts/RMRK/extension/revealable/IRMRKRevealer.sol
+++ b/contracts/RMRK/extension/revealable/IRMRKRevealer.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.21;
 
 interface IRMRKRevealer {
     event Revealed(
-        uint256[] tokenIds,
+        uint256[] indexed tokenIds,
         uint64[] revealedAssetsIds,
         uint64[] assetsToReplaceIds
     );

--- a/contracts/RMRK/extension/revealable/RMRKRevealable.sol
+++ b/contracts/RMRK/extension/revealable/RMRKRevealable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-import "./IRMRKRevealable.sol";
-import "./IRMRKRevealer.sol";
+import {IRMRKRevealable} from "./IRMRKRevealable.sol";
+import {IRMRKRevealer} from "./IRMRKRevealer.sol";
 
 pragma solidity ^0.8.21;
 

--- a/contracts/RMRK/extension/soulbound/IERC6454.sol
+++ b/contracts/RMRK/extension/soulbound/IERC6454.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IERC6454

--- a/contracts/RMRK/extension/soulbound/IERC6454.sol
+++ b/contracts/RMRK/extension/soulbound/IERC6454.sol
@@ -18,11 +18,11 @@ interface IERC6454 is IERC165 {
      * @param tokenId ID of the token being checked
      * @param from Address from which the token is being transferred
      * @param to Address to which the token is being transferred
-     * @return Boolean value indicating whether the given token is transferable
+     * @return isTransferable_ Boolean value indicating whether the given token is transferable
      */
     function isTransferable(
         uint256 tokenId,
         address from,
         address to
-    ) external view returns (bool);
+    ) external view returns (bool isTransferable_);
 }

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -36,8 +36,8 @@ abstract contract RMRKSoulbound is IERC6454 {
         uint256,
         address from,
         address to
-    ) public view virtual returns (bool) {
-        return ((from == address(0) || // Exclude minting
+    ) public view virtual returns (bool isTransferable_) {
+        isTransferable_ = ((from == address(0) || // Exclude minting
             to == address(0)) && from != to); // Exclude Burning // Besides the obvious transfer to self, if both are address 0 (general transferability check), it returns false
     }
 

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../../core/RMRKCore.sol";
-import "./IERC6454.sol";
+import {IERC6454} from "./IERC6454.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKCore} from "../../core/RMRKCore.sol";
 import "../../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulbound.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.21;
 
 import {IERC6454} from "./IERC6454.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import {RMRKCore} from "../../core/RMRKCore.sol";
 import "../../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol
@@ -37,7 +37,7 @@ abstract contract RMRKSoulboundAfterBlockNumber is RMRKSoulbound {
         uint256,
         address,
         address
-    ) public view virtual override returns (bool) {
-        return _lastBlockToTransfer > block.number;
+    ) public view virtual override returns (bool isTransferable_) {
+        isTransferable_ = _lastBlockToTransfer > block.number;
     }
 }

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKSoulbound.sol";
+import {IERC6454} from "./IERC6454.sol";
+import {RMRKSoulbound} from "./RMRKSoulbound.sol";
 
 /**
  * @title RMRKSoulboundAfterBlockNumber

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKSoulbound.sol";
+import {IERC6454} from "./IERC6454.sol";
+import {RMRKSoulbound} from "./RMRKSoulbound.sol";
 
 /**
  * @title RMRKSoulboundAfterTransactions

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol
@@ -47,6 +47,7 @@ abstract contract RMRKSoulboundAfterTransactions is RMRKSoulbound {
         address to,
         uint256 tokenId
     ) internal virtual {
+        // to
         // We won't count minting:
         if (from != address(0)) {
             _transfersPerToken[tokenId]++;
@@ -80,7 +81,7 @@ abstract contract RMRKSoulboundAfterTransactions is RMRKSoulbound {
         uint256 tokenId,
         address,
         address
-    ) public view virtual override returns (bool) {
-        return _transfersPerToken[tokenId] < _maxNumberOfTransfers;
+    ) public view virtual override returns (bool isTransferable_) {
+        isTransferable_ = _transfersPerToken[tokenId] < _maxNumberOfTransfers;
     }
 }

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundPerToken.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundPerToken.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKSoulbound.sol";
+import {IERC6454} from "./IERC6454.sol";
+import {RMRKSoulbound} from "./RMRKSoulbound.sol";
 
 /**
  * @title RMRKSoulboundPerToken

--- a/contracts/RMRK/extension/soulbound/RMRKSoulboundPerToken.sol
+++ b/contracts/RMRK/extension/soulbound/RMRKSoulboundPerToken.sol
@@ -39,8 +39,8 @@ abstract contract RMRKSoulboundPerToken is RMRKSoulbound {
         uint256 tokenId,
         address from,
         address to
-    ) public view virtual override returns (bool) {
-        return (from == address(0) || // Exclude minting
+    ) public view virtual override returns (bool isTransferable_) {
+        isTransferable_ = (from == address(0) || // Exclude minting
             to == address(0) || // Exclude Burning
             !_isSoulbound[tokenId]);
     }

--- a/contracts/RMRK/extension/tokenAttributes/IERC7508.sol
+++ b/contracts/RMRK/extension/tokenAttributes/IERC7508.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IERC7508

--- a/contracts/RMRK/extension/tokenAttributes/IERC7508.sol
+++ b/contracts/RMRK/extension/tokenAttributes/IERC7508.sol
@@ -560,13 +560,13 @@ interface IERC7508 is IERC165 {
      * @notice Used to check if the specified address is listed as a collaborator of the given collection's parameter.
      * @param collaborator Address to be checked.
      * @param collection Address of the collection.
-     * @return Boolean value indicating if the address is a collaborator of the given collection's (`true`) or not
+     * @return isCollaborator_ Boolean value indicating if the address is a collaborator of the given collection's (`true`) or not
      *  (`false`).
      */
     function isCollaborator(
         address collaborator,
         address collection
-    ) external view returns (bool);
+    ) external view returns (bool isCollaborator_);
 
     /**
      * @notice Used to check if the specified address is listed as a specific address of the given collection's
@@ -574,79 +574,79 @@ interface IERC7508 is IERC165 {
      * @param specificAddress Address to be checked.
      * @param collection Address of the collection.
      * @param key The key of the attribute
-     * @return Boolean value indicating if the address is a specific address of the given collection's parameter
+     * @return isSpecificAddress_ Boolean value indicating if the address is a specific address of the given collection's parameter
      *  (`true`) or not (`false`).
      */
     function isSpecificAddress(
         address specificAddress,
         address collection,
         string memory key
-    ) external view returns (bool);
+    ) external view returns (bool isSpecificAddress_);
 
     /**
      * @notice Used to retrieve the string type token attributes.
      * @param collection The collection address
      * @param tokenId The token ID
      * @param key The key of the attribute
-     * @return The value of the string attribute
+     * @return attribute The value of the string attribute
      */
     function getStringAttribute(
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (string memory);
+    ) external view returns (string memory attribute);
 
     /**
      * @notice Used to retrieve the uint type token attributes.
      * @param collection The collection address
      * @param tokenId The token ID
      * @param key The key of the attribute
-     * @return The value of the uint attribute
+     * @return attribute The value of the uint attribute
      */
     function getUintAttribute(
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (uint256);
+    ) external view returns (uint256 attribute);
 
     /**
      * @notice Used to retrieve the bool type token attributes.
      * @param collection The collection address
      * @param tokenId The token ID
      * @param key The key of the attribute
-     * @return The value of the bool attribute
+     * @return attribute The value of the bool attribute
      */
     function getBoolAttribute(
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (bool);
+    ) external view returns (bool attribute);
 
     /**
      * @notice Used to retrieve the address type token attributes.
      * @param collection The collection address
      * @param tokenId The token ID
      * @param key The key of the attribute
-     * @return The value of the address attribute
+     * @return attribute The value of the address attribute
      */
     function getAddressAttribute(
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (address);
+    ) external view returns (address attribute);
 
     /**
      * @notice Used to retrieve the bytes type token attributes.
      * @param collection The collection address
      * @param tokenId The token ID
      * @param key The key of the attribute
-     * @return The value of the bytes attribute
+     * @return attribute The value of the bytes attribute
      */
     function getBytesAttribute(
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (bytes memory);
+    ) external view returns (bytes memory attribute);
 
     /**
      * @notice Used to retrieve the message to be signed for submitting a presigned uint attribute change.
@@ -655,7 +655,7 @@ interface IERC7508 is IERC165 {
      * @param key The attribute key
      * @param value The attribute value
      * @param deadline The deadline timestamp for the presigned transaction after which the message is invalid
-     * @return Raw message to be signed by the authorized account
+     * @return message Raw message to be signed by the authorized account
      */
     function prepareMessageToPresignUintAttribute(
         address collection,
@@ -663,7 +663,7 @@ interface IERC7508 is IERC165 {
         string memory key,
         uint256 value,
         uint256 deadline
-    ) external view returns (bytes32);
+    ) external view returns (bytes32 message);
 
     /**
      * @notice Used to retrieve the message to be signed for submitting a presigned string attribute change.
@@ -672,7 +672,7 @@ interface IERC7508 is IERC165 {
      * @param key The attribute key
      * @param value The attribute value
      * @param deadline The deadline timestamp for the presigned transaction after which the message is invalid
-     * @return Raw message to be signed by the authorized account
+     * @return message Raw message to be signed by the authorized account
      */
     function prepareMessageToPresignStringAttribute(
         address collection,
@@ -680,7 +680,7 @@ interface IERC7508 is IERC165 {
         string memory key,
         string memory value,
         uint256 deadline
-    ) external view returns (bytes32);
+    ) external view returns (bytes32 message);
 
     /**
      * @notice Used to retrieve the message to be signed for submitting a presigned bool attribute change.
@@ -689,7 +689,7 @@ interface IERC7508 is IERC165 {
      * @param key The attribute key
      * @param value The attribute value
      * @param deadline The deadline timestamp for the presigned transaction after which the message is invalid
-     * @return Raw message to be signed by the authorized account
+     * @return message Raw message to be signed by the authorized account
      */
     function prepareMessageToPresignBoolAttribute(
         address collection,
@@ -697,7 +697,7 @@ interface IERC7508 is IERC165 {
         string memory key,
         bool value,
         uint256 deadline
-    ) external view returns (bytes32);
+    ) external view returns (bytes32 message);
 
     /**
      * @notice Used to retrieve the message to be signed for submitting a presigned bytes attribute change.
@@ -706,7 +706,7 @@ interface IERC7508 is IERC165 {
      * @param key The attribute key
      * @param value The attribute value
      * @param deadline The deadline timestamp for the presigned transaction after which the message is invalid
-     * @return Raw message to be signed by the authorized account
+     * @return message Raw message to be signed by the authorized account
      */
     function prepareMessageToPresignBytesAttribute(
         address collection,
@@ -714,7 +714,7 @@ interface IERC7508 is IERC165 {
         string memory key,
         bytes memory value,
         uint256 deadline
-    ) external view returns (bytes32);
+    ) external view returns (bytes32 message);
 
     /**
      * @notice Used to retrieve the message to be signed for submitting a presigned address attribute change.
@@ -723,7 +723,7 @@ interface IERC7508 is IERC165 {
      * @param key The attribute key
      * @param value The attribute value
      * @param deadline The deadline timestamp for the presigned transaction after which the message is invalid
-     * @return Raw message to be signed by the authorized account
+     * @return message Raw message to be signed by the authorized account
      */
     function prepareMessageToPresignAddressAttribute(
         address collection,
@@ -731,7 +731,7 @@ interface IERC7508 is IERC165 {
         string memory key,
         address value,
         uint256 deadline
-    ) external view returns (bytes32);
+    ) external view returns (bytes32 message);
 
     /**
      * @notice Used to retrieve multiple token attributes of any type at once.
@@ -783,13 +783,13 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection the token belongs to
      * @param tokenId ID of the token for which the attributes are being retrieved
      * @param stringKeys An array of string keys to retrieve
-     * @return An array of `StringAttribute` structs
+     * @return attributes An array of `StringAttribute` structs
      */
     function getStringAttributes(
         address collection,
         uint256 tokenId,
         string[] memory stringKeys
-    ) external view returns (StringAttribute[] memory);
+    ) external view returns (StringAttribute[] memory attributes);
 
     /**
      * @notice Used to get multiple uint parameter values for a token.
@@ -801,13 +801,13 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection the token belongs to
      * @param tokenId ID of the token for which the attributes are being retrieved
      * @param uintKeys An array of uint keys to retrieve
-     * @return An array of `UintAttribute` structs
+     * @return attributes An array of `UintAttribute` structs
      */
     function getUintAttributes(
         address collection,
         uint256 tokenId,
         string[] memory uintKeys
-    ) external view returns (UintAttribute[] memory);
+    ) external view returns (UintAttribute[] memory attributes);
 
     /**
      * @notice Used to get multiple bool parameter values for a token.
@@ -819,13 +819,13 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection the token belongs to
      * @param tokenId ID of the token for which the attributes are being retrieved
      * @param boolKeys An array of bool keys to retrieve
-     * @return An array of `BoolAttribute` structs
+     * @return attributes An array of `BoolAttribute` structs
      */
     function getBoolAttributes(
         address collection,
         uint256 tokenId,
         string[] memory boolKeys
-    ) external view returns (BoolAttribute[] memory);
+    ) external view returns (BoolAttribute[] memory attributes);
 
     /**
      * @notice Used to get multiple address parameter values for a token.
@@ -837,13 +837,13 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection the token belongs to
      * @param tokenId ID of the token for which the attributes are being retrieved
      * @param addressKeys An array of address keys to retrieve
-     * @return An array of `AddressAttribute` structs
+     * @return attributes An array of `AddressAttribute` structs
      */
     function getAddressAttributes(
         address collection,
         uint256 tokenId,
         string[] memory addressKeys
-    ) external view returns (AddressAttribute[] memory);
+    ) external view returns (AddressAttribute[] memory attributes);
 
     /**
      * @notice Used to get multiple bytes parameter values for a token.
@@ -855,11 +855,11 @@ interface IERC7508 is IERC165 {
      * @param collection Address of the collection the token belongs to
      * @param tokenId ID of the token for which the attributes are being retrieved
      * @param bytesKeys An array of bytes keys to retrieve
-     * @return An array of `BytesAttribute` structs
+     * @return attributes An array of `BytesAttribute` structs
      */
     function getBytesAttributes(
         address collection,
         uint256 tokenId,
         string[] memory bytesKeys
-    ) external view returns (BytesAttribute[] memory);
+    ) external view returns (BytesAttribute[] memory attributes);
 }

--- a/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
+++ b/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
@@ -188,8 +188,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
     function isCollaborator(
         address collaborator,
         address collection
-    ) external view returns (bool) {
-        return _collaborators[collection][collaborator];
+    ) external view returns (bool isCollaborator_) {
+        isCollaborator_ = _collaborators[collection][collaborator];
     }
 
     /**
@@ -199,8 +199,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address specificAddress,
         address collection,
         string memory key
-    ) external view returns (bool) {
-        return
+    ) external view returns (bool isSpecificAddress_) {
+        isSpecificAddress_ =
             _parameterSpecificAddress[collection][_keysToIds[key]] ==
             specificAddress;
     }
@@ -319,11 +319,11 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (string memory) {
+    ) external view returns (string memory attribute) {
         uint256 idForValue = _stringValueIds[collection][tokenId][
             _keysToIds[key]
         ];
-        return _stringIdToValue[collection][idForValue];
+        attribute = _stringIdToValue[collection][idForValue];
     }
 
     /**
@@ -333,8 +333,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (uint256) {
-        return _uintValues[collection][tokenId][_keysToIds[key]];
+    ) external view returns (uint256 attribute) {
+        attribute = _uintValues[collection][tokenId][_keysToIds[key]];
     }
 
     /**
@@ -344,8 +344,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (bool) {
-        return _boolValues[collection][tokenId][_keysToIds[key]];
+    ) external view returns (bool attribute) {
+        attribute = _boolValues[collection][tokenId][_keysToIds[key]];
     }
 
     /**
@@ -355,8 +355,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (address) {
-        return _addressValues[collection][tokenId][_keysToIds[key]];
+    ) external view returns (address attribute) {
+        attribute = _addressValues[collection][tokenId][_keysToIds[key]];
     }
 
     /**
@@ -366,8 +366,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string memory key
-    ) external view returns (bytes memory) {
-        return _bytesValues[collection][tokenId][_keysToIds[key]];
+    ) external view returns (bytes memory attribute) {
+        attribute = _bytesValues[collection][tokenId][_keysToIds[key]];
     }
 
     /**
@@ -414,15 +414,13 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string[] memory stringKeys
-    ) public view returns (StringAttribute[] memory) {
+    ) public view returns (StringAttribute[] memory attributes) {
         uint256 stringLen = stringKeys.length;
 
-        StringAttribute[] memory stringAttributes = new StringAttribute[](
-            stringLen
-        );
+        attributes = new StringAttribute[](stringLen);
 
         for (uint i; i < stringLen; ) {
-            stringAttributes[i] = StringAttribute({
+            attributes[i] = StringAttribute({
                 key: stringKeys[i],
                 value: _stringIdToValue[collection][
                     _stringValueIds[collection][tokenId][
@@ -434,8 +432,6 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
                 ++i;
             }
         }
-
-        return stringAttributes;
     }
 
     /**
@@ -445,13 +441,13 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string[] memory uintKeys
-    ) public view returns (UintAttribute[] memory) {
+    ) public view returns (UintAttribute[] memory attributes) {
         uint256 uintLen = uintKeys.length;
 
-        UintAttribute[] memory uintAttributes = new UintAttribute[](uintLen);
+        attributes = new UintAttribute[](uintLen);
 
         for (uint i; i < uintLen; ) {
-            uintAttributes[i] = UintAttribute({
+            attributes[i] = UintAttribute({
                 key: uintKeys[i],
                 value: _uintValues[collection][tokenId][_keysToIds[uintKeys[i]]]
             });
@@ -459,8 +455,6 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
                 ++i;
             }
         }
-
-        return uintAttributes;
     }
 
     /**
@@ -470,13 +464,13 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string[] memory boolKeys
-    ) public view returns (BoolAttribute[] memory) {
+    ) public view returns (BoolAttribute[] memory attributes) {
         uint256 boolLen = boolKeys.length;
 
-        BoolAttribute[] memory boolAttributes = new BoolAttribute[](boolLen);
+        attributes = new BoolAttribute[](boolLen);
 
         for (uint i; i < boolLen; ) {
-            boolAttributes[i] = BoolAttribute({
+            attributes[i] = BoolAttribute({
                 key: boolKeys[i],
                 value: _boolValues[collection][tokenId][_keysToIds[boolKeys[i]]]
             });
@@ -484,8 +478,6 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
                 ++i;
             }
         }
-
-        return boolAttributes;
     }
 
     /**
@@ -495,15 +487,12 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string[] memory addressKeys
-    ) public view returns (AddressAttribute[] memory) {
+    ) public view returns (AddressAttribute[] memory attributes) {
         uint256 addressLen = addressKeys.length;
-
-        AddressAttribute[] memory addressAttributes = new AddressAttribute[](
-            addressLen
-        );
+        attributes = new AddressAttribute[](addressLen);
 
         for (uint i; i < addressLen; ) {
-            addressAttributes[i] = AddressAttribute({
+            attributes[i] = AddressAttribute({
                 key: addressKeys[i],
                 value: _addressValues[collection][tokenId][
                     _keysToIds[addressKeys[i]]
@@ -513,8 +502,6 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
                 ++i;
             }
         }
-
-        return addressAttributes;
     }
 
     /**
@@ -524,15 +511,12 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address collection,
         uint256 tokenId,
         string[] memory bytesKeys
-    ) public view returns (BytesAttribute[] memory) {
+    ) public view returns (BytesAttribute[] memory attributes) {
         uint256 bytesLen = bytesKeys.length;
-
-        BytesAttribute[] memory bytesAttributes = new BytesAttribute[](
-            bytesLen
-        );
+        attributes = new BytesAttribute[](bytesLen);
 
         for (uint i; i < bytesLen; ) {
-            bytesAttributes[i] = BytesAttribute({
+            attributes[i] = BytesAttribute({
                 key: bytesKeys[i],
                 value: _bytesValues[collection][tokenId][
                     _keysToIds[bytesKeys[i]]
@@ -542,8 +526,6 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
                 ++i;
             }
         }
-
-        return bytesAttributes;
     }
 
     /**
@@ -555,19 +537,18 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         string memory key,
         uint256 value,
         uint256 deadline
-    ) public view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    DOMAIN_SEPARATOR,
-                    SET_UINT_ATTRIBUTE_TYPEHASH,
-                    collection,
-                    tokenId,
-                    key,
-                    value,
-                    deadline
-                )
-            );
+    ) public view returns (bytes32 message) {
+        message = keccak256(
+            abi.encode(
+                DOMAIN_SEPARATOR,
+                SET_UINT_ATTRIBUTE_TYPEHASH,
+                collection,
+                tokenId,
+                key,
+                value,
+                deadline
+            )
+        );
     }
 
     /**
@@ -579,19 +560,18 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         string memory key,
         string memory value,
         uint256 deadline
-    ) public view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    DOMAIN_SEPARATOR,
-                    SET_STRING_ATTRIBUTE_TYPEHASH,
-                    collection,
-                    tokenId,
-                    key,
-                    value,
-                    deadline
-                )
-            );
+    ) public view returns (bytes32 message) {
+        message = keccak256(
+            abi.encode(
+                DOMAIN_SEPARATOR,
+                SET_STRING_ATTRIBUTE_TYPEHASH,
+                collection,
+                tokenId,
+                key,
+                value,
+                deadline
+            )
+        );
     }
 
     /**
@@ -603,19 +583,18 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         string memory key,
         bool value,
         uint256 deadline
-    ) public view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    DOMAIN_SEPARATOR,
-                    SET_BOOL_ATTRIBUTE_TYPEHASH,
-                    collection,
-                    tokenId,
-                    key,
-                    value,
-                    deadline
-                )
-            );
+    ) public view returns (bytes32 message) {
+        message = keccak256(
+            abi.encode(
+                DOMAIN_SEPARATOR,
+                SET_BOOL_ATTRIBUTE_TYPEHASH,
+                collection,
+                tokenId,
+                key,
+                value,
+                deadline
+            )
+        );
     }
 
     /**
@@ -627,19 +606,18 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         string memory key,
         bytes memory value,
         uint256 deadline
-    ) public view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    DOMAIN_SEPARATOR,
-                    SET_BYTES_ATTRIBUTE_TYPEHASH,
-                    collection,
-                    tokenId,
-                    key,
-                    value,
-                    deadline
-                )
-            );
+    ) public view returns (bytes32 message) {
+        message = keccak256(
+            abi.encode(
+                DOMAIN_SEPARATOR,
+                SET_BYTES_ATTRIBUTE_TYPEHASH,
+                collection,
+                tokenId,
+                key,
+                value,
+                deadline
+            )
+        );
     }
 
     /**
@@ -651,19 +629,18 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         string memory key,
         address value,
         uint256 deadline
-    ) public view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    DOMAIN_SEPARATOR,
-                    SET_ADDRESS_ATTRIBUTE_TYPEHASH,
-                    collection,
-                    tokenId,
-                    key,
-                    value,
-                    deadline
-                )
-            );
+    ) public view returns (bytes32 message) {
+        message = keccak256(
+            abi.encode(
+                DOMAIN_SEPARATOR,
+                SET_ADDRESS_ATTRIBUTE_TYPEHASH,
+                collection,
+                tokenId,
+                key,
+                value,
+                deadline
+            )
+        );
     }
 
     /**

--- a/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
+++ b/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
@@ -419,7 +419,7 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
 
         attributes = new StringAttribute[](stringLen);
 
-        for (uint i; i < stringLen; ) {
+        for (uint256 i; i < stringLen; ) {
             attributes[i] = StringAttribute({
                 key: stringKeys[i],
                 value: _stringIdToValue[collection][
@@ -446,7 +446,7 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
 
         attributes = new UintAttribute[](uintLen);
 
-        for (uint i; i < uintLen; ) {
+        for (uint256 i; i < uintLen; ) {
             attributes[i] = UintAttribute({
                 key: uintKeys[i],
                 value: _uintValues[collection][tokenId][_keysToIds[uintKeys[i]]]
@@ -469,7 +469,7 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
 
         attributes = new BoolAttribute[](boolLen);
 
-        for (uint i; i < boolLen; ) {
+        for (uint256 i; i < boolLen; ) {
             attributes[i] = BoolAttribute({
                 key: boolKeys[i],
                 value: _boolValues[collection][tokenId][_keysToIds[boolKeys[i]]]
@@ -491,7 +491,7 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         uint256 addressLen = addressKeys.length;
         attributes = new AddressAttribute[](addressLen);
 
-        for (uint i; i < addressLen; ) {
+        for (uint256 i; i < addressLen; ) {
             attributes[i] = AddressAttribute({
                 key: addressKeys[i],
                 value: _addressValues[collection][tokenId][
@@ -515,7 +515,7 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         uint256 bytesLen = bytesKeys.length;
         attributes = new BytesAttribute[](bytesLen);
 
-        for (uint i; i < bytesLen; ) {
+        for (uint256 i; i < bytesLen; ) {
             attributes[i] = BytesAttribute({
                 key: bytesKeys[i],
                 value: _bytesValues[collection][tokenId][
@@ -1155,15 +1155,15 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
      *  IDs are shared among all tokens and types
      * @dev The ID of 0 is not used as it represents the default value.
      * @param key The attribute key
-     * @return The ID of the key
+     * @return keyID The ID of the key
      */
-    function _getIdForKey(string memory key) internal returns (uint256) {
+    function _getIdForKey(string memory key) internal returns (uint256 keyID) {
         if (_keysToIds[key] == 0) {
             _totalAttributes++;
             _keysToIds[key] = _totalAttributes;
-            return _totalAttributes;
+            keyID = _totalAttributes;
         } else {
-            return _keysToIds[key];
+            keyID = _keysToIds[key];
         }
     }
 
@@ -1172,12 +1172,12 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
      * @dev IDs are shared among all tokens and used only for strings.
      * @param collection Address of the collection being checked for string ID
      * @param value The attribute value
-     * @return The id for the string value
+     * @return stringId The id for the string value
      */
     function _getStringIdForValue(
         address collection,
         string memory value
-    ) internal returns (uint256) {
+    ) internal returns (uint256 stringId) {
         if (_stringValueToId[collection][value] == 0) {
             _totalStringValues[collection]++;
             _stringValueToId[collection][value] = _totalStringValues[
@@ -1186,9 +1186,9 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
             _stringIdToValue[collection][
                 _totalStringValues[collection]
             ] = value;
-            return _totalStringValues[collection];
+            stringId = _totalStringValues[collection];
         } else {
-            return _stringValueToId[collection][value];
+            stringId = _stringValueToId[collection][value];
         }
     }
 

--- a/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
+++ b/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
@@ -2,13 +2,13 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 
 import "../../library/RMRKErrors.sol";
-import "./IERC7508.sol";
+import {IERC7508} from "./IERC7508.sol";
 
 /**
  * @title RMRKTokenAttributesRepository

--- a/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
+++ b/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.21;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 
 import "../../library/RMRKErrors.sol";
 import "./IERC7508.sol";
@@ -14,7 +15,7 @@ import "./IERC7508.sol";
  * @author RMRK team
  * @notice Smart contract of the RMRK Token property repository module.
  */
-contract RMRKTokenAttributesRepository is IERC7508 {
+contract RMRKTokenAttributesRepository is IERC7508, Context {
     bytes32 public immutable DOMAIN_SEPARATOR =
         keccak256(
             abi.encode(
@@ -121,7 +122,7 @@ contract RMRKTokenAttributesRepository is IERC7508 {
         }
         if (
             ownableSuccess &&
-            address(uint160(uint256(bytes32(ownableReturn)))) != msg.sender
+            address(uint160(uint256(bytes32(ownableReturn)))) != _msgSender()
         ) {
             revert NotCollectionIssuer();
         }
@@ -134,7 +135,7 @@ contract RMRKTokenAttributesRepository is IERC7508 {
         emit AccessControlRegistration(
             collection,
             issuer,
-            msg.sender,
+            _msgSender(),
             useOwnable
         );
     }
@@ -220,7 +221,7 @@ contract RMRKTokenAttributesRepository is IERC7508 {
         string memory key,
         uint256 tokenId
     ) {
-        _onlyAuthorizedCaller(msg.sender, collection, key, tokenId);
+        _onlyAuthorizedCaller(_msgSender(), collection, key, tokenId);
         _;
     }
 
@@ -252,10 +253,10 @@ contract RMRKTokenAttributesRepository is IERC7508 {
      */
     modifier onlyIssuer(address collection) {
         if (_issuerSettings[collection].useOwnable) {
-            if (Ownable(collection).owner() != msg.sender) {
+            if (Ownable(collection).owner() != _msgSender()) {
                 revert NotCollectionIssuer();
             }
-        } else if (_issuerSettings[collection].issuer != msg.sender) {
+        } else if (_issuerSettings[collection].issuer != _msgSender()) {
             revert NotCollectionIssuer();
         }
         _;

--- a/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
+++ b/contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol
@@ -6,8 +6,6 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
-
-import "../../library/RMRKErrors.sol";
 import {IERC7508} from "./IERC7508.sol";
 
 /**
@@ -165,10 +163,11 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         address[] memory collaboratorAddresses,
         bool[] memory collaboratorAddressAccess
     ) external onlyRegisteredCollection(collection) onlyIssuer(collection) {
-        if (collaboratorAddresses.length != collaboratorAddressAccess.length) {
+        uint256 length = collaboratorAddresses.length;
+        if (length != collaboratorAddressAccess.length) {
             revert CollaboratorArraysNotEqualLength();
         }
-        for (uint256 i; i < collaboratorAddresses.length; ) {
+        for (uint256 i; i < length; ) {
             _collaborators[collection][
                 collaboratorAddresses[i]
             ] = collaboratorAddressAccess[i];
@@ -742,7 +741,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         uint256 tokenId,
         StringAttribute[] memory attributes
     ) external onlyAuthorizedCaller(collection, "", tokenId) {
-        for (uint256 i = 0; i < attributes.length; ) {
+        uint256 length = attributes.length;
+        for (uint256 i = 0; i < length; ) {
             _stringValueIds[collection][tokenId][
                 _getIdForKey(attributes[i].key)
             ] = _getStringIdForValue(collection, attributes[i].value);
@@ -766,7 +766,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         uint256 tokenId,
         UintAttribute[] memory attributes
     ) external onlyAuthorizedCaller(collection, "", tokenId) {
-        for (uint256 i = 0; i < attributes.length; ) {
+        uint256 length = attributes.length;
+        for (uint256 i = 0; i < length; ) {
             _uintValues[collection][tokenId][
                 _getIdForKey(attributes[i].key)
             ] = attributes[i].value;
@@ -790,7 +791,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         uint256 tokenId,
         BoolAttribute[] memory attributes
     ) external onlyAuthorizedCaller(collection, "", tokenId) {
-        for (uint256 i = 0; i < attributes.length; ) {
+        uint256 length = attributes.length;
+        for (uint256 i = 0; i < length; ) {
             _boolValues[collection][tokenId][
                 _getIdForKey(attributes[i].key)
             ] = attributes[i].value;
@@ -814,7 +816,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         uint256 tokenId,
         AddressAttribute[] memory attributes
     ) external onlyAuthorizedCaller(collection, "", tokenId) {
-        for (uint256 i = 0; i < attributes.length; ) {
+        uint256 length = attributes.length;
+        for (uint256 i = 0; i < length; ) {
             _addressValues[collection][tokenId][
                 _getIdForKey(attributes[i].key)
             ] = attributes[i].value;
@@ -838,7 +841,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         uint256 tokenId,
         BytesAttribute[] memory attributes
     ) external onlyAuthorizedCaller(collection, "", tokenId) {
-        for (uint256 i = 0; i < attributes.length; ) {
+        uint256 length = attributes.length;
+        for (uint256 i = 0; i < length; ) {
             _bytesValues[collection][tokenId][
                 _getIdForKey(attributes[i].key)
             ] = attributes[i].value;
@@ -866,7 +870,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
         AddressAttribute[] memory addressAttributes,
         BytesAttribute[] memory bytesAttributes
     ) external onlyAuthorizedCaller(collection, "", tokenId) {
-        for (uint256 i = 0; i < stringAttributes.length; ) {
+        uint256 length = stringAttributes.length;
+        for (uint256 i = 0; i < length; ) {
             _stringValueIds[collection][tokenId][
                 _getIdForKey(stringAttributes[i].key)
             ] = _getStringIdForValue(collection, stringAttributes[i].value);
@@ -881,7 +886,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
             }
         }
 
-        for (uint256 i = 0; i < uintAttributes.length; ) {
+        length = uintAttributes.length;
+        for (uint256 i = 0; i < length; ) {
             _uintValues[collection][tokenId][
                 _getIdForKey(uintAttributes[i].key)
             ] = uintAttributes[i].value;
@@ -896,7 +902,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
             }
         }
 
-        for (uint256 i = 0; i < boolAttributes.length; ) {
+        length = boolAttributes.length;
+        for (uint256 i = 0; i < length; ) {
             _boolValues[collection][tokenId][
                 _getIdForKey(boolAttributes[i].key)
             ] = boolAttributes[i].value;
@@ -911,7 +918,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
             }
         }
 
-        for (uint256 i = 0; i < addressAttributes.length; ) {
+        length = addressAttributes.length;
+        for (uint256 i = 0; i < length; ) {
             _addressValues[collection][tokenId][
                 _getIdForKey(addressAttributes[i].key)
             ] = addressAttributes[i].value;
@@ -926,7 +934,8 @@ contract RMRKTokenAttributesRepository is IERC7508, Context {
             }
         }
 
-        for (uint256 i = 0; i < bytesAttributes.length; ) {
+        length = bytesAttributes.length;
+        for (uint256 i = 0; i < length; ) {
             _bytesValues[collection][tokenId][
                 _getIdForKey(bytesAttributes[i].key)
             ] = bytesAttributes[i].value;

--- a/contracts/RMRK/extension/tokenHolder/IRMRKTokenHolder.sol
+++ b/contracts/RMRK/extension/tokenHolder/IRMRKTokenHolder.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IRMRKTokenHolder

--- a/contracts/RMRK/extension/tokenHolder/RMRKTokenHolder.sol
+++ b/contracts/RMRK/extension/tokenHolder/RMRKTokenHolder.sol
@@ -2,12 +2,12 @@
 
 pragma solidity ^0.8.21;
 
-import "./IRMRKTokenHolder.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {IRMRKTokenHolder} from "./IRMRKTokenHolder.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
 error InvalidValue();
 error InvalidAddress();

--- a/contracts/RMRK/extension/typedMultiAsset/IRMRKTypedMultiAsset.sol
+++ b/contracts/RMRK/extension/typedMultiAsset/IRMRKTypedMultiAsset.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-// import "../../multiasset/IERC5773.sol";
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+// import {IERC5773} from "../../multiasset/IERC5773.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IRMRKTypedMultiAsset

--- a/contracts/RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol
+++ b/contracts/RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-import "./IRMRKTypedMultiAsset.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IRMRKTypedMultiAsset} from "./IRMRKTypedMultiAsset.sol";
 
 /**
  * @title RMRKTypedMultiAsset

--- a/contracts/RMRK/library/RMRKErrors.sol
+++ b/contracts/RMRK/library/RMRKErrors.sol
@@ -14,8 +14,6 @@ error ERC721AddressZeroIsNotaValidOwner();
 error ERC721ApprovalToCurrentOwner();
 /// Attempting to grant approval when not being owner or approved for all should not be permitted
 error ERC721ApproveCallerIsNotOwnerNorApprovedForAll();
-/// Attempting to get approvals for a token owned by 0x0 (considered non-existent)
-error ERC721ApprovedQueryForNonexistentToken();
 /// Attempting to grant approval to self
 error ERC721ApproveToCaller();
 /// Attempting to use an invalid token ID
@@ -50,16 +48,8 @@ error RMRKChildAlreadyExists();
 error RMRKChildIndexOutOfRange();
 /// Attempting to find the index of a child token on a parent which does not own it.
 error RMRKChildNotFoundInParent();
-/// Attempting to pass collaborator address array and collaborator permission array of different lengths
-error RMRKCollaboratorArraysNotEqualLength();
-/// Attempting to register a collection that is already registered
-error RMRKCollectionAlreadyRegistered();
-/// Attempting to manage or interact with colleciton that is not registered
-error RMRKCollectionNotRegistered();
 /// Attempting to equip a `Part` with a child not approved by the Catalog
 error RMRKEquippableEquipNotAllowedByCatalog();
-/// Attempting to pass an epired ECDSA deadline
-error RMRKExpiredDeadline();
 /// Attempting to use ID 0, which is not supported
 /// @dev The ID 0 in RMRK suite is reserved for empty values. Guarding against its use ensures the expected operation
 error RMRKIdZeroForbidden();
@@ -67,8 +57,6 @@ error RMRKIdZeroForbidden();
 error RMRKIndexOutOfRange();
 /// Attempting to reclaim a child that can't be reclaimed
 error RMRKInvalidChildReclaim();
-/// Attempting to use and invalid ECDSA signature
-error RMRKInvalidSignature();
 /// Attempting to interact with an end-user account when the contract account is expected
 error RMRKIsNotContract();
 /// Attempting to interact with a contract that had its operation locked
@@ -107,12 +95,6 @@ error RMRKNotApprovedForAssetsOrOwner();
 /// @dev When a token is nested, only the direct owner (NFT parent) can mange it. In that case, approved addresses are
 ///  not allowed to manage it, in order to ensure the expected behaviour
 error RMRKNotApprovedOrDirectOwner();
-/// Attempting to manage a collection without being the collection's collaborator
-error RMRKNotCollectionCollaborator();
-/// Attemting to manage a collection without being the collection's issuer
-error RMRKNotCollectionIssuer();
-/// Attempting to manage a collection without being the collection's issuer or collaborator
-error RMRKNotCollectionIssuerOrCollaborator();
 /// Attempting to compose an asset wihtout having an associated Catalog
 error RMRKNotComposableAsset();
 /// Attempting to unequip an item that isn't equipped
@@ -121,16 +103,10 @@ error RMRKNotEquipped();
 error RMRKNotOwner();
 /// Attempting to interact with a function without being the owner or contributor of the collection
 error RMRKNotOwnerOrContributor();
-/// Attempting to manage a collection without being the specific address
-error RMRKNotSpecificAddress();
-/// Attempting to manage a token without being its owner
-error RMRKNotTokenOwner();
 /// Attempting to transfer the ownership to the 0x0 address
 error RMRKNewOwnerIsZeroAddress();
 /// Attempting to assign a 0x0 address as a contributor
 error RMRKNewContributorIsZeroAddress();
-/// Attemtping to use `Ownable` interface without implementing it
-error RMRKOwnableNotImplemented();
 /// Attempting an operation requiring the token being nested, while it is not
 error RMRKParentIsNotNFT();
 /// Attempting to add a `Part` with an ID that is already used
@@ -173,3 +149,5 @@ error RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
 error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
 /// Attempting to pay with native token with a value different than expected
 error RMRKWrongValueSent();
+// Attempting to send native token to a recipient that is unable to receive it
+error TransferFailed();

--- a/contracts/RMRK/library/RMRKLib.sol
+++ b/contracts/RMRK/library/RMRKLib.sol
@@ -8,6 +8,8 @@ pragma solidity ^0.8.21;
  * @notice RMRK library smart contract.
  */
 library RMRKLib {
+    error IndexOutOfBounds();
+
     /**
      * @notice Used to remove an item from the array using the specified index.
      * @dev The item is removed by replacing it with the last item and removing the last element.
@@ -16,7 +18,7 @@ library RMRKLib {
      */
     function removeItemByIndex(uint64[] storage array, uint256 index) internal {
         //Check to see if this is already gated by require in all calls
-        require(index < array.length);
+        if (index >= array.length) revert IndexOutOfBounds();
         array[index] = array[array.length - 1];
         array.pop();
     }

--- a/contracts/RMRK/multiasset/AbstractMultiAsset.sol
+++ b/contracts/RMRK/multiasset/AbstractMultiAsset.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "./IERC5773.sol";
-import "../library/RMRKLib.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
+import {IERC5773} from "./IERC5773.sol";
+import {RMRKLib} from "../library/RMRKLib.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/multiasset/AbstractMultiAsset.sol
+++ b/contracts/RMRK/multiasset/AbstractMultiAsset.sol
@@ -45,9 +45,9 @@ abstract contract AbstractMultiAsset is Context, IERC5773 {
     function getAssetMetadata(
         uint256 tokenId,
         uint64 assetId
-    ) public view virtual returns (string memory) {
+    ) public view virtual returns (string memory metadata) {
         if (!_tokenAssets[tokenId][assetId]) revert RMRKTokenDoesNotHaveAsset();
-        return _assets[assetId];
+        metadata = _assets[assetId];
     }
 
     /**
@@ -55,8 +55,8 @@ abstract contract AbstractMultiAsset is Context, IERC5773 {
      */
     function getActiveAssets(
         uint256 tokenId
-    ) public view virtual returns (uint64[] memory) {
-        return _activeAssets[tokenId];
+    ) public view virtual returns (uint64[] memory assetIds) {
+        assetIds = _activeAssets[tokenId];
     }
 
     /**
@@ -64,8 +64,8 @@ abstract contract AbstractMultiAsset is Context, IERC5773 {
      */
     function getPendingAssets(
         uint256 tokenId
-    ) public view virtual returns (uint64[] memory) {
-        return _pendingAssets[tokenId];
+    ) public view virtual returns (uint64[] memory assetIds) {
+        assetIds = _pendingAssets[tokenId];
     }
 
     /**
@@ -73,8 +73,8 @@ abstract contract AbstractMultiAsset is Context, IERC5773 {
      */
     function getActiveAssetPriorities(
         uint256 tokenId
-    ) public view virtual returns (uint64[] memory) {
-        return _activeAssetPriorities[tokenId];
+    ) public view virtual returns (uint64[] memory priorities) {
+        priorities = _activeAssetPriorities[tokenId];
     }
 
     /**
@@ -83,8 +83,8 @@ abstract contract AbstractMultiAsset is Context, IERC5773 {
     function getAssetReplacements(
         uint256 tokenId,
         uint64 newAssetId
-    ) public view virtual returns (uint64) {
-        return _assetReplacements[tokenId][newAssetId];
+    ) public view virtual returns (uint64 replacesAssetId) {
+        replacesAssetId = _assetReplacements[tokenId][newAssetId];
     }
 
     /**
@@ -93,8 +93,8 @@ abstract contract AbstractMultiAsset is Context, IERC5773 {
     function isApprovedForAllForAssets(
         address owner,
         address operator
-    ) public view virtual returns (bool) {
-        return _operatorApprovalsForAssets[owner][operator];
+    ) public view virtual returns (bool isApproved) {
+        isApproved = _operatorApprovalsForAssets[owner][operator];
     }
 
     /**

--- a/contracts/RMRK/multiasset/IERC5773.sol
+++ b/contracts/RMRK/multiasset/IERC5773.sol
@@ -163,33 +163,33 @@ interface IERC5773 is IERC165 {
      *  `getAssetMetadata(tokenId, assetId)`.
      * @dev You can safely get 10k
      * @param tokenId ID of the token to retrieve the IDs of the active assets
-     * @return An array of active asset IDs of the given token
+     * @return assetIds An array of active asset IDs of the given token
      */
     function getActiveAssets(
         uint256 tokenId
-    ) external view returns (uint64[] memory);
+    ) external view returns (uint64[] memory assetIds);
 
     /**
      * @notice Used to retrieve IDs of the pending assets of given token.
      * @dev Asset data is stored by reference, in order to access the data corresponding to the ID, call
      *  `getAssetMetadata(tokenId, assetId)`.
      * @param tokenId ID of the token to retrieve the IDs of the pending assets
-     * @return An array of pending asset IDs of the given token
+     * @return assetIds An array of pending asset IDs of the given token
      */
     function getPendingAssets(
         uint256 tokenId
-    ) external view returns (uint64[] memory);
+    ) external view returns (uint64[] memory assetIds);
 
     /**
      * @notice Used to retrieve the priorities of the active resoources of a given token.
      * @dev Asset priorities are a non-sequential array of uint64 values with an array size equal to active asset
      *  priorites.
      * @param tokenId ID of the token for which to retrieve the priorities of the active assets
-     * @return An array of priorities of the active assets of the given token
+     * @return priorities An array of priorities of the active assets of the given token
      */
     function getActiveAssetPriorities(
         uint256 tokenId
-    ) external view returns (uint64[] memory);
+    ) external view returns (uint64[] memory priorities);
 
     /**
      * @notice Used to retrieve the asset that will be replaced if a given asset from the token's pending array
@@ -198,12 +198,12 @@ interface IERC5773 is IERC165 {
      *  `getAssetMetadata(tokenId, assetId)`.
      * @param tokenId ID of the token to check
      * @param newAssetId ID of the pending asset which will be accepted
-     * @return ID of the asset which will be replaced
+     * @return replacesAssetWithId ID of the asset which will be replaced
      */
     function getAssetReplacements(
         uint256 tokenId,
         uint64 newAssetId
-    ) external view returns (uint64);
+    ) external view returns (uint64 replacesAssetWithId);
 
     /**
      * @notice Used to fetch the asset metadata of the specified token's active asset with the given index.
@@ -211,13 +211,13 @@ interface IERC5773 is IERC165 {
      * @dev Can be overriden to implement enumerate, fallback or other custom logic.
      * @param tokenId ID of the token from which to retrieve the asset metadata
      * @param assetId Asset Id, must be in the active assets array
-     * @return The metadata of the asset belonging to the specified index in the token's active assets
+     * @return metadata The metadata of the asset belonging to the specified index in the token's active assets
      *  array
      */
     function getAssetMetadata(
         uint256 tokenId,
         uint64 assetId
-    ) external view returns (string memory);
+    ) external view returns (string memory metadata);
 
     // Approvals
 
@@ -242,11 +242,11 @@ interface IERC5773 is IERC165 {
      *
      *  - `tokenId` must exist.
      * @param tokenId ID of the token for which to retrieve the approved address
-     * @return Address of the account that is approved to manage the specified token's assets
+     * @return approved Address of the account that is approved to manage the specified token's assets
      */
     function getApprovedForAssets(
         uint256 tokenId
-    ) external view returns (address);
+    ) external view returns (address approved);
 
     /**
      * @notice Used to add or remove an operator of assets for the caller.
@@ -270,10 +270,10 @@ interface IERC5773 is IERC165 {
      * @dev See {setApprovalForAllForAssets}.
      * @param owner Address of the account that we are checking for whether it has granted the operator role
      * @param operator Address of the account that we are checking whether it has the operator role or not
-     * @return A boolean value indicating wehter the account we are checking has been granted the operator role
+     * @return isApproved A boolean value indicating whether the account we are checking has been granted the operator role
      */
     function isApprovedForAllForAssets(
         address owner,
         address operator
-    ) external view returns (bool);
+    ) external view returns (bool isApproved);
 }

--- a/contracts/RMRK/multiasset/IERC5773.sol
+++ b/contracts/RMRK/multiasset/IERC5773.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IERC5773

--- a/contracts/RMRK/multiasset/RMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/RMRKMultiAsset.sol
@@ -307,10 +307,12 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      * @dev Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
      * @dev Tokens start existing when they are minted (`_mint`) and stop existing when they are burned (`_burn`).
      * @param tokenId ID of the token being checked
-     * @return A boolean value signifying whether the token exists
+     * @return exists A boolean value signifying whether the token exists
      */
-    function _exists(uint256 tokenId) internal view virtual returns (bool) {
-        return _owners[tokenId] != address(0);
+    function _exists(
+        uint256 tokenId
+    ) internal view virtual returns (bool exists) {
+        exists = _owners[tokenId] != address(0);
     }
 
     /**
@@ -483,14 +485,14 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      * @param to Yarget address that will receive the tokens
      * @param tokenId ID of the token to be transferred
      * @param data Optional data to send along with the call
-     * @return Boolean value signifying whether the call correctly returned the expected magic value
+     * @return valid Boolean value signifying whether the call correctly returned the expected magic value
      */
     function _checkOnERC721Received(
         address from,
         address to,
         uint256 tokenId,
         bytes memory data
-    ) private returns (bool) {
+    ) private returns (bool valid) {
         if (to.code.length != 0) {
             try
                 IERC721Receiver(to).onERC721Received(
@@ -500,7 +502,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
                     data
                 )
             returns (bytes4 retval) {
-                return retval == IERC721Receiver.onERC721Received.selector;
+                valid = retval == IERC721Receiver.onERC721Received.selector;
             } catch (bytes memory reason) {
                 if (reason.length == uint256(0)) {
                     revert ERC721TransferToNonReceiverImplementer();
@@ -512,7 +514,7 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
                 }
             }
         } else {
-            return true;
+            valid = true;
         }
     }
 

--- a/contracts/RMRK/multiasset/RMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/RMRKMultiAsset.sol
@@ -114,11 +114,13 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
     /**
      * @notice Used to retrieve the number of tokens in ``owner``'s account.
      * @param owner Address of the account being checked
-     * @return The balance of the given account
+     * @return balance The balance of the given account
      */
-    function balanceOf(address owner) public view virtual returns (uint256) {
+    function balanceOf(
+        address owner
+    ) public view virtual returns (uint256 balance) {
         if (owner == address(0)) revert ERC721AddressZeroIsNotaValidOwner();
-        return _balances[owner];
+        balance = _balances[owner];
     }
 
     /**
@@ -127,12 +129,13 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      *
      *  - `tokenId` must exist.
      * @param tokenId ID of the token for which to retrieve the token for
-     * @return Address of the account owning the token
+     * @return owner Address of the account owning the token
      */
-    function ownerOf(uint256 tokenId) public view virtual returns (address) {
-        address owner = _owners[tokenId];
+    function ownerOf(
+        uint256 tokenId
+    ) public view virtual returns (address owner) {
+        owner = _owners[tokenId];
         if (owner == address(0)) revert ERC721InvalidTokenId();
-        return owner;
     }
 
     /**
@@ -164,14 +167,14 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      *
      *  - `tokenId` must exist.
      * @param tokenId ID of the token to check for approval
-     * @return Address of the account approved to manage the token
+     * @return approved Address of the account approved to manage the token
      */
     function getApproved(
         uint256 tokenId
-    ) public view virtual returns (address) {
+    ) public view virtual returns (address approved) {
         _requireMinted(tokenId);
 
-        return _tokenApprovals[tokenId];
+        approved = _tokenApprovals[tokenId];
     }
 
     /**
@@ -192,14 +195,14 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      * @notice Used to check if the given address is allowed to manage the tokens of the specified address.
      * @param owner Address of the owner of the tokens
      * @param operator Address being checked for approval
-     * @return A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)
+     * @return isApproved A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)
      *  or not (`false`)
      */
     function isApprovedForAll(
         address owner,
         address operator
-    ) public view virtual returns (bool) {
-        return _operatorApprovals[owner][operator];
+    ) public view virtual returns (bool isApproved) {
+        isApproved = _operatorApprovals[owner][operator];
     }
 
     /**
@@ -589,9 +592,9 @@ contract RMRKMultiAsset is IERC165, IERC721, AbstractMultiAsset, RMRKCore {
      */
     function getApprovedForAssets(
         uint256 tokenId
-    ) public view virtual returns (address) {
+    ) public view virtual returns (address approved) {
         _requireMinted(tokenId);
-        return _tokenApprovalsForAssets[tokenId];
+        approved = _tokenApprovalsForAssets[tokenId];
     }
 
     /**

--- a/contracts/RMRK/multiasset/RMRKMultiAsset.sol
+++ b/contracts/RMRK/multiasset/RMRKMultiAsset.sol
@@ -3,11 +3,12 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "./AbstractMultiAsset.sol";
-import "../core/RMRKCore.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC5773} from "./IERC5773.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {AbstractMultiAsset} from "./AbstractMultiAsset.sol";
+import {RMRKCore} from "../core/RMRKCore.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/nestable/IERC7401.sol
+++ b/contracts/RMRK/nestable/IERC7401.sol
@@ -148,12 +148,12 @@ interface IERC7401 is IERC165 {
      * @dev Emits a {Transfer} event.
      * @param tokenId ID of the token to burn
      * @param maxRecursiveBurns Maximum number of tokens to recursively burn
-     * @return Number of recursively burned children
+     * @return burnedChildren Number of recursively burned children
      */
     function burn(
         uint256 tokenId,
         uint256 maxRecursiveBurns
-    ) external returns (uint256);
+    ) external returns (uint256 burnedChildren);
 
     /**
      * @notice Used to add a child token to a given parent token.

--- a/contracts/RMRK/nestable/IERC7401.sol
+++ b/contracts/RMRK/nestable/IERC7401.sol
@@ -117,9 +117,9 @@ interface IERC7401 is IERC165 {
      * @dev The *root* owner of the token is an externally owned account (EOA). If the given token is child of another
      *  NFT, this will return an EOA address. Otherwise, if the token is owned by an EOA, this EOA wil be returned.
      * @param tokenId ID of the token for which the *root* owner has been retrieved
-     * @return owner The *root* owner of the token
+     * @return owner_ The *root* owner of the token
      */
-    function ownerOf(uint256 tokenId) external view returns (address owner);
+    function ownerOf(uint256 tokenId) external view returns (address owner_);
 
     /**
      * @notice Used to retrieve the immediate owner of the given token.
@@ -244,11 +244,11 @@ interface IERC7401 is IERC165 {
      *      contractAddress
      *  ]
      * @param parentId ID of the parent token for which to retrieve the active child tokens
-     * @return An array of Child structs containing the parent token's active child tokens
+     * @return children An array of Child structs containing the parent token's active child tokens
      */
     function childrenOf(
         uint256 parentId
-    ) external view returns (Child[] memory);
+    ) external view returns (Child[] memory children);
 
     /**
      * @notice Used to retrieve the pending child tokens of a given parent token.
@@ -259,11 +259,11 @@ interface IERC7401 is IERC165 {
      *      contractAddress
      *  ]
      * @param parentId ID of the parent token for which to retrieve the pending child tokens
-     * @return An array of Child structs containing the parent token's pending child tokens
+     * @return children An array of Child structs containing the parent token's pending child tokens
      */
     function pendingChildrenOf(
         uint256 parentId
-    ) external view returns (Child[] memory);
+    ) external view returns (Child[] memory children);
 
     /**
      * @notice Used to retrieve a specific active child token for a given parent token.
@@ -275,12 +275,12 @@ interface IERC7401 is IERC165 {
      *  ]
      * @param parentId ID of the parent token for which the child is being retrieved
      * @param index Index of the child token in the parent token's active child tokens array
-     * @return A Child struct containing data about the specified child
+     * @return child A Child struct containing data about the specified child
      */
     function childOf(
         uint256 parentId,
         uint256 index
-    ) external view returns (Child memory);
+    ) external view returns (Child memory child);
 
     /**
      * @notice Used to retrieve a specific pending child token from a given parent token.
@@ -292,12 +292,12 @@ interface IERC7401 is IERC165 {
      *  ]
      * @param parentId ID of the parent token for which the pending child token is being retrieved
      * @param index Index of the child token in the parent token's pending child tokens array
-     * @return A Child struct containting data about the specified child
+     * @return child A Child struct containting data about the specified child
      */
     function pendingChildOf(
         uint256 parentId,
         uint256 index
-    ) external view returns (Child memory);
+    ) external view returns (Child memory child);
 
     /**
      * @notice Used to transfer the token into another token.

--- a/contracts/RMRK/nestable/IERC7401.sol
+++ b/contracts/RMRK/nestable/IERC7401.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title IERC7401

--- a/contracts/RMRK/nestable/IERC7401.sol
+++ b/contracts/RMRK/nestable/IERC7401.sol
@@ -126,13 +126,13 @@ interface IERC7401 is IERC165 {
      * @dev If the immediate owner is another token, the address returned, should be the one of the parent token's
      *  collection smart contract.
      * @param tokenId ID of the token for which the RMRK owner is being retrieved
-     * @return Address of the given token's owner
-     * @return The ID of the parent token. Should be `0` if the owner is an externally owned account
-     * @return The boolean value signifying whether the owner is an NFT or not
+     * @return owner Address of the given token's owner
+     * @return parentId The ID of the parent token. Should be `0` if the owner is an externally owned account
+     * @return isNFT The boolean value signifying whether the owner is an NFT or not
      */
     function directOwnerOf(
         uint256 tokenId
-    ) external view returns (address, uint256, bool);
+    ) external view returns (address owner, uint256 parentId, bool isNFT);
 
     /**
      * @notice Used to burn a given token.

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -109,11 +109,13 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
     /**
      * @notice Used to retrieve the number of tokens in `owner`'s account.
      * @param owner Address of the account being checked
-     * @return The balance of the given account
+     * @return balance The balance of the given account
      */
-    function balanceOf(address owner) public view virtual returns (uint256) {
+    function balanceOf(
+        address owner
+    ) public view virtual returns (uint256 balance) {
         if (owner == address(0)) revert ERC721AddressZeroIsNotaValidOwner();
-        return _balances[owner];
+        balance = _balances[owner];
     }
 
     ////////////////////////////////////////
@@ -497,14 +499,14 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      */
     function ownerOf(
         uint256 tokenId
-    ) public view virtual override(IERC7401, IERC721) returns (address) {
+    ) public view virtual override(IERC7401, IERC721) returns (address owner_) {
         (address owner, uint256 ownerTokenId, bool isNft) = directOwnerOf(
             tokenId
         );
         if (isNft) {
             owner = IERC7401(owner).ownerOf(ownerTokenId);
         }
-        return owner;
+        owner_ = owner;
     }
 
     /**
@@ -516,7 +518,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
         public
         view
         virtual
-        returns (address owner, uint256 parentId, bool isNFT)
+        returns (address owner_, uint256 parentId, bool isNFT)
     {
         DirectOwner memory owner = _RMRKOwners[tokenId];
         if (owner.ownerAddress == address(0)) revert ERC721InvalidTokenId();
@@ -543,8 +545,13 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
     function burn(
         uint256 tokenId,
         uint256 maxChildrenBurns
-    ) public virtual onlyApprovedOrDirectOwner(tokenId) returns (uint256) {
-        return _burn(tokenId, maxChildrenBurns);
+    )
+        public
+        virtual
+        onlyApprovedOrDirectOwner(tokenId)
+        returns (uint256 burnedChildren)
+    {
+        burnedChildren = _burn(tokenId, maxChildrenBurns);
     }
 
     /**
@@ -668,14 +675,14 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      *
      *  - `tokenId` must exist.
      * @param tokenId ID of the token to check for approval
-     * @return Address of the account approved to manage the token
+     * @return approved Address of the account approved to manage the token
      */
     function getApproved(
         uint256 tokenId
-    ) public view virtual returns (address) {
+    ) public view virtual returns (address approved) {
         _requireMinted(tokenId);
 
-        return _tokenApprovals[tokenId][ownerOf(tokenId)];
+        approved = _tokenApprovals[tokenId][ownerOf(tokenId)];
     }
 
     /**
@@ -698,14 +705,14 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      * @notice Used to check if the given address is allowed to manage the tokens of the specified address.
      * @param owner Address of the owner of the tokens
      * @param operator Address being checked for approval
-     * @return A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)
+     * @return isApproved A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)
      *  or not (`false`)
      */
     function isApprovedForAll(
         address owner,
         address operator
-    ) public view virtual returns (bool) {
-        return _operatorApprovals[owner][operator];
+    ) public view virtual returns (bool isApproved) {
+        isApproved = _operatorApprovals[owner][operator];
     }
 
     /**
@@ -1130,9 +1137,8 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
 
     function childrenOf(
         uint256 parentId
-    ) public view virtual returns (Child[] memory) {
-        Child[] memory children = _activeChildren[parentId];
-        return children;
+    ) public view virtual returns (Child[] memory children) {
+        children = _activeChildren[parentId];
     }
 
     /**
@@ -1141,9 +1147,8 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
 
     function pendingChildrenOf(
         uint256 parentId
-    ) public view virtual returns (Child[] memory) {
-        Child[] memory pendingChildren = _pendingChildren[parentId];
-        return pendingChildren;
+    ) public view virtual returns (Child[] memory children) {
+        children = _pendingChildren[parentId];
     }
 
     /**
@@ -1152,11 +1157,10 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
     function childOf(
         uint256 parentId,
         uint256 index
-    ) public view virtual returns (Child memory) {
+    ) public view virtual returns (Child memory child) {
         if (childrenOf(parentId).length <= index)
             revert RMRKChildIndexOutOfRange();
-        Child memory child = _activeChildren[parentId][index];
-        return child;
+        child = _activeChildren[parentId][index];
     }
 
     /**
@@ -1165,11 +1169,10 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
     function pendingChildOf(
         uint256 parentId,
         uint256 index
-    ) public view virtual returns (Child memory) {
+    ) public view virtual returns (Child memory child) {
         if (pendingChildrenOf(parentId).length <= index)
             revert RMRKPendingChildIndexOutOfRange();
-        Child memory child = _pendingChildren[parentId][index];
-        return child;
+        child = _pendingChildren[parentId][index];
     }
 
     /**

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -4,12 +4,12 @@
 
 pragma solidity ^0.8.21;
 
-import "./IERC7401.sol";
-import "../core/RMRKCore.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC7401} from "./IERC7401.sol";
+import {RMRKCore} from "../core/RMRKCore.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -523,7 +523,9 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
         DirectOwner memory owner = _RMRKOwners[tokenId];
         if (owner.ownerAddress == address(0)) revert ERC721InvalidTokenId();
 
-        return (owner.ownerAddress, owner.tokenId, owner.tokenId != 0);
+        owner_ = owner.ownerAddress;
+        parentId = owner.tokenId;
+        isNFT = owner.tokenId != 0;
     }
 
     ////////////////////////////////////////
@@ -816,10 +818,12 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      * @notice Used to check whether the given token exists.
      * @dev Tokens start existing when they are minted (`_mint`) and stop existing when they are burned (`_burn`).
      * @param tokenId ID of the token being checked
-     * @return A boolean value signifying whether the token exists
+     * @return exists A boolean value signifying whether the token exists
      */
-    function _exists(uint256 tokenId) internal view virtual returns (bool) {
-        return _RMRKOwners[tokenId].ownerAddress != address(0);
+    function _exists(
+        uint256 tokenId
+    ) internal view virtual returns (bool exists) {
+        exists = _RMRKOwners[tokenId].ownerAddress != address(0);
     }
 
     /**
@@ -829,14 +833,14 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      * @param to Yarget address that will receive the tokens
      * @param tokenId ID of the token to be transferred
      * @param data Optional data to send along with the call
-     * @return Boolean value signifying whether the call correctly returned the expected magic value
+     * @return valid Boolean value signifying whether the call correctly returned the expected magic value
      */
     function _checkOnERC721Received(
         address from,
         address to,
         uint256 tokenId,
         bytes memory data
-    ) private returns (bool) {
+    ) private returns (bool valid) {
         if (to.code.length != 0) {
             try
                 IERC721Receiver(to).onERC721Received(
@@ -846,7 +850,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
                     data
                 )
             returns (bytes4 retval) {
-                return retval == IERC721Receiver.onERC721Received.selector;
+                valid = retval == IERC721Receiver.onERC721Received.selector;
             } catch (bytes memory reason) {
                 if (reason.length == uint256(0)) {
                     revert ERC721TransferToNonReceiverImplementer();
@@ -858,7 +862,7 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
                 }
             }
         } else {
-            return true;
+            valid = true;
         }
     }
 

--- a/contracts/RMRK/nestable/RMRKNestable.sol
+++ b/contracts/RMRK/nestable/RMRKNestable.sol
@@ -512,7 +512,12 @@ contract RMRKNestable is Context, IERC165, IERC721, IERC7401, RMRKCore {
      */
     function directOwnerOf(
         uint256 tokenId
-    ) public view virtual returns (address, uint256, bool) {
+    )
+        public
+        view
+        virtual
+        returns (address owner, uint256 parentId, bool isNFT)
+    {
         DirectOwner memory owner = _RMRKOwners[tokenId];
         if (owner.ownerAddress == address(0)) revert ERC721InvalidTokenId();
 

--- a/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
+++ b/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
@@ -124,9 +124,9 @@ contract RMRKNestableMultiAsset is RMRKNestable, AbstractMultiAsset {
      */
     function getApprovedForAssets(
         uint256 tokenId
-    ) public view virtual returns (address) {
+    ) public view virtual returns (address approved) {
         _requireMinted(tokenId);
-        return _tokenApprovalsForAssets[tokenId][ownerOf(tokenId)];
+        approved = _tokenApprovalsForAssets[tokenId][ownerOf(tokenId)];
     }
 
     /**

--- a/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
+++ b/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
@@ -4,10 +4,12 @@
 
 pragma solidity ^0.8.21;
 
-import "../multiasset/AbstractMultiAsset.sol";
-import "./IERC7401.sol";
-import "./RMRKNestable.sol";
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {AbstractMultiAsset} from "../multiasset/AbstractMultiAsset.sol";
+import {IERC7401} from "./IERC7401.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {RMRKNestable} from "./RMRKNestable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "../library/RMRKErrors.sol";
 
 /**
  * @title RMRKNestableMultiAsset

--- a/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
+++ b/contracts/RMRK/nestable/RMRKNestableMultiAsset.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.8.21;
 
 import {AbstractMultiAsset} from "../multiasset/AbstractMultiAsset.sol";
-import {IERC7401} from "./IERC7401.sol";
 import {IERC5773} from "../multiasset/IERC5773.sol";
 import {RMRKNestable} from "./RMRKNestable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/contracts/RMRK/utils/IERC20.sol
+++ b/contracts/RMRK/utils/IERC20.sol
@@ -11,22 +11,25 @@ interface IERC20 {
      * @notice Used to transfer tokens from the caller's account to another.
      * @param to Address of the account to which the tokens are being transferred
      * @param amount Amount of tokens that are being transferred
-     * @return A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`)
+     * @return success A boolean value signifying whether the transfer was succesful (`true`) or not (`false`)
      */
-    function transfer(address to, uint256 amount) external returns (bool);
+    function transfer(
+        address to,
+        uint256 amount
+    ) external returns (bool success);
 
     /**
      * @notice Used to transfer tokens from one address to another.
      * @param from Address of the account from which the the tokens are being transferred
      * @param to Address of the account to which the tokens are being transferred
      * @param amount Amount of tokens that are being transferred
-     * @return A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`)
+     * @return success A boolean value signifying whether the transfer was succesful (`true`) or not (`false`)
      */
     function transferFrom(
         address from,
         address to,
         uint256 amount
-    ) external returns (bool);
+    ) external returns (bool success);
 
     /**
      * @notice Used to grant permission to an account to spend the tokens of another

--- a/contracts/RMRK/utils/RMRKBulkWriter.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriter.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "../equippable/IERC6220.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {IERC6220} from "../equippable/IERC6220.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/utils/RMRKBulkWriter.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriter.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../equippable/IERC6220.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+import "../equippable/IERC6220.sol";
 import "../library/RMRKErrors.sol";
 
 /**
@@ -12,7 +13,7 @@ import "../library/RMRKErrors.sol";
  * @notice Smart contract of the RMRK Bulk Writer module.
  * @dev Extra utility functions for RMRK contracts.
  */
-contract RMRKBulkWriter {
+contract RMRKBulkWriter is Context {
     /**
      * @notice Used to provide a struct for inputing unequip data.
      * @dev Only used for input and not storage of data.
@@ -128,7 +129,7 @@ contract RMRKBulkWriter {
         uint256 tokenId
     ) internal view {
         address tokenOwner = IERC721(collection).ownerOf(tokenId);
-        if (tokenOwner != msg.sender) {
+        if (tokenOwner != _msgSender()) {
             revert RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
         }
     }

--- a/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
@@ -48,10 +48,10 @@ contract RMRKBulkWriterPerCollection is Context {
 
     /**
      * @notice Returns the address of the collection that this contract is managing
-     * @return Address of the collection that this contract is managing
+     * @return collection Address of the collection that this contract is managing
      */
-    function getCollection() public view returns (address) {
-        return _collection;
+    function getCollection() public view returns (address collection) {
+        collection = _collection;
     }
 
     /**

--- a/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "../equippable/IERC6220.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {IERC6220} from "../equippable/IERC6220.sol";
 
 error RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
 error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();

--- a/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
+++ b/contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../equippable/IERC6220.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+import "../equippable/IERC6220.sol";
 
 error RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
 error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
@@ -14,7 +15,7 @@ error RMRKCanOnlyDoBulkOperationsWithOneTokenAtATime();
  * @notice Smart contract of the RMRK Bulk Writer per collection module.
  * @dev Extra utility functions for RMRK contracts.
  */
-contract RMRKBulkWriterPerCollection {
+contract RMRKBulkWriterPerCollection is Context {
     /**
      * @notice Used to provide a struct for inputing unequip data.
      * @dev Only used for input and not storage of data
@@ -133,7 +134,7 @@ contract RMRKBulkWriterPerCollection {
      */
     function _checkTokenOwner(uint256 tokenId) internal view {
         address tokenOwner = IERC721(_collection).ownerOf(tokenId);
-        if (tokenOwner != msg.sender) {
+        if (tokenOwner != _msgSender()) {
             revert RMRKCanOnlyDoBulkOperationsOnOwnedTokens();
         }
     }

--- a/contracts/RMRK/utils/RMRKCatalogUtils.sol
+++ b/contracts/RMRK/utils/RMRKCatalogUtils.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "../catalog/IRMRKCatalog.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IRMRKCatalog} from "../catalog/IRMRKCatalog.sol";
 
 /**
  * @title RMRKCatalogUtils

--- a/contracts/RMRK/utils/RMRKCatalogUtils.sol
+++ b/contracts/RMRK/utils/RMRKCatalogUtils.sol
@@ -68,7 +68,7 @@ contract RMRKCatalogUtils {
         uint256 length = partIds.length;
         IRMRKCatalog target = IRMRKCatalog(catalog);
         parts = new ExtendedPart[](length);
-        for (uint256 i = 0; i < length; i++) {
+        for (uint256 i = 0; i < length; ) {
             uint64 partId = partIds[i];
             bool isEquippableToAll = target.checkIsEquippableToAll(partId);
             IRMRKCatalog.Part memory part = target.getPart(partId);
@@ -80,6 +80,9 @@ contract RMRKCatalogUtils {
                 equippableToAll: isEquippableToAll,
                 metadataURI: part.metadataURI
             });
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/contracts/RMRK/utils/RMRKCollectionUtils.sol
+++ b/contracts/RMRK/utils/RMRKCollectionUtils.sol
@@ -19,10 +19,29 @@ import {IRMRKCollectionData} from "./IRMRKCollectionData.sol";
  * @dev Extra utility functions for RMRK contracts.
  */
 contract RMRKCollectionUtils {
-    event CollectionTokensMetadataRefreshTriggered(address indexed collection);
-    event TokenMetadataRefreshTriggered(
-        address indexed collection,
-        uint256 indexed tokenId
+    /**
+     * @notice This event emits when the metadata of a token is changed.
+     * So that the third-party platforms such as NFT market could
+     * timely update the images and related attributes of the NFT.
+     * Inspired on ERC4906, but adding collection.
+     * @param collection Address of the collection to emit the event from
+     * @param tokenId ID of the token to emit the event from
+     */
+    event MetadataUpdate(address collection, uint256 tokenId);
+
+    /**
+     * @notice This event emits when the metadata of a range of tokens is changed.
+     * So that the third-party platforms such as NFT market could
+     * timely update the images and related attributes of the NFTs.
+     * Inspired on ERC4906, but adding collection.
+     * @param collection Address of the collection to emit the event from
+     * @param fromTokenId ID of the first token to emit the event from
+     * @param toTokenId ID of the last token to emit the event from
+     */
+    event BatchMetadataUpdate(
+        address collection,
+        uint256 fromTokenId,
+        uint256 toTokenId
     );
 
     /**
@@ -194,13 +213,19 @@ contract RMRKCollectionUtils {
      * @notice Triggers an event to refresh the collection metadata.
      * @dev It will do nothing if the given collection address is not a contract.
      * @param collectionAddress Address of the collection to refresh the metadata from
+     * @param fromTokenId ID of the first token to refresh the metadata from
+     * @param toTokenId ID of the last token to refresh the metadata from
      */
-    function refreshCollectionTokensMetadata(address collectionAddress) public {
+    function refreshCollectionTokensMetadata(
+        address collectionAddress,
+        uint256 fromTokenId,
+        uint256 toTokenId
+    ) public {
         // To avoid some spam
         if (collectionAddress.code.length == 0) {
             return;
         }
-        emit CollectionTokensMetadataRefreshTriggered(collectionAddress);
+        emit BatchMetadataUpdate(collectionAddress, fromTokenId, toTokenId);
     }
 
     /**
@@ -217,6 +242,6 @@ contract RMRKCollectionUtils {
         if (collectionAddress.code.length == 0) {
             return;
         }
-        emit TokenMetadataRefreshTriggered(collectionAddress, tokenId);
+        emit MetadataUpdate(collectionAddress, tokenId);
     }
 }

--- a/contracts/RMRK/utils/RMRKCollectionUtils.sol
+++ b/contracts/RMRK/utils/RMRKCollectionUtils.sol
@@ -27,7 +27,7 @@ contract RMRKCollectionUtils {
      * @param collection Address of the collection to emit the event from
      * @param tokenId ID of the token to emit the event from
      */
-    event MetadataUpdate(address collection, uint256 tokenId);
+    event MetadataUpdate(address indexed collection, uint256 indexed tokenId);
 
     /**
      * @notice This event emits when the metadata of a range of tokens is changed.
@@ -39,9 +39,9 @@ contract RMRKCollectionUtils {
      * @param toTokenId ID of the last token to emit the event from
      */
     event BatchMetadataUpdate(
-        address collection,
-        uint256 fromTokenId,
-        uint256 toTokenId
+        address indexed collection,
+        uint256 indexed fromTokenId,
+        uint256 indexed toTokenId
     );
 
     /**
@@ -177,7 +177,7 @@ contract RMRKCollectionUtils {
         uint256 pageStart,
         uint256 pageSize
     ) public view returns (uint256[] memory page) {
-        uint256[] memory tmpIds = new uint[](pageSize);
+        uint256[] memory tmpIds = new uint256[](pageSize);
         uint256 found;
         for (uint256 i = 0; i < pageSize; ) {
             try IERC721(targetEquippable).ownerOf(pageStart + i) returns (

--- a/contracts/RMRK/utils/RMRKCollectionUtils.sol
+++ b/contracts/RMRK/utils/RMRKCollectionUtils.sol
@@ -2,13 +2,15 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/interfaces/IERC2981.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "../equippable/IERC6220.sol";
-import "../nestable/IERC7401.sol";
-import "../extension/soulbound/IERC6454.sol";
-import "./IRMRKCollectionData.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC6220} from "../equippable/IERC6220.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {IERC7401} from "../nestable/IERC7401.sol";
+import {IERC6454} from "../extension/soulbound/IERC6454.sol";
+import {IRMRKCollectionData} from "./IRMRKCollectionData.sol";
 
 /**
  * @title RMRKCollectionUtils

--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -2,13 +2,14 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKRenderUtils.sol";
-import "./RMRKMultiAssetRenderUtils.sol";
-import "./RMRKNestableRenderUtils.sol";
-import "../catalog/IRMRKCatalog.sol";
-import "../equippable/IERC6220.sol";
-import "../nestable/IERC7401.sol";
-import "../library/RMRKLib.sol";
+import {RMRKRenderUtils} from "./RMRKRenderUtils.sol";
+import {RMRKMultiAssetRenderUtils} from "./RMRKMultiAssetRenderUtils.sol";
+import {RMRKNestableRenderUtils} from "./RMRKNestableRenderUtils.sol";
+import {IRMRKCatalog} from "../catalog/IRMRKCatalog.sol";
+import {IERC6220} from "../equippable/IERC6220.sol";
+import {IERC7401} from "../nestable/IERC7401.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {RMRKLib} from "../library/RMRKLib.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -145,12 +145,17 @@ contract RMRKEquipRenderUtils is
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the extended active assets for
-     * @return An array of ExtendedEquippableActiveAssets present on the given token
+     * @return activeAssets An array of ExtendedEquippableActiveAssets present on the given token
      */
     function getExtendedEquippableActiveAssets(
         address target,
         uint256 tokenId
-    ) public view virtual returns (ExtendedEquippableActiveAsset[] memory) {
+    )
+        public
+        view
+        virtual
+        returns (ExtendedEquippableActiveAsset[] memory activeAssets)
+    {
         IERC6220 target_ = IERC6220(target);
 
         uint64[] memory assets = target_.getActiveAssets(tokenId);
@@ -160,8 +165,7 @@ contract RMRKEquipRenderUtils is
             revert RMRKTokenHasNoAssets();
         }
 
-        ExtendedEquippableActiveAsset[]
-            memory activeAssets = new ExtendedEquippableActiveAsset[](len);
+        activeAssets = new ExtendedEquippableActiveAsset[](len);
 
         for (uint256 i; i < len; ) {
             (
@@ -206,12 +210,17 @@ contract RMRKEquipRenderUtils is
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the extended pending assets for
-     * @return An array of ExtendedPendingAssets present on the given token
+     * @return pendingAssets An array of ExtendedPendingAssets present on the given token
      */
     function getExtendedPendingAssets(
         address target,
         uint256 tokenId
-    ) public view virtual returns (ExtendedPendingAsset[] memory) {
+    )
+        public
+        view
+        virtual
+        returns (ExtendedPendingAsset[] memory pendingAssets)
+    {
         IERC6220 target_ = IERC6220(target);
 
         uint64[] memory assets = target_.getPendingAssets(tokenId);
@@ -220,8 +229,7 @@ contract RMRKEquipRenderUtils is
             revert RMRKTokenHasNoAssets();
         }
 
-        ExtendedPendingAsset[]
-            memory pendingAssets = new ExtendedPendingAsset[](len);
+        pendingAssets = new ExtendedPendingAsset[](len);
         uint64 replacesAssetWithId;
         for (uint256 i; i < len; ) {
             (
@@ -527,6 +535,7 @@ contract RMRKEquipRenderUtils is
             targetChild,
             childId
         );
+
         childIndex = getChildIndex(
             parentAddress,
             parentId,
@@ -579,6 +588,7 @@ contract RMRKEquipRenderUtils is
             targetChild,
             childId
         );
+
         childIndex = getPendingChildIndex(
             parentAddress,
             parentId,
@@ -1035,19 +1045,22 @@ contract RMRKEquipRenderUtils is
      *  ]
      * @param parentAddress Address of the collection smart contract of the parent token
      * @param parentId ID of the parent token
-     * @return An array of `ChildWithTopAssetMetadata` structs representing the children with their top asset metadata
+     * @return childrenWithMetadata An array of `ChildWithTopAssetMetadata` structs representing the children with their top asset metadata
      */
     function getChildrenWithTopMetadata(
         address parentAddress,
         uint256 parentId
-    ) public view returns (ChildWithTopAssetMetadata[] memory) {
+    )
+        public
+        view
+        returns (ChildWithTopAssetMetadata[] memory childrenWithMetadata)
+    {
         IERC7401.Child[] memory children = IERC7401(parentAddress).childrenOf(
             parentId
         );
         (parentId);
         uint256 len = children.length;
-        ChildWithTopAssetMetadata[]
-            memory childrenWithMetadata = new ChildWithTopAssetMetadata[](len);
+        childrenWithMetadata = new ChildWithTopAssetMetadata[](len);
 
         for (uint256 i; i < len; ) {
             string memory meta = getTopAssetMetaForToken(

--- a/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKEquipRenderUtils.sol
@@ -441,7 +441,7 @@ contract RMRKEquipRenderUtils is
         uint256 totalChildAssets = IERC5773(targetChild)
             .getActiveAssets(childId)
             .length;
-        uint256 totalMatchesForAll = 0;
+        uint256 totalMatchesForAll;
 
         // This is the most valid asset combinations that can be made. When we know the real total we'll recreate it
         EquippableData[] memory allTempAssetsWithSlots = new EquippableData[](
@@ -459,7 +459,7 @@ contract RMRKEquipRenderUtils is
                 parentId,
                 parentAssets[0]
             );
-            uint totalMatchesForParentAsset = assetsWithSlotsForParentAsset
+            uint256 totalMatchesForParentAsset = assetsWithSlotsForParentAsset
                 .length;
 
             // We move them to the temporary array of all matches. Optionally filtering for onlyEquipped
@@ -817,7 +817,8 @@ contract RMRKEquipRenderUtils is
         allAssetsWithSlots = new EquippableData[](totalChildAssets);
 
         for (uint256 i; i < totalChildAssets; ) {
-            for (uint256 j; j < parentSlotPartIds.length; ) {
+            uint256 slotsLength = parentSlotPartIds.length;
+            for (uint256 j; j < slotsLength; ) {
                 if (
                     childContract.canTokenBeEquippedWithAssetIntoSlot(
                         parentAddress,
@@ -1025,10 +1026,14 @@ contract RMRKEquipRenderUtils is
         for (uint256 i; i < numParts; ) {
             if (allParts[i].itemType == IRMRKCatalog.ItemType.Fixed) {
                 fixedPartIds[fixedPartsIndex] = allPartIds[i];
-                fixedPartsIndex += 1;
+                unchecked {
+                    ++fixedPartsIndex;
+                }
             } else if (allParts[i].itemType == IRMRKCatalog.ItemType.Slot) {
                 slotPartIds[slotPartsIndex] = allPartIds[i];
-                slotPartsIndex += 1;
+                unchecked {
+                    ++slotPartsIndex;
+                }
             }
             unchecked {
                 ++i;

--- a/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../multiasset/IERC5773.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
 import "../library/RMRKErrors.sol";
 
 /**

--- a/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol
@@ -48,12 +48,12 @@ contract RMRKMultiAssetRenderUtils {
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the active assets for
-     * @return An array of ActiveAssets present on the given token
+     * @return activeAssets An array of ActiveAssets present on the given token
      */
     function getExtendedActiveAssets(
         address target,
         uint256 tokenId
-    ) public view virtual returns (ExtendedActiveAsset[] memory) {
+    ) public view virtual returns (ExtendedActiveAsset[] memory activeAssets) {
         IERC5773 target_ = IERC5773(target);
 
         uint64[] memory assets = target_.getActiveAssets(tokenId);
@@ -63,9 +63,7 @@ contract RMRKMultiAssetRenderUtils {
             revert RMRKTokenHasNoAssets();
         }
 
-        ExtendedActiveAsset[] memory activeAssets = new ExtendedActiveAsset[](
-            len
-        );
+        activeAssets = new ExtendedActiveAsset[](len);
         string memory metadata;
         for (uint256 i; i < len; ) {
             metadata = target_.getAssetMetadata(tokenId, assets[i]);
@@ -92,12 +90,12 @@ contract RMRKMultiAssetRenderUtils {
      *  ]
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the pending assets for
-     * @return An array of PendingAssets present on the given token
+     * @return pendingAssets An array of PendingAssets present on the given token
      */
     function getPendingAssets(
         address target,
         uint256 tokenId
-    ) public view virtual returns (PendingAsset[] memory) {
+    ) public view virtual returns (PendingAsset[] memory pendingAssets) {
         IERC5773 target_ = IERC5773(target);
 
         uint64[] memory assets = target_.getPendingAssets(tokenId);
@@ -106,7 +104,7 @@ contract RMRKMultiAssetRenderUtils {
             revert RMRKTokenHasNoAssets();
         }
 
-        PendingAsset[] memory pendingAssets = new PendingAsset[](len);
+        pendingAssets = new PendingAsset[](len);
         string memory metadata;
         uint64 replacesAssetWithId;
         for (uint256 i; i < len; ) {
@@ -136,16 +134,16 @@ contract RMRKMultiAssetRenderUtils {
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token to retrieve the specified assets for
      * @param assetIds[] An array of asset IDs for which to retrieve the metadata URIs
-     * @return An array of metadata URIs belonging to specified assets
+     * @return assets An array of metadata URIs belonging to specified assets
      */
     function getAssetsById(
         address target,
         uint256 tokenId,
         uint64[] calldata assetIds
-    ) public view virtual returns (string[] memory) {
+    ) public view virtual returns (string[] memory assets) {
         IERC5773 target_ = IERC5773(target);
         uint256 len = assetIds.length;
-        string[] memory assets = new string[](len);
+        assets = new string[](len);
         for (uint256 i; i < len; ) {
             assets[i] = target_.getAssetMetadata(tokenId, assetIds[i]);
             unchecked {
@@ -159,17 +157,20 @@ contract RMRKMultiAssetRenderUtils {
      * @notice Used to retrieve the metadata URI of the specified token's asset with the highest priority.
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token for which to retrieve the metadata URI of the asset with the highest priority
-     * @return The metadata URI of the asset with the highest priority
+     * @return metadata The metadata URI of the asset with the highest priority
      */
     function getTopAssetMetaForToken(
         address target,
         uint256 tokenId
-    ) public view returns (string memory) {
+    ) public view returns (string memory metadata) {
         (uint64 maxPriorityAssetId, ) = getAssetIdWithTopPriority(
             target,
             tokenId
         );
-        return IERC5773(target).getAssetMetadata(tokenId, maxPriorityAssetId);
+        metadata = IERC5773(target).getAssetMetadata(
+            tokenId,
+            maxPriorityAssetId
+        );
     }
 
     /**
@@ -197,13 +198,13 @@ contract RMRKMultiAssetRenderUtils {
      * @notice Used to retrieve the ID of the specified token's asset with the highest priority.
      * @param target Address of the smart contract of the given token
      * @param tokenId ID of the token for which to retrieve the ID of the asset with the highest priority
-     * @return The ID of the asset with the highest priority
-     * @return The priority value of the asset with the highest priority
+     * @return maxPriorityAssetId The ID of the asset with the highest priority
+     * @return maxPriority The priority value of the asset with the highest priority
      */
     function getAssetIdWithTopPriority(
         address target,
         uint256 tokenId
-    ) public view returns (uint64, uint64) {
+    ) public view returns (uint64 maxPriorityAssetId, uint64 maxPriority) {
         IERC5773 target_ = IERC5773(target);
         uint64[] memory priorities = target_.getActiveAssetPriorities(tokenId);
         uint64[] memory assets = target_.getActiveAssets(tokenId);
@@ -212,8 +213,7 @@ contract RMRKMultiAssetRenderUtils {
             revert RMRKTokenHasNoAssets();
         }
 
-        uint64 maxPriority = _LOWEST_POSSIBLE_PRIORITY;
-        uint64 maxPriorityAssetId;
+        maxPriority = _LOWEST_POSSIBLE_PRIORITY;
         for (uint64 i; i < len; ) {
             uint64 currentPrio = priorities[i];
             if (currentPrio < maxPriority) {
@@ -224,7 +224,6 @@ contract RMRKMultiAssetRenderUtils {
                 ++i;
             }
         }
-        return (maxPriorityAssetId, maxPriority);
     }
 
     /**

--- a/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "../nestable/IERC7401.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {IERC7401} from "../nestable/IERC7401.sol";
 import "../library/RMRKErrors.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
 /**
  * @title RMRKNestableRenderUtils

--- a/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKNestableRenderUtils.sol
@@ -20,14 +20,14 @@ contract RMRKNestableRenderUtils {
      * @param parentId ID of the parent token
      * @param childAddress Address of the child token's colection smart contract
      * @param childId ID of the child token
-     * @return The index of the child token in the parent token's child tokens array
+     * @return index The index of the child token in the parent token's child tokens array
      */
     function getChildIndex(
         address parentAddress,
         uint256 parentId,
         address childAddress,
         uint256 childId
-    ) public view returns (uint256) {
+    ) public view returns (uint256 index) {
         IERC7401.Child[] memory children = IERC7401(parentAddress).childrenOf(
             parentId
         );
@@ -37,7 +37,9 @@ contract RMRKNestableRenderUtils {
             if (
                 children[i].tokenId == childId &&
                 children[i].contractAddress == childAddress
-            ) return i;
+            ) {
+                return i;
+            }
             unchecked {
                 ++i;
             }
@@ -51,14 +53,14 @@ contract RMRKNestableRenderUtils {
      * @param parentId ID of the parent token
      * @param childAddress Address of the child token's colection smart contract
      * @param childId ID of the child token
-     * @return The index of the child token in the parent token's pending child tokens array
+     * @return index The index of the child token in the parent token's pending child tokens array
      */
     function getPendingChildIndex(
         address parentAddress,
         uint256 parentId,
         address childAddress,
         uint256 childId
-    ) public view returns (uint256) {
+    ) public view returns (uint256 index) {
         IERC7401.Child[] memory children = IERC7401(parentAddress)
             .pendingChildrenOf(parentId);
         (parentId);
@@ -67,7 +69,9 @@ contract RMRKNestableRenderUtils {
             if (
                 children[i].tokenId == childId &&
                 children[i].contractAddress == childAddress
-            ) return i;
+            ) {
+                return i;
+            }
             unchecked {
                 ++i;
             }
@@ -215,24 +219,23 @@ contract RMRKNestableRenderUtils {
      * @param childAddress Address of the child token's collection smart contract
      * @param parentId ID of the parent token
      * @param childId ID of the child token
-     * @return A boolean value indicating whether the child token is owned by the parent token or not
+     * @return validChild A boolean value indicating whether the child token is owned by the parent token or not
      */
     function validateChildOf(
         address parentAddress,
         address childAddress,
         uint256 parentId,
         uint256 childId
-    ) public view returns (bool) {
+    ) public view returns (bool validChild) {
         if (
             !IERC165(childAddress).supportsInterface(type(IERC7401).interfaceId)
         ) {
-            return false;
+            validChild = false;
+        } else {
+            (address directOwner, uint256 ownerId, ) = IERC7401(childAddress)
+                .directOwnerOf(childId);
+            validChild = (directOwner == parentAddress && ownerId == parentId);
         }
-
-        (address directOwner, uint256 ownerId, ) = IERC7401(childAddress)
-            .directOwnerOf(childId);
-
-        return (directOwner == parentAddress && ownerId == parentId);
     }
 
     /**
@@ -241,8 +244,8 @@ contract RMRKNestableRenderUtils {
      * @param childAddresses An array of the child token's collection smart contract addresses
      * @param parentId ID of the parent token
      * @param childIds An array of child token IDs to verify
-     * @return A boolean value indicating whether all of the child tokens are owned by the parent token or not
-     * @return An array of boolean values indicating whether each of the child tokens are owned by the parent token or
+     * @return isValid A boolean value indicating whether all of the child tokens are owned by the parent token or not
+     * @return validityOfChildren An array of boolean values indicating whether each of the child tokens are owned by the parent token or
      *  not
      */
     function validateChildrenOf(
@@ -250,15 +253,13 @@ contract RMRKNestableRenderUtils {
         address[] memory childAddresses,
         uint256 parentId,
         uint256[] memory childIds
-    ) public view returns (bool, bool[] memory) {
+    ) public view returns (bool isValid, bool[] memory validityOfChildren) {
         if (childAddresses.length != childIds.length) {
             revert RMRKMismachedArrayLength();
         }
 
-        address directOwner;
-        uint256 ownerId;
-        bool[] memory validityOfChildren = new bool[](childAddresses.length);
-        bool isValid = true;
+        validityOfChildren = new bool[](childAddresses.length);
+        isValid = true;
 
         for (uint256 i; i < childAddresses.length; ) {
             validityOfChildren[i] = validateChildOf(
@@ -272,15 +273,10 @@ contract RMRKNestableRenderUtils {
                 isValid = false;
             }
 
-            delete directOwner;
-            delete ownerId;
-
             unchecked {
                 ++i;
             }
         }
-
-        return (isValid, validityOfChildren);
     }
 
     /**
@@ -321,12 +317,12 @@ contract RMRKNestableRenderUtils {
      * @notice Used to retrieve whether a token has more than one level of nesting.
      * @param collection Address of the token's collection smart contract
      * @param tokenId ID of the token
-     * @return A boolean value indicating whether the given token has more than one level of nesting
+     * @return hasMoreThanOneLevelOfNesting_ A boolean value indicating whether the given token has more than one level of nesting
      */
     function hasMoreThanOneLevelOfNesting(
         address collection,
         uint256 tokenId
-    ) public view returns (bool) {
+    ) public view returns (bool hasMoreThanOneLevelOfNesting_) {
         IERC7401.Child[] memory children = IERC7401(collection).childrenOf(
             tokenId
         );
@@ -338,12 +334,12 @@ contract RMRKNestableRenderUtils {
                     .childrenOf(children[i].tokenId)
                     .length > 0
             ) {
-                return true;
+                hasMoreThanOneLevelOfNesting_ = true;
+                break;
             }
             unchecked {
                 ++i;
             }
         }
-        return false;
     }
 }

--- a/contracts/RMRK/utils/RMRKRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKRenderUtils.sol
@@ -2,14 +2,20 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "../access/Ownable.sol";
-import "../equippable/RMRKEquippable.sol";
-import "../extension/soulbound/RMRKSoulbound.sol";
-import "../library/RMRKLib.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {Ownable} from "../access/Ownable.sol";
+import {RMRKEquippable} from "../equippable/RMRKEquippable.sol";
+import {RMRKSoulbound} from "../extension/soulbound/RMRKSoulbound.sol";
+import {IERC6454} from "../extension/soulbound/IERC6454.sol";
+import {IERC6220} from "../equippable/IERC6220.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {IERC7401} from "../nestable/IERC7401.sol";
+
+import {RMRKLib} from "../library/RMRKLib.sol";
 import "../library/RMRKErrors.sol";
-import "./IRMRKCollectionData.sol";
+import {IRMRKCollectionData} from "./IRMRKCollectionData.sol";
 
 /**
  * @title RMRKRenderUtils

--- a/contracts/RMRK/utils/RMRKRenderUtils.sol
+++ b/contracts/RMRK/utils/RMRKRenderUtils.sol
@@ -7,15 +7,12 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import {Ownable} from "../access/Ownable.sol";
 import {RMRKEquippable} from "../equippable/RMRKEquippable.sol";
-import {RMRKSoulbound} from "../extension/soulbound/RMRKSoulbound.sol";
 import {IERC6454} from "../extension/soulbound/IERC6454.sol";
 import {IERC6220} from "../equippable/IERC6220.sol";
 import {IERC5773} from "../multiasset/IERC5773.sol";
 import {IERC7401} from "../nestable/IERC7401.sol";
-
-import {RMRKLib} from "../library/RMRKLib.sol";
-import "../library/RMRKErrors.sol";
 import {IRMRKCollectionData} from "./IRMRKCollectionData.sol";
+import "../library/RMRKErrors.sol";
 
 /**
  * @title RMRKRenderUtils

--- a/contracts/implementations/RMRKCatalogImpl.sol
+++ b/contracts/implementations/RMRKCatalogImpl.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/access/OwnableLock.sol";
-import "../RMRK/catalog/RMRKCatalog.sol";
+import {OwnableLock} from "../RMRK/access/OwnableLock.sol";
+import {RMRKCatalog} from "../RMRK/catalog/RMRKCatalog.sol";
 
 /**
  * @title RMRKCatalogImpl

--- a/contracts/implementations/abstract/RMRKAbstractEquippable.sol
+++ b/contracts/implementations/abstract/RMRKAbstractEquippable.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "../../RMRK/equippable/RMRKMinifiedEquippable.sol";
-import "../utils/RMRKImplementationBase.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {RMRKMinifiedEquippable} from "../../RMRK/equippable/RMRKMinifiedEquippable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
 
 /**
  * @title RMRKAbstractEquippable

--- a/contracts/implementations/abstract/RMRKAbstractEquippable.sol
+++ b/contracts/implementations/abstract/RMRKAbstractEquippable.sol
@@ -42,14 +42,14 @@ abstract contract RMRKAbstractEquippable is
      * @param catalogAddress Address of the `Catalog` smart contract this asset belongs to
      * @param metadataURI Metadata URI of the asset
      * @param partIds An array of IDs of fixed and slot parts to be included in the asset
-     * @return The total number of assets after this asset has been added
+     * @return assetId The ID of the newly added asset
      */
     function addEquippableAssetEntry(
         uint64 equippableGroupId,
         address catalogAddress,
         string memory metadataURI,
         uint64[] memory partIds
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 assetId) {
         unchecked {
             ++_totalAssets;
         }
@@ -60,23 +60,23 @@ abstract contract RMRKAbstractEquippable is
             metadataURI,
             partIds
         );
-        return _totalAssets;
+        assetId = _totalAssets;
     }
 
     /**
      * @notice Used to add a asset entry.
      * @dev The ID of the asset is automatically assigned to be the next available asset ID.
      * @param metadataURI Metadata URI of the asset
-     * @return ID of the newly added asset
+     * @return assetId ID of the newly added asset
      */
     function addAssetEntry(
         string memory metadataURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 assetId) {
         unchecked {
             ++_totalAssets;
         }
         _addAssetEntry(uint64(_totalAssets), metadataURI);
-        return _totalAssets;
+        assetId = _totalAssets;
     }
 
     /**

--- a/contracts/implementations/abstract/RMRKAbstractMultiAsset.sol
+++ b/contracts/implementations/abstract/RMRKAbstractMultiAsset.sol
@@ -39,16 +39,16 @@ abstract contract RMRKAbstractMultiAsset is
      * @notice Used to add a asset entry.
      * @dev The ID of the asset is automatically assigned to be the next available asset ID.
      * @param metadataURI Metadata URI of the asset
-     * @return ID of the newly added asset
+     * @return assetId The ID of the newly added asset
      */
     function addAssetEntry(
         string memory metadataURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 assetId) {
         unchecked {
             ++_totalAssets;
         }
         _addAssetEntry(uint64(_totalAssets), metadataURI);
-        return _totalAssets;
+        assetId = _totalAssets;
     }
 
     /**

--- a/contracts/implementations/abstract/RMRKAbstractMultiAsset.sol
+++ b/contracts/implementations/abstract/RMRKAbstractMultiAsset.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "../../RMRK/multiasset/RMRKMultiAsset.sol";
-import "../utils/RMRKImplementationBase.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {RMRKMultiAsset} from "../../RMRK/multiasset/RMRKMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
 
 /**
  * @title RMRKAbstractMultiAsset

--- a/contracts/implementations/abstract/RMRKAbstractNestable.sol
+++ b/contracts/implementations/abstract/RMRKAbstractNestable.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "../../RMRK/nestable/RMRKNestable.sol";
-import "../utils/RMRKImplementationBase.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {RMRKNestable} from "../../RMRK/nestable/RMRKNestable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
 
 /**
  * @title RMRKAbstractNestable

--- a/contracts/implementations/abstract/RMRKAbstractNestableMultiAsset.sol
+++ b/contracts/implementations/abstract/RMRKAbstractNestableMultiAsset.sol
@@ -39,16 +39,16 @@ abstract contract RMRKAbstractNestableMultiAsset is
      * @notice Used to add a asset entry.
      * @dev The ID of the asset is automatically assigned to be the next available asset ID.
      * @param metadataURI Metadata URI of the asset
-     * @return ID of the newly added asset
+     * @return assetId The ID of the newly added asset
      */
     function addAssetEntry(
         string memory metadataURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 assetId) {
         unchecked {
             ++_totalAssets;
         }
         _addAssetEntry(uint64(_totalAssets), metadataURI);
-        return _totalAssets;
+        assetId = _totalAssets;
     }
 
     /**

--- a/contracts/implementations/abstract/RMRKAbstractNestableMultiAsset.sol
+++ b/contracts/implementations/abstract/RMRKAbstractNestableMultiAsset.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "../../RMRK/nestable/RMRKNestableMultiAsset.sol";
-import "../utils/RMRKImplementationBase.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC2981} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {RMRKNestableMultiAsset} from "../../RMRK/nestable/RMRKNestableMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
 
 /**
  * @title RMRKAbstractNestableMultiAsset

--- a/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
@@ -2,10 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../abstract/RMRKAbstractEquippable.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataERC20Pay.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {RMRKAbstractEquippable} from "../abstract/RMRKAbstractEquippable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataERC20Pay} from "./InitDataERC20Pay.sol";
 
 /**
  * @title RMRKEquippableLazyMintErc20

--- a/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
@@ -56,12 +56,12 @@ contract RMRKEquippableLazyMintErc20 is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public virtual returns (uint256) {
+    ) public virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -74,7 +74,7 @@ contract RMRKEquippableLazyMintErc20 is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -84,13 +84,13 @@ contract RMRKEquippableLazyMintErc20 is
      * @param to Address of the collection smart contract of the token into which to mint the child token
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId
-    ) public virtual returns (uint256) {
+    ) public virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -103,7 +103,7 @@ contract RMRKEquippableLazyMintErc20 is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -121,18 +121,23 @@ contract RMRKEquippableLazyMintErc20 is
 
     /**
      * @notice Used to retrieve the address of the ERC20 token this smart contract supports.
-     * @return Address of the ERC20 token's smart contract
+     * @return erc20Token Address of the ERC20 token's smart contract
      */
-    function erc20TokenAddress() public view virtual returns (address) {
-        return _erc20TokenAddress;
+    function erc20TokenAddress()
+        public
+        view
+        virtual
+        returns (address erc20Token)
+    {
+        erc20Token = _erc20TokenAddress;
     }
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
@@ -18,8 +18,8 @@ contract RMRKEquippableLazyMintErc20 is
     RMRKTokenURIEnumerated,
     RMRKAbstractEquippable
 {
-    uint256 private _pricePerMint;
-    address private _erc20TokenAddress;
+    uint256 internal _pricePerMint;
+    address internal _erc20TokenAddress;
 
     /**
      * @notice Used to initialize the smart contract.

--- a/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol
@@ -112,7 +112,7 @@ contract RMRKEquippableLazyMintErc20 is
     function _chargeMints(uint256 numToMint) internal {
         uint256 price = numToMint * _pricePerMint;
         IERC20(_erc20TokenAddress).transferFrom(
-            msg.sender,
+            _msgSender(),
             address(this),
             price
         );

--- a/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKEquippableLazyMintErc20.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKEquippableLazyMintErc20} from "./RMRKEquippableLazyMintErc20.sol";
+import {RMRKAbstractEquippable} from "../abstract/RMRKAbstractEquippable.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKEquippableLazyMintErc20Soulbound

--- a/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
@@ -18,8 +18,8 @@ contract RMRKMultiAssetLazyMintErc20 is
     RMRKTokenURIEnumerated,
     RMRKAbstractMultiAsset
 {
-    uint256 private _pricePerMint;
-    address private _erc20TokenAddress;
+    uint256 internal _pricePerMint;
+    address internal _erc20TokenAddress;
 
     /**
      * @notice Used to initialize the smart contract.

--- a/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
@@ -2,10 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../abstract/RMRKAbstractMultiAsset.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataERC20Pay.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {RMRKAbstractMultiAsset} from "../abstract/RMRKAbstractMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataERC20Pay} from "./InitDataERC20Pay.sol";
 
 /**
  * @title RMRKMultiAssetLazyMintErc20

--- a/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
@@ -79,7 +79,7 @@ contract RMRKMultiAssetLazyMintErc20 is
     function _chargeMints(uint256 numToMint) internal {
         uint256 price = numToMint * _pricePerMint;
         IERC20(_erc20TokenAddress).transferFrom(
-            msg.sender,
+            _msgSender(),
             address(this),
             price
         );

--- a/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol
@@ -56,12 +56,12 @@ contract RMRKMultiAssetLazyMintErc20 is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -74,7 +74,7 @@ contract RMRKMultiAssetLazyMintErc20 is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     function _chargeMints(uint256 numToMint) internal {
@@ -88,18 +88,23 @@ contract RMRKMultiAssetLazyMintErc20 is
 
     /**
      * @notice Used to retrieve the address of the ERC20 token this smart contract supports.
-     * @return Address of the ERC20 token's smart contract
+     * @return erc20Token Address of the ERC20 token's smart contract
      */
-    function erc20TokenAddress() public view virtual returns (address) {
-        return _erc20TokenAddress;
+    function erc20TokenAddress()
+        public
+        view
+        virtual
+        returns (address erc20Token)
+    {
+        erc20Token = _erc20TokenAddress;
     }
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKMultiAssetLazyMintErc20.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractMultiAsset} from "../abstract/RMRKAbstractMultiAsset.sol";
+import {RMRKMultiAssetLazyMintErc20} from "./RMRKMultiAssetLazyMintErc20.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKMultiAssetLazyMintErc20Soulbound

--- a/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
@@ -108,7 +108,7 @@ contract RMRKNestableLazyMintErc20 is
     function _chargeMints(uint256 numToMint) internal {
         uint256 price = numToMint * _pricePerMint;
         IERC20(_erc20TokenAddress).transferFrom(
-            msg.sender,
+            _msgSender(),
             address(this),
             price
         );

--- a/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
@@ -56,12 +56,12 @@ contract RMRKNestableLazyMintErc20 is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -74,7 +74,7 @@ contract RMRKNestableLazyMintErc20 is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -84,13 +84,13 @@ contract RMRKNestableLazyMintErc20 is
      * @param to Address of the collection smart contract of the token into which to mint the child token
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -103,7 +103,7 @@ contract RMRKNestableLazyMintErc20 is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     function _chargeMints(uint256 numToMint) internal {
@@ -117,18 +117,23 @@ contract RMRKNestableLazyMintErc20 is
 
     /**
      * @notice Used to retrieve the address of the ERC20 token this smart contract supports.
-     * @return Address of the ERC20 token's smart contract
+     * @return erc20Token Address of the ERC20 token's smart contract
      */
-    function erc20TokenAddress() public view virtual returns (address) {
-        return _erc20TokenAddress;
+    function erc20TokenAddress()
+        public
+        view
+        virtual
+        returns (address erc20Token)
+    {
+        erc20Token = _erc20TokenAddress;
     }
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
@@ -18,8 +18,8 @@ contract RMRKNestableLazyMintErc20 is
     RMRKTokenURIEnumerated,
     RMRKAbstractNestable
 {
-    uint256 private _pricePerMint;
-    address private _erc20TokenAddress;
+    uint256 internal _pricePerMint;
+    address internal _erc20TokenAddress;
 
     /**
      * @notice Used to initialize the smart contract.

--- a/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol
@@ -2,10 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../abstract/RMRKAbstractNestable.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataERC20Pay.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {RMRKAbstractNestable} from "../abstract/RMRKAbstractNestable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataERC20Pay} from "./InitDataERC20Pay.sol";
 
 /**
  * @title RMRKNestableLazyMintErc20

--- a/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKNestableLazyMintErc20.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractNestable} from "../abstract/RMRKAbstractNestable.sol";
+import {RMRKNestableLazyMintErc20} from "./RMRKNestableLazyMintErc20.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKNestableLazyMintErc20Soulbound

--- a/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
@@ -108,7 +108,7 @@ contract RMRKNestableMultiAssetLazyMintErc20 is
     function _chargeMints(uint256 numToMint) internal {
         uint256 price = numToMint * _pricePerMint;
         IERC20(_erc20TokenAddress).transferFrom(
-            msg.sender,
+            _msgSender(),
             address(this),
             price
         );

--- a/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
@@ -2,10 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "../abstract/RMRKAbstractNestableMultiAsset.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataERC20Pay.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {RMRKAbstractNestableMultiAsset} from "../abstract/RMRKAbstractNestableMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataERC20Pay} from "./InitDataERC20Pay.sol";
 
 /**
  * @title RMRKNestableMultiAssetLazyMintErc20

--- a/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
@@ -56,12 +56,12 @@ contract RMRKNestableMultiAssetLazyMintErc20 is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -74,7 +74,7 @@ contract RMRKNestableMultiAssetLazyMintErc20 is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -84,13 +84,13 @@ contract RMRKNestableMultiAssetLazyMintErc20 is
      * @param to Address of the collection smart contract of the token into which to mint the child token
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -103,7 +103,7 @@ contract RMRKNestableMultiAssetLazyMintErc20 is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     function _chargeMints(uint256 numToMint) internal {
@@ -117,18 +117,23 @@ contract RMRKNestableMultiAssetLazyMintErc20 is
 
     /**
      * @notice Used to retrieve the address of the ERC20 token this smart contract supports.
-     * @return Address of the ERC20 token's smart contract
+     * @return erc20Token Address of the ERC20 token's smart contract
      */
-    function erc20TokenAddress() public view virtual returns (address) {
-        return _erc20TokenAddress;
+    function erc20TokenAddress()
+        public
+        view
+        virtual
+        returns (address erc20Token)
+    {
+        erc20Token = _erc20TokenAddress;
     }
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol
@@ -18,8 +18,8 @@ contract RMRKNestableMultiAssetLazyMintErc20 is
     RMRKTokenURIEnumerated,
     RMRKAbstractNestableMultiAsset
 {
-    uint256 private _pricePerMint;
-    address private _erc20TokenAddress;
+    uint256 internal _pricePerMint;
+    address internal _erc20TokenAddress;
 
     /**
      * @notice Used to initialize the smart contract.

--- a/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.sol
+++ b/contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKNestableMultiAssetLazyMintErc20.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractNestableMultiAsset} from "../abstract/RMRKAbstractNestableMultiAsset.sol";
+import {RMRKNestableMultiAssetLazyMintErc20} from "./RMRKNestableMultiAssetLazyMintErc20.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKNestableMultiAssetLazyMintErc20Soulbound

--- a/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNative.sol
@@ -54,12 +54,12 @@ contract RMRKEquippableLazyMintNative is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -72,7 +72,7 @@ contract RMRKEquippableLazyMintNative is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -82,13 +82,13 @@ contract RMRKEquippableLazyMintNative is
      * @param to Address of the collection smart contract of the token into which to mint the child token
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -101,7 +101,7 @@ contract RMRKEquippableLazyMintNative is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     function _chargeMints(uint256 numToMint) internal {
@@ -111,10 +111,10 @@ contract RMRKEquippableLazyMintNative is
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNative.sol
@@ -123,17 +123,8 @@ contract RMRKEquippableLazyMintNative is
      * @param to Address to receive the given amount of minting proceedings
      * @param amount The amount to withdraw
      */
-    function withdrawRaised(address to, uint256 amount) external onlyOwner {
-        _withdraw(to, amount);
-    }
-
-    /**
-     * @notice Used to withdraw the minting proceedings to a specified address.
-     * @param _address Address to receive the given amount of minting proceedings
-     * @param _amount The amount to withdraw
-     */
-    function _withdraw(address _address, uint256 _amount) private {
-        (bool success, ) = _address.call{value: _amount}("");
-        require(success, "Transfer failed.");
+    function withdraw(address to, uint256 amount) external onlyOwner {
+        (bool success, ) = to.call{value: amount}("");
+        if (!success) revert TransferFailed();
     }
 }

--- a/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNative.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractEquippable.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataNativePay.sol";
+import {RMRKAbstractEquippable} from "../abstract/RMRKAbstractEquippable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataNativePay} from "./InitDataNativePay.sol";
+import "../../RMRK/library/RMRKErrors.sol";
 
 /**
  * @title RMRKEquippableLazyMintNative

--- a/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.sol
+++ b/contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKEquippableLazyMintNative.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractEquippable} from "../abstract/RMRKAbstractEquippable.sol";
+import {RMRKEquippableLazyMintNative} from "./RMRKEquippableLazyMintNative.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKEquippableLazyMintNativeSoulbound

--- a/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.sol
@@ -94,17 +94,8 @@ contract RMRKMultiAssetLazyMintNative is
      * @param to Address to receive the given amount of minting proceedings
      * @param amount The amount to withdraw
      */
-    function withdrawRaised(address to, uint256 amount) external onlyOwner {
-        _withdraw(to, amount);
-    }
-
-    /**
-     * @notice Used to withdraw the minting proceedings to a specified address.
-     * @param _address Address to receive the given amount of minting proceedings
-     * @param _amount The amount to withdraw
-     */
-    function _withdraw(address _address, uint256 _amount) private {
-        (bool success, ) = _address.call{value: _amount}("");
-        require(success, "Transfer failed.");
+    function withdraw(address to, uint256 amount) external onlyOwner {
+        (bool success, ) = to.call{value: amount}("");
+        if (!success) revert TransferFailed();
     }
 }

--- a/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractMultiAsset.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataNativePay.sol";
+import {RMRKAbstractMultiAsset} from "../abstract/RMRKAbstractMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataNativePay} from "./InitDataNativePay.sol";
+import "../../RMRK/library/RMRKErrors.sol";
 
 /**
  * @title RMRKMultiAssetLazyMintNative

--- a/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.sol
@@ -54,12 +54,12 @@ contract RMRKMultiAssetLazyMintNative is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -72,7 +72,7 @@ contract RMRKMultiAssetLazyMintNative is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     function _chargeMints(uint256 numToMint) internal {
@@ -82,10 +82,10 @@ contract RMRKMultiAssetLazyMintNative is
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.sol
+++ b/contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKMultiAssetLazyMintNative.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractMultiAsset} from "../abstract/RMRKAbstractMultiAsset.sol";
+import {RMRKMultiAssetLazyMintNative} from "./RMRKMultiAssetLazyMintNative.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKMultiAssetLazyMintNativeSoulbound

--- a/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNative.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractNestable.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataNativePay.sol";
+import {RMRKAbstractNestable} from "../abstract/RMRKAbstractNestable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataNativePay} from "./InitDataNativePay.sol";
+import "../../RMRK/library/RMRKErrors.sol";
 
 /**
  * @title RMRKNestableLazyMintNative

--- a/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNative.sol
@@ -123,17 +123,8 @@ contract RMRKNestableLazyMintNative is
      * @param to Address to receive the given amount of minting proceedings
      * @param amount The amount to withdraw
      */
-    function withdrawRaised(address to, uint256 amount) external onlyOwner {
-        _withdraw(to, amount);
-    }
-
-    /**
-     * @notice Used to withdraw the minting proceedings to a specified address.
-     * @param _address Address to receive the given amount of minting proceedings
-     * @param _amount The amount to withdraw
-     */
-    function _withdraw(address _address, uint256 _amount) private {
-        (bool success, ) = _address.call{value: _amount}("");
-        require(success, "Transfer failed.");
+    function withdraw(address to, uint256 amount) external onlyOwner {
+        (bool success, ) = to.call{value: amount}("");
+        if (!success) revert TransferFailed();
     }
 }

--- a/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNative.sol
@@ -54,12 +54,12 @@ contract RMRKNestableLazyMintNative is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -72,7 +72,7 @@ contract RMRKNestableLazyMintNative is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -82,13 +82,13 @@ contract RMRKNestableLazyMintNative is
      * @param to Address of the collection smart contract of the token into which to mint the child token
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -101,7 +101,7 @@ contract RMRKNestableLazyMintNative is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     function _chargeMints(uint256 numToMint) internal {
@@ -111,10 +111,10 @@ contract RMRKNestableLazyMintNative is
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKNestableLazyMintNative.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractNestable} from "../abstract/RMRKAbstractNestable.sol";
+import {RMRKNestableLazyMintNative} from "./RMRKNestableLazyMintNative.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKNestableLazyMintNativeSoulbound

--- a/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.sol
@@ -136,17 +136,8 @@ contract RMRKNestableMultiAssetLazyMintNative is
      * @param to Address to receive the given amount of minting proceedings
      * @param amount The amount to withdraw
      */
-    function withdrawRaised(address to, uint256 amount) external onlyOwner {
-        _withdraw(to, amount);
-    }
-
-    /**
-     * @notice Used to withdraw the minting proceedings to a specified address.
-     * @param _address Address to receive the given amount of minting proceedings
-     * @param _amount The amount to withdraw
-     */
-    function _withdraw(address _address, uint256 _amount) private {
-        (bool success, ) = _address.call{value: _amount}("");
-        require(success, "Transfer failed.");
+    function withdraw(address to, uint256 amount) external onlyOwner {
+        (bool success, ) = to.call{value: amount}("");
+        if (!success) revert TransferFailed();
     }
 }

--- a/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.sol
@@ -67,12 +67,12 @@ contract RMRKNestableMultiAssetLazyMintNative is
      * @dev Can only be called while the open sale is open.
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -85,7 +85,7 @@ contract RMRKNestableMultiAssetLazyMintNative is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -95,13 +95,13 @@ contract RMRKNestableMultiAssetLazyMintNative is
      * @param to Address of the collection smart contract of the token into which to mint the child token
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId
-    ) public payable virtual returns (uint256) {
+    ) public payable virtual returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -114,7 +114,7 @@ contract RMRKNestableMultiAssetLazyMintNative is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     function _chargeMints(uint256 numToMint) internal {
@@ -124,10 +124,10 @@ contract RMRKNestableMultiAssetLazyMintNative is
 
     /**
      * @notice Used to retrieve the price per mint.
-     * @return The price per mint of a single token expressed in the lowest denomination of a native currency
+     * @return price The price per mint of a single token expressed in the lowest denomination of a native currency
      */
-    function pricePerMint() public view returns (uint256) {
-        return _pricePerMint;
+    function pricePerMint() public view returns (uint256 price) {
+        price = _pricePerMint;
     }
 
     /**

--- a/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.sol
@@ -2,9 +2,11 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractNestableMultiAsset.sol";
-import "../utils/RMRKTokenURIEnumerated.sol";
-import "./InitDataNativePay.sol";
+import {RMRKAbstractNestableMultiAsset} from "../abstract/RMRKAbstractNestableMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIEnumerated} from "../utils/RMRKTokenURIEnumerated.sol";
+import {InitDataNativePay} from "./InitDataNativePay.sol";
+import "../../RMRK/library/RMRKErrors.sol";
 
 /**
  * @title RMRKNestableMultiAssetLazyMintNative

--- a/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.sol
+++ b/contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKNestableMultiAssetLazyMintNative.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractNestableMultiAsset} from "../abstract/RMRKAbstractNestableMultiAsset.sol";
+import {RMRKNestableMultiAssetLazyMintNative} from "./RMRKNestableMultiAssetLazyMintNative.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKNestableMultiAssetLazyMintNativeSoulbound

--- a/contracts/implementations/premint/RMRKEquippablePreMint.sol
+++ b/contracts/implementations/premint/RMRKEquippablePreMint.sol
@@ -46,13 +46,13 @@ contract RMRKEquippablePreMint is RMRKTokenURIPerToken, RMRKAbstractEquippable {
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
      * @param tokenURI URI assigned to all the minted tokens
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint,
         string memory tokenURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -65,7 +65,7 @@ contract RMRKEquippablePreMint is RMRKTokenURIPerToken, RMRKAbstractEquippable {
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -76,14 +76,14 @@ contract RMRKEquippablePreMint is RMRKTokenURIPerToken, RMRKAbstractEquippable {
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
      * @param tokenURI URI assigned to all the minted tokens
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId,
         string memory tokenURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -96,6 +96,6 @@ contract RMRKEquippablePreMint is RMRKTokenURIPerToken, RMRKAbstractEquippable {
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 }

--- a/contracts/implementations/premint/RMRKEquippablePreMint.sol
+++ b/contracts/implementations/premint/RMRKEquippablePreMint.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractEquippable.sol";
-import "../utils/RMRKTokenURIPerToken.sol";
+import {RMRKAbstractEquippable} from "../abstract/RMRKAbstractEquippable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIPerToken} from "../utils/RMRKTokenURIPerToken.sol";
 
 /**
  * @title RMRKEquippablePreMint

--- a/contracts/implementations/premint/RMRKEquippablePreMintSoulbound.sol
+++ b/contracts/implementations/premint/RMRKEquippablePreMintSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKEquippablePreMint.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractEquippable} from "../abstract/RMRKAbstractEquippable.sol";
+import {RMRKEquippablePreMint} from "./RMRKEquippablePreMint.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKEquippablePreMintSoulbound

--- a/contracts/implementations/premint/RMRKMultiAssetPreMint.sol
+++ b/contracts/implementations/premint/RMRKMultiAssetPreMint.sol
@@ -46,13 +46,13 @@ contract RMRKMultiAssetPreMint is RMRKTokenURIPerToken, RMRKAbstractMultiAsset {
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
      * @param tokenURI URI assigned to all the minted tokens
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint,
         string memory tokenURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -65,6 +65,6 @@ contract RMRKMultiAssetPreMint is RMRKTokenURIPerToken, RMRKAbstractMultiAsset {
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 }

--- a/contracts/implementations/premint/RMRKMultiAssetPreMint.sol
+++ b/contracts/implementations/premint/RMRKMultiAssetPreMint.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractMultiAsset.sol";
-import "../utils/RMRKTokenURIPerToken.sol";
+import {RMRKAbstractMultiAsset} from "../abstract/RMRKAbstractMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIPerToken} from "../utils/RMRKTokenURIPerToken.sol";
 
 /**
  * @title RMRKMultiAssetPreMint

--- a/contracts/implementations/premint/RMRKMultiAssetPreMintSoulbound.sol
+++ b/contracts/implementations/premint/RMRKMultiAssetPreMintSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKMultiAssetPreMint.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractMultiAsset} from "../abstract/RMRKAbstractMultiAsset.sol";
+import {RMRKMultiAssetPreMint} from "./RMRKMultiAssetPreMint.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKMultiAssetPreMintSoulbound

--- a/contracts/implementations/premint/RMRKNestableMultiAssetPreMint.sol
+++ b/contracts/implementations/premint/RMRKNestableMultiAssetPreMint.sol
@@ -49,13 +49,13 @@ contract RMRKNestableMultiAssetPreMint is
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
      * @param tokenURI URI assigned to all the minted tokens
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint,
         string memory tokenURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -68,7 +68,7 @@ contract RMRKNestableMultiAssetPreMint is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -79,14 +79,14 @@ contract RMRKNestableMultiAssetPreMint is
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
      * @param tokenURI URI assigned to all the minted tokens
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId,
         string memory tokenURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -99,6 +99,6 @@ contract RMRKNestableMultiAssetPreMint is
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 }

--- a/contracts/implementations/premint/RMRKNestableMultiAssetPreMint.sol
+++ b/contracts/implementations/premint/RMRKNestableMultiAssetPreMint.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractNestableMultiAsset.sol";
-import "../utils/RMRKTokenURIPerToken.sol";
+import {RMRKAbstractNestableMultiAsset} from "../abstract/RMRKAbstractNestableMultiAsset.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIPerToken} from "../utils/RMRKTokenURIPerToken.sol";
 
 /**
  * @title RMRKNestableMultiAssetPreMint

--- a/contracts/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.sol
+++ b/contracts/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKNestableMultiAssetPreMint.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractNestableMultiAsset} from "../abstract/RMRKAbstractNestableMultiAsset.sol";
+import {RMRKNestableMultiAssetPreMint} from "./RMRKNestableMultiAssetPreMint.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKNestableMultiAssetPreMintSoulbound

--- a/contracts/implementations/premint/RMRKNestablePreMint.sol
+++ b/contracts/implementations/premint/RMRKNestablePreMint.sol
@@ -46,13 +46,13 @@ contract RMRKNestablePreMint is RMRKTokenURIPerToken, RMRKAbstractNestable {
      * @param to Address to which to mint the token
      * @param numToMint Number of tokens to mint
      * @param tokenURI URI assigned to all the minted tokens
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function mint(
         address to,
         uint256 numToMint,
         string memory tokenURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -65,7 +65,7 @@ contract RMRKNestablePreMint is RMRKTokenURIPerToken, RMRKAbstractNestable {
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 
     /**
@@ -76,14 +76,14 @@ contract RMRKNestablePreMint is RMRKTokenURIPerToken, RMRKAbstractNestable {
      * @param numToMint Number of tokens to mint
      * @param destinationId ID of the token into which to mint the new child token
      * @param tokenURI URI assigned to all the minted tokens
-     * @return The ID of the first token to be minted in the current minting cycle
+     * @return firstTokenId The ID of the first token to be minted in the current minting cycle
      */
     function nestMint(
         address to,
         uint256 numToMint,
         uint256 destinationId,
         string memory tokenURI
-    ) public virtual onlyOwnerOrContributor returns (uint256) {
+    ) public virtual onlyOwnerOrContributor returns (uint256 firstTokenId) {
         (uint256 nextToken, uint256 totalSupplyOffset) = _prepareMint(
             numToMint
         );
@@ -96,6 +96,6 @@ contract RMRKNestablePreMint is RMRKTokenURIPerToken, RMRKAbstractNestable {
             }
         }
 
-        return nextToken;
+        firstTokenId = nextToken;
     }
 }

--- a/contracts/implementations/premint/RMRKNestablePreMint.sol
+++ b/contracts/implementations/premint/RMRKNestablePreMint.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../abstract/RMRKAbstractNestable.sol";
-import "../utils/RMRKTokenURIPerToken.sol";
+import {RMRKAbstractNestable} from "../abstract/RMRKAbstractNestable.sol";
+import {RMRKImplementationBase} from "../utils/RMRKImplementationBase.sol";
+import {RMRKTokenURIPerToken} from "../utils/RMRKTokenURIPerToken.sol";
 
 /**
  * @title RMRKNestablePreMint

--- a/contracts/implementations/premint/RMRKNestablePreMintSoulbound.sol
+++ b/contracts/implementations/premint/RMRKNestablePreMintSoulbound.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "./RMRKNestablePreMint.sol";
-import "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {RMRKAbstractNestable} from "../abstract/RMRKAbstractNestable.sol";
+import {RMRKNestablePreMint} from "./RMRKNestablePreMint.sol";
+import {RMRKSoulbound} from "../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 /**
  * @title RMRKNestablePreMintSoulbound

--- a/contracts/implementations/utils/RMRKImplementationBase.sol
+++ b/contracts/implementations/utils/RMRKImplementationBase.sol
@@ -46,50 +46,55 @@ abstract contract RMRKImplementationBase is RMRKRoyalties, Ownable {
 
     /**
      * @notice Used to retrieve the total supply of the tokens in a collection.
-     * @return The number of tokens in a collection
+     * @return totalSupply_ The number of tokens in a collection
      */
-    function totalSupply() public view virtual returns (uint256) {
-        return _totalSupply;
+    function totalSupply() public view virtual returns (uint256 totalSupply_) {
+        totalSupply_ = _totalSupply;
     }
 
     /**
      * @notice Used to retrieve the maximum supply of the collection.
-     * @return The maximum supply of tokens in the collection
+     * @return maxSupply_ The maximum supply of tokens in the collection
      */
-    function maxSupply() public view virtual returns (uint256) {
-        return _maxSupply;
+    function maxSupply() public view virtual returns (uint256 maxSupply_) {
+        maxSupply_ = _maxSupply;
     }
 
     /**
      * @notice Used to retrieve the total number of assets.
-     * @return The total number of assets
+     * @return totalAssets_ The total number of assets
      */
-    function totalAssets() public view virtual returns (uint256) {
-        return _totalAssets;
+    function totalAssets() public view virtual returns (uint256 totalAssets_) {
+        totalAssets_ = _totalAssets;
     }
 
     /**
-     * @notice Used to retrieve the metadata of the collection.
-     * @return string The metadata URI of the collection
+     * @notice Used to retrieve the metadata URI of the collection.
+     * @return contractURI_ string The metadata URI of the collection
      */
-    function contractURI() public view virtual returns (string memory) {
-        return _collectionMetadata;
+    function contractURI()
+        public
+        view
+        virtual
+        returns (string memory contractURI_)
+    {
+        contractURI_ = _collectionMetadata;
     }
 
     /**
      * @notice Used to retrieve the collection name.
-     * @return Name of the collection
+     * @return name_ Name of the collection
      */
-    function name() public view virtual returns (string memory) {
-        return _name;
+    function name() public view virtual returns (string memory name_) {
+        name_ = _name;
     }
 
     /**
      * @notice Used to retrieve the collection symbol.
-     * @return Symbol of the collection
+     * @return symbol_ Symbol of the collection
      */
-    function symbol() public view virtual returns (string memory) {
-        return _symbol;
+    function symbol() public view virtual returns (string memory symbol_) {
+        symbol_ = _symbol;
     }
 
     /**

--- a/contracts/implementations/utils/RMRKImplementationBase.sol
+++ b/contracts/implementations/utils/RMRKImplementationBase.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.21;
 
-import "../../RMRK/access/Ownable.sol";
+import {Ownable} from "../../RMRK/access/Ownable.sol";
 import "../../RMRK/library/RMRKErrors.sol";
-import "../../RMRK/extension/RMRKRoyalties.sol";
+import {RMRKRoyalties} from "../../RMRK/extension/RMRKRoyalties.sol";
 
 /**
  * @title RMRKImplementationBase

--- a/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
+++ b/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.21;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 
 error InvalidInput();
 error FailedToSend();
@@ -13,7 +14,7 @@ error OnlyBeneficiary();
  * @notice Smart contract of the RMRK Royalties Spliter module.
  * @dev This smart contract provides a simple way to share royalties from either native or erc20 payments.
  */
-contract RMRKRoyaltiesSplitter {
+contract RMRKRoyaltiesSplitter is Context {
     event NativePaymentDistributed(address indexed sender, uint256 amount);
     event ERCPaymentDistributed(
         address indexed sender,
@@ -70,7 +71,7 @@ contract RMRKRoyaltiesSplitter {
             }
         }
 
-        emit NativePaymentDistributed(msg.sender, msg.value);
+        emit NativePaymentDistributed(_msgSender(), msg.value);
     }
 
     /**
@@ -85,7 +86,7 @@ contract RMRKRoyaltiesSplitter {
 
         bool callerIsBeneficiary;
         for (uint256 i; i < length; ) {
-            if (_beneficiaries[i] == msg.sender) {
+            if (_beneficiaries[i] == _msgSender()) {
                 callerIsBeneficiary = true;
                 break;
             }
@@ -111,7 +112,7 @@ contract RMRKRoyaltiesSplitter {
             }
         }
 
-        emit ERCPaymentDistributed(msg.sender, currency, amount);
+        emit ERCPaymentDistributed(_msgSender(), currency, amount);
     }
 
     /**

--- a/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
+++ b/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 
 error InvalidInput();
 error FailedToSend();

--- a/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
+++ b/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
@@ -34,7 +34,7 @@ contract RMRKRoyaltiesSplitter is Context {
     constructor(address[] memory beneficiaries, uint256[] memory sharesBps) {
         uint256 length = beneficiaries.length;
         if (length != sharesBps.length) revert InvalidInput();
-        uint256 totalShares = 0;
+        uint256 totalShares;
 
         for (uint256 i; i < length; ) {
             _beneficiaries.push(beneficiaries[i]);

--- a/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
+++ b/contracts/implementations/utils/RMRKRoyaltiesSplitter.sol
@@ -22,7 +22,7 @@ contract RMRKRoyaltiesSplitter is Context {
         uint256 amount
     );
 
-    uint256 constant MAX_BPS = 10000;
+    uint256 public constant MAX_BPS = 10000;
     address[] private _beneficiaries;
     mapping(address => uint256) private _sharesBps;
 

--- a/contracts/implementations/utils/RMRKTokenURIEnumerated.sol
+++ b/contracts/implementations/utils/RMRKTokenURIEnumerated.sol
@@ -21,11 +21,11 @@ contract RMRKTokenURIEnumerated {
     /**
      * @notice Used to retrieve the metadata URI of a token.
      * @param tokenId ID of the token to retrieve the metadata URI for
-     * @return Metadata URI of the specified token
+     * @return tokenURI_ Metadata URI of the specified token
      */
     function tokenURI(
         uint256 tokenId
-    ) public view virtual returns (string memory) {
-        return string(abi.encodePacked(_baseTokenURI, tokenId.toString()));
+    ) public view virtual returns (string memory tokenURI_) {
+        tokenURI_ = string(abi.encodePacked(_baseTokenURI, tokenId.toString()));
     }
 }

--- a/contracts/implementations/utils/RMRKTokenURIEnumerated.sol
+++ b/contracts/implementations/utils/RMRKTokenURIEnumerated.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/Strings.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
 /**
  * @title RMRKTokenURIEnumerated

--- a/contracts/implementations/utils/RMRKTokenURIPerToken.sol
+++ b/contracts/implementations/utils/RMRKTokenURIPerToken.sol
@@ -13,12 +13,12 @@ contract RMRKTokenURIPerToken {
     /**
      * @notice Used to retrieve the metadata URI of a token.
      * @param tokenId ID of the token to retrieve the metadata URI for
-     * @return Metadata URI of the specified token
+     * @return tokenURI_ Metadata URI of the specified token
      */
     function tokenURI(
         uint256 tokenId
-    ) public view virtual returns (string memory) {
-        return _tokenURIs[tokenId];
+    ) public view virtual returns (string memory tokenURI_) {
+        tokenURI_ = _tokenURIs[tokenId];
     }
 
     /**

--- a/contracts/mocks/ERC1155Mock.sol
+++ b/contracts/mocks/ERC1155Mock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 
 /**
  * @title ERC1155Mock

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract ERC20Mock is ERC20 {
     constructor() ERC20("Test Token", "TEST") {}

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 /**
  * @title ERC721Mock

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -15,6 +15,6 @@ contract ERC721Mock is ERC721 {
     ) ERC721(name, symbol) {}
 
     function mint(address to, uint256 tokenId) public {
-        _mint(to, tokenId);
+        _safeMint(to, tokenId);
     }
 }

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -12,14 +12,19 @@ contract ERC721ReceiverMock is IERC721Receiver {
         Panic
     }
 
-    bytes4 internal immutable _retval;
-    Error internal immutable _error;
+    bytes4 internal immutable _RET_VAL;
+    Error internal immutable _ERROR;
 
-    event Received(address operator, address from, uint256 tokenId, bytes data);
+    event Received(
+        address indexed operator,
+        address indexed from,
+        uint256 indexed tokenId,
+        bytes data
+    );
 
     constructor(bytes4 retval, Error error) {
-        _retval = retval;
-        _error = error;
+        _RET_VAL = retval;
+        _ERROR = error;
     }
 
     function onERC721Received(
@@ -28,15 +33,15 @@ contract ERC721ReceiverMock is IERC721Receiver {
         uint256 tokenId,
         bytes memory data
     ) public override returns (bytes4) {
-        if (_error == Error.RevertWithMessage) {
+        if (_ERROR == Error.RevertWithMessage) {
             revert("ERC721ReceiverMock: reverting");
-        } else if (_error == Error.RevertWithoutMessage) {
+        } else if (_ERROR == Error.RevertWithoutMessage) {
             revert();
-        } else if (_error == Error.Panic) {
+        } else if (_ERROR == Error.Panic) {
             uint256 a = uint256(0) / uint256(0);
             a;
         }
         emit Received(operator, from, tokenId, data);
-        return _retval;
+        return _RET_VAL;
     }
 }

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 contract ERC721ReceiverMock is IERC721Receiver {
     enum Error {

--- a/contracts/mocks/OwnableLockMock.sol
+++ b/contracts/mocks/OwnableLockMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/access/OwnableLock.sol";
+import {OwnableLock} from "../RMRK/access/OwnableLock.sol";
 
 contract OwnableLockMock is OwnableLock {
     function testLock() external view notLocked returns (bool) {

--- a/contracts/mocks/OwnableMintableERC721Mock.sol
+++ b/contracts/mocks/OwnableMintableERC721Mock.sol
@@ -5,7 +5,11 @@ pragma solidity ^0.8.21;
 /// @dev This mock smart contract is intended to be used with `@defi-wonderland/smock` and doesn't need any business
 ///  logic.
 contract OwnableMintableERC721Mock {
-    function owner() public returns (address) {}
+    function owner() public returns (address) {
+        return address(0);
+    }
 
-    function ownerOf(uint256 tokenId) public returns (address) {}
+    function ownerOf(uint256 tokenId) public returns (address) {
+        return address(0);
+    }
 }

--- a/contracts/mocks/RMRKEquippableMock.sol
+++ b/contracts/mocks/RMRKEquippableMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/equippable/RMRKEquippable.sol";
+import {RMRKEquippable} from "../RMRK/equippable/RMRKEquippable.sol";
 
 //Minimal public implementation of RMRKEquippable for testing.
 contract RMRKEquippableMock is RMRKEquippable {

--- a/contracts/mocks/RMRKImplementationBaseMock.sol
+++ b/contracts/mocks/RMRKImplementationBaseMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../implementations/utils/RMRKImplementationBase.sol";
+import {RMRKImplementationBase} from "../implementations/utils/RMRKImplementationBase.sol";
 
 contract RMRKImplementationBaseMock is RMRKImplementationBase {
     constructor(

--- a/contracts/mocks/RMRKImplementationBaseMock.sol
+++ b/contracts/mocks/RMRKImplementationBaseMock.sol
@@ -21,7 +21,7 @@ contract RMRKImplementationBaseMock is RMRKImplementationBase {
         )
     {}
 
-    function mockMint(uint256 total) external payable {
+    function mockMint(uint256 total) external {
         _prepareMint(total);
     }
 }

--- a/contracts/mocks/RMRKMinifiedEquippableMock.sol
+++ b/contracts/mocks/RMRKMinifiedEquippableMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/equippable/RMRKMinifiedEquippable.sol";
+import {RMRKMinifiedEquippable} from "../RMRK/equippable/RMRKMinifiedEquippable.sol";
 
 //Minimal public implementation of RMRKEquippable for testing.
 contract RMRKMinifiedEquippableMock is RMRKMinifiedEquippable {

--- a/contracts/mocks/RMRKMultiAssetAutoIndexMock.sol
+++ b/contracts/mocks/RMRKMultiAssetAutoIndexMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol";
+import {RMRKMultiAssetAutoIndex} from "../RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol";
 
 contract RMRKMultiAssetAutoIndexMock is RMRKMultiAssetAutoIndex {
     function mint(address to, uint256 tokenId) external {

--- a/contracts/mocks/RMRKMultiAssetMock.sol
+++ b/contracts/mocks/RMRKMultiAssetMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/multiasset/RMRKMultiAsset.sol";
+import {RMRKMultiAsset} from "../RMRK/multiasset/RMRKMultiAsset.sol";
 
 contract RMRKMultiAssetMock is RMRKMultiAsset {
     function mint(address to, uint256 tokenId) external {

--- a/contracts/mocks/RMRKNestableAutoIndexMock.sol
+++ b/contracts/mocks/RMRKNestableAutoIndexMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.sol";
+import {RMRKNestableAutoIndex} from "../RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.sol";
 
 contract RMRKNestableAutoIndexMock is RMRKNestableAutoIndex {
     function mint(address to, uint256 tokenId) external {

--- a/contracts/mocks/RMRKNestableMock.sol
+++ b/contracts/mocks/RMRKNestableMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/nestable/RMRKNestable.sol";
+import {RMRKNestable} from "../RMRK/nestable/RMRKNestable.sol";
 
 //Minimal public implementation of IERC7401 for testing.
 contract RMRKNestableMock is RMRKNestable {

--- a/contracts/mocks/RMRKNestableMultiAssetMock.sol
+++ b/contracts/mocks/RMRKNestableMultiAssetMock.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/nestable/RMRKNestableMultiAsset.sol";
+import {RMRKNestableMultiAsset} from "../RMRK/nestable/RMRKNestableMultiAsset.sol";
 
 //Minimal public implementation of RMRKNestableMultiAsset for testing.
 contract RMRKNestableMultiAssetMock is RMRKNestableMultiAsset {

--- a/contracts/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.sol
+++ b/contracts/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.sol
@@ -6,8 +6,6 @@ import {RMRKReclaimableChild} from "../../../RMRK/extension/reclaimableChild/RMR
 import {RMRKNestableMock} from "../../RMRKNestableMock.sol";
 import {RMRKNestable} from "../../../RMRK/nestable/RMRKNestable.sol";
 
-error RMRKTokenHasNoAssetsWithType();
-
 contract RMRKNestableClaimableChildMock is
     RMRKNestableMock,
     RMRKReclaimableChild

--- a/contracts/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.sol
+++ b/contracts/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol";
-import "../../RMRKNestableMock.sol";
+import {RMRKReclaimableChild} from "../../../RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol";
+import {RMRKNestableMock} from "../../RMRKNestableMock.sol";
+import {RMRKNestable} from "../../../RMRK/nestable/RMRKNestable.sol";
 
 error RMRKTokenHasNoAssetsWithType();
 

--- a/contracts/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.sol
+++ b/contracts/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/revealable/RMRKRevealable.sol";
-import "../../RMRKMultiAssetMock.sol";
+import {IRMRKRevealable} from "../../../RMRK/extension/revealable/IRMRKRevealable.sol";
+import {RMRKRevealable} from "../../../RMRK/extension/revealable/RMRKRevealable.sol";
+import {RMRKMultiAssetMock} from "../../RMRKMultiAssetMock.sol";
+import {RMRKMultiAsset} from "../../../RMRK/multiasset/RMRKMultiAsset.sol";
 
 contract RMRKMultiAssetRevealableMock is RMRKMultiAssetMock, RMRKRevealable {
     function supportsInterface(

--- a/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
+++ b/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
@@ -2,13 +2,14 @@
 
 pragma solidity ^0.8.21;
 
+import "@openzeppelin/contracts/utils/Context.sol";
 import "../../../RMRK/extension/revealable/IRMRKRevealer.sol";
 import "../../RMRKMultiAssetMock.sol";
 
 error AlreadyRevealed(uint256 tokenId);
 error CallerIsNotRevealable();
 
-contract RMRKRevealerMock is IRMRKRevealer {
+contract RMRKRevealerMock is IRMRKRevealer, Context {
     uint64 private _revealedAssetId;
     address private _revealableContract;
     mapping(uint256 tokenId => bool revealed) private _revealed;
@@ -52,7 +53,7 @@ contract RMRKRevealerMock is IRMRKRevealer {
             uint64[] memory assetsToReplaceIds
         )
     {
-        if (msg.sender != _revealableContract) {
+        if (_msgSender() != _revealableContract) {
             revert CallerIsNotRevealable();
         }
         uint256 length = tokenIds.length;
@@ -64,7 +65,7 @@ contract RMRKRevealerMock is IRMRKRevealer {
                 revert AlreadyRevealed(tokenId);
             }
             _revealed[tokenId] = true;
-            uint64[] memory activeAssets = RMRKMultiAssetMock(msg.sender)
+            uint64[] memory activeAssets = RMRKMultiAssetMock(_msgSender())
                 .getActiveAssets(tokenId);
             // Asumes that the token has at least one asset
             revealedAssetsIds[i] = _revealedAssetId;

--- a/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
+++ b/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/utils/Context.sol";
-import "../../../RMRK/extension/revealable/IRMRKRevealer.sol";
-import "../../RMRKMultiAssetMock.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {IRMRKRevealer} from "../../../RMRK/extension/revealable/IRMRKRevealer.sol";
+import {RMRKMultiAssetMock} from "../../RMRKMultiAssetMock.sol";
 
 error AlreadyRevealed(uint256 tokenId);
 error CallerIsNotRevealable();

--- a/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
+++ b/contracts/mocks/extensions/revealable/RMRKRevealerMock.sol
@@ -21,8 +21,8 @@ contract RMRKRevealerMock is IRMRKRevealer, Context {
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual returns (bool) {
-        return interfaceId == type(IRMRKRevealer).interfaceId;
+    ) public view virtual returns (bool supportsInterface_) {
+        supportsInterface_ = interfaceId == type(IRMRKRevealer).interfaceId;
     }
 
     /**-

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol
@@ -2,9 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
-// import "../../../RMRK/equippable/RMRKEquippable.sol";
-import "../../RMRKEquippableMock.sol";
+import {RMRKSoulbound} from "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {RMRKNestable} from "../../../RMRK/nestable/RMRKNestable.sol";
+import {RMRKEquippable} from "../../../RMRK/equippable/RMRKEquippable.sol";
+import {RMRKEquippableMock} from "../../RMRKEquippableMock.sol";
 
 contract RMRKSoulboundEquippableMock is RMRKSoulbound, RMRKEquippableMock {
     function supportsInterface(

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
-import "../../RMRKMultiAssetMock.sol";
+import {RMRKSoulbound} from "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {RMRKMultiAsset} from "../../../RMRK/multiasset/RMRKMultiAsset.sol";
+import {RMRKMultiAssetMock} from "../../RMRKMultiAssetMock.sol";
 
 contract RMRKSoulboundMultiAssetMock is RMRKSoulbound, RMRKMultiAssetMock {
     function supportsInterface(

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestableMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestableMock.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
-import "../../RMRKNestableMock.sol";
+import {RMRKSoulbound} from "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {RMRKNestable} from "../../../RMRK/nestable/RMRKNestable.sol";
+import {RMRKNestableMock} from "../../RMRKNestableMock.sol";
 
 contract RMRKSoulboundNestableMock is RMRKSoulbound, RMRKNestableMock {
     function supportsInterface(

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
-import "../../RMRKNestableMultiAssetMock.sol";
+import {RMRKSoulbound} from "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
+import {RMRKNestable} from "../../../RMRK/nestable/RMRKNestable.sol";
+import {RMRKNestableMultiAsset} from "../../../RMRK/nestable/RMRKNestableMultiAsset.sol";
+import {RMRKNestableMultiAssetMock} from "../../RMRKNestableMultiAssetMock.sol";
 
 contract RMRKSoulboundNestableMultiAssetMock is
     RMRKSoulbound,

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundVariantMocks.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundVariantMocks.sol
@@ -14,8 +14,6 @@ contract RMRKSoulboundAfterBlockNumberMock is
     RMRKSoulboundAfterBlockNumber,
     RMRKMultiAssetMock
 {
-    mapping(uint256 => bool) soulboundExempt;
-
     constructor(
         uint256 lastBlockToTransfer
     ) RMRKSoulboundAfterBlockNumber(lastBlockToTransfer) {}
@@ -48,8 +46,6 @@ contract RMRKSoulboundAfterTransactionsMock is
     RMRKSoulboundAfterTransactions,
     RMRKMultiAssetMock
 {
-    mapping(uint256 => bool) soulboundExempt;
-
     constructor(
         uint256 numberOfTransfers
     ) RMRKSoulboundAfterTransactions(numberOfTransfers) {}
@@ -96,8 +92,6 @@ contract RMRKSoulboundPerTokenMock is
     RMRKMultiAssetMock,
     Ownable
 {
-    mapping(uint256 => bool) soulboundExempt;
-
     function supportsInterface(
         bytes4 interfaceId
     )

--- a/contracts/mocks/extensions/soulbound/RMRKSoulboundVariantMocks.sol
+++ b/contracts/mocks/extensions/soulbound/RMRKSoulboundVariantMocks.sol
@@ -2,11 +2,13 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/access/Ownable.sol";
-import "../../../RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol";
-import "../../../RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol";
-import "../../../RMRK/extension/soulbound/RMRKSoulboundPerToken.sol";
-import "../../RMRKMultiAssetMock.sol";
+import {Ownable} from "../../../RMRK/access/Ownable.sol";
+import {RMRKSoulboundAfterBlockNumber} from "../../../RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol";
+import {RMRKSoulboundAfterTransactions} from "../../../RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol";
+import {RMRKMultiAsset} from "../../../RMRK/multiasset/RMRKMultiAsset.sol";
+import {RMRKSoulboundPerToken} from "../../../RMRK/extension/soulbound/RMRKSoulboundPerToken.sol";
+import {RMRKMultiAssetMock} from "../../RMRKMultiAssetMock.sol";
+import {RMRKSoulbound} from "../../../RMRK/extension/soulbound/RMRKSoulbound.sol";
 
 contract RMRKSoulboundAfterBlockNumberMock is
     RMRKSoulboundAfterBlockNumber,

--- a/contracts/mocks/extensions/tokenHolder/RMRKTokenHolderMock.sol
+++ b/contracts/mocks/extensions/tokenHolder/RMRKTokenHolderMock.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.21;
-import "../../../RMRK/extension/tokenHolder/RMRKTokenHolder.sol";
+
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "../../../RMRK/extension/tokenHolder/RMRKTokenHolder.sol";
 
 error OnlyNFTOwnerCanTransferTokensFromIt();
 error OnlyNFTOwnerCanTransferTokensToIt();
@@ -63,7 +64,7 @@ contract RMRKTokenHolderMock is RMRKTokenHolder, ERC721 {
         address to,
         bytes memory data
     ) external {
-        if (msg.sender != ownerOf(tokenId)) {
+        if (_msgSender() != ownerOf(tokenId)) {
             revert OnlyNFTOwnerCanTransferTokensFromIt();
         }
         _transferHeldTokenFromToken(

--- a/contracts/mocks/extensions/tokenHolder/RMRKTokenHolderMock.sol
+++ b/contracts/mocks/extensions/tokenHolder/RMRKTokenHolderMock.sol
@@ -7,7 +7,6 @@ import {RMRKTokenHolder} from "../../../RMRK/extension/tokenHolder/RMRKTokenHold
 import {IRMRKTokenHolder} from "../../../RMRK/extension/tokenHolder/IRMRKTokenHolder.sol";
 
 error OnlyNFTOwnerCanTransferTokensFromIt();
-error OnlyNFTOwnerCanTransferTokensToIt();
 
 /**
  * @title RMRKTokenHolderMock
@@ -21,7 +20,7 @@ contract RMRKTokenHolderMock is RMRKTokenHolder, ERC721 {
     ) ERC721(name, symbol) {}
 
     function mint(address to, uint256 tokenId) public {
-        _mint(to, tokenId);
+        _safeMint(to, tokenId);
     }
 
     function supportsInterface(

--- a/contracts/mocks/extensions/tokenHolder/RMRKTokenHolderMock.sol
+++ b/contracts/mocks/extensions/tokenHolder/RMRKTokenHolderMock.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "../../../RMRK/extension/tokenHolder/RMRKTokenHolder.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {RMRKTokenHolder} from "../../../RMRK/extension/tokenHolder/RMRKTokenHolder.sol";
+import {IRMRKTokenHolder} from "../../../RMRK/extension/tokenHolder/IRMRKTokenHolder.sol";
 
 error OnlyNFTOwnerCanTransferTokensFromIt();
 error OnlyNFTOwnerCanTransferTokensToIt();

--- a/contracts/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.sol
+++ b/contracts/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol";
-import "../../RMRKNestableMultiAssetMock.sol";
+import {RMRKTypedMultiAsset} from "../../../RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol";
+import {RMRKNestableMultiAssetMock} from "../../RMRKNestableMultiAssetMock.sol";
+import {RMRKNestableMultiAsset} from "../../../RMRK/nestable/RMRKNestableMultiAsset.sol";
 
 error RMRKTokenHasNoAssetsWithType();
 

--- a/contracts/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.sol
+++ b/contracts/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.sol
@@ -6,8 +6,6 @@ import {RMRKTypedMultiAsset} from "../../../RMRK/extension/typedMultiAsset/RMRKT
 import {RMRKNestableMultiAssetMock} from "../../RMRKNestableMultiAssetMock.sol";
 import {RMRKNestableMultiAsset} from "../../../RMRK/nestable/RMRKNestableMultiAsset.sol";
 
-error RMRKTokenHasNoAssetsWithType();
-
 contract RMRKNestableTypedMultiAssetMock is
     RMRKNestableMultiAssetMock,
     RMRKTypedMultiAsset

--- a/contracts/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.sol
+++ b/contracts/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol";
-import "../../RMRKEquippableMock.sol";
+import {RMRKTypedMultiAsset} from "../../../RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol";
+import {RMRKEquippableMock} from "../../RMRKEquippableMock.sol";
+import {RMRKEquippable} from "../../../RMRK/equippable/RMRKEquippable.sol";
 
 error RMRKTokenHasNoAssetsWithType();
 

--- a/contracts/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.sol
+++ b/contracts/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.sol
@@ -6,8 +6,6 @@ import {RMRKTypedMultiAsset} from "../../../RMRK/extension/typedMultiAsset/RMRKT
 import {RMRKEquippableMock} from "../../RMRKEquippableMock.sol";
 import {RMRKEquippable} from "../../../RMRK/equippable/RMRKEquippable.sol";
 
-error RMRKTokenHasNoAssetsWithType();
-
 contract RMRKTypedEquippableMock is RMRKEquippableMock, RMRKTypedMultiAsset {
     function supportsInterface(
         bytes4 interfaceId

--- a/contracts/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.sol
+++ b/contracts/mocks/extensions/typedMultiAsset/RMRKTypedMultiAssetMock.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.21;
 
-import "../../../RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol";
-import "../../RMRKMultiAssetMock.sol";
+import {RMRKTypedMultiAsset} from "../../../RMRK/extension/typedMultiAsset/RMRKTypedMultiAsset.sol";
+import {RMRKMultiAssetMock} from "../../RMRKMultiAssetMock.sol";
+import {RMRKMultiAsset} from "../../../RMRK/multiasset/RMRKMultiAsset.sol";
 
 error RMRKTokenHasNoAssetsWithType();
 

--- a/contracts/security_mocks/ChildAdder.sol
+++ b/contracts/security_mocks/ChildAdder.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.21;
 
-import "../RMRK/nestable/IERC7401.sol";
+import {IERC7401} from "../RMRK/nestable/IERC7401.sol";
 
 /**
  * @title ChildAdder

--- a/contracts/security_mocks/ChildAdder.sol
+++ b/contracts/security_mocks/ChildAdder.sol
@@ -24,8 +24,11 @@ contract ChildAdder {
         uint256 childId,
         uint256 numChildren
     ) external {
-        for (uint256 i; i < numChildren; i++) {
+        for (uint256 i; i < numChildren; ) {
             IERC7401(destContract).addChild(parentId, childId, "");
+            unchecked {
+                ++i;
+            }
         }
     }
 }

--- a/docs/RMRK/access/Ownable.md
+++ b/docs/RMRK/access/Ownable.md
@@ -13,7 +13,7 @@ A minimal ownable smart contract or owner and contributors.
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -30,7 +30,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -52,7 +52,7 @@ Adds or removes a contributor to the smart contract.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -64,7 +64,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### renounceOwnership
 

--- a/docs/RMRK/access/OwnableLock.md
+++ b/docs/RMRK/access/OwnableLock.md
@@ -13,7 +13,7 @@ A minimal ownable lock smart contract.
 ### getLock
 
 ```solidity
-function getLock() external view returns (bool)
+function getLock() external view returns (bool isLocked)
 ```
 
 Used to retrieve the status of a lockable smart contract.
@@ -25,12 +25,12 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the smart contract has been locked |
+| isLocked | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -47,7 +47,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -69,7 +69,7 @@ Adds or removes a contributor to the smart contract.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -81,7 +81,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### renounceOwnership
 

--- a/docs/RMRK/catalog/IRMRKCatalog.md
+++ b/docs/RMRK/catalog/IRMRKCatalog.md
@@ -13,7 +13,7 @@ An interface Catalog for RMRK equippable module.
 ### checkIsEquippable
 
 ```solidity
-function checkIsEquippable(uint64 partId, address targetAddress) external view returns (bool)
+function checkIsEquippable(uint64 partId, address targetAddress) external view returns (bool isEquippable)
 ```
 
 Used to check whether the given address is allowed to equip the desired `Part`.
@@ -31,12 +31,12 @@ Used to check whether the given address is allowed to equip the desired `Part`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
+| isEquippable | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
 
 ### checkIsEquippableToAll
 
 ```solidity
-function checkIsEquippableToAll(uint64 partId) external view returns (bool)
+function checkIsEquippableToAll(uint64 partId) external view returns (bool isEquippableToAll)
 ```
 
 Used to check if the part is equippable by all addresses.
@@ -53,7 +53,7 @@ Used to check if the part is equippable by all addresses.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
+| isEquippableToAll | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
 
 ### getMetadataURI
 
@@ -75,7 +75,7 @@ Used to return the metadata URI of the associated Catalog.
 ### getPart
 
 ```solidity
-function getPart(uint64 partId) external view returns (struct IRMRKCatalog.Part)
+function getPart(uint64 partId) external view returns (struct IRMRKCatalog.Part part)
 ```
 
 Used to retrieve a `Part` with id `partId`
@@ -92,12 +92,12 @@ Used to retrieve a `Part` with id `partId`
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
+| part | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
 
 ### getParts
 
 ```solidity
-function getParts(uint64[] partIds) external view returns (struct IRMRKCatalog.Part[])
+function getParts(uint64[] partIds) external view returns (struct IRMRKCatalog.Part[] part)
 ```
 
 Used to retrieve multiple parts at the same time.
@@ -114,7 +114,7 @@ Used to retrieve multiple parts at the same time.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
+| part | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
 
 ### getType
 

--- a/docs/RMRK/catalog/RMRKCatalog.md
+++ b/docs/RMRK/catalog/RMRKCatalog.md
@@ -13,7 +13,7 @@ Catalog contract for RMRK equippable module.
 ### checkIsEquippable
 
 ```solidity
-function checkIsEquippable(uint64 partId, address targetAddress) external view returns (bool)
+function checkIsEquippable(uint64 partId, address targetAddress) external view returns (bool isEquippable)
 ```
 
 Used to check whether the given address is allowed to equip the desired `Part`.
@@ -31,12 +31,12 @@ Used to check whether the given address is allowed to equip the desired `Part`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
+| isEquippable | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
 
 ### checkIsEquippableToAll
 
 ```solidity
-function checkIsEquippableToAll(uint64 partId) external view returns (bool)
+function checkIsEquippableToAll(uint64 partId) external view returns (bool isEquippable)
 ```
 
 Used to check if the part is equippable by all addresses.
@@ -53,7 +53,7 @@ Used to check if the part is equippable by all addresses.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
+| isEquippable | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
 
 ### getMetadataURI
 
@@ -75,7 +75,7 @@ Used to return the metadata URI of the associated Catalog.
 ### getPart
 
 ```solidity
-function getPart(uint64 partId) external view returns (struct IRMRKCatalog.Part)
+function getPart(uint64 partId) external view returns (struct IRMRKCatalog.Part part)
 ```
 
 Used to retrieve a `Part` with id `partId`
@@ -92,12 +92,12 @@ Used to retrieve a `Part` with id `partId`
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
+| part | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
 
 ### getParts
 
 ```solidity
-function getParts(uint64[] partIds) external view returns (struct IRMRKCatalog.Part[])
+function getParts(uint64[] partIds) external view returns (struct IRMRKCatalog.Part[] parts)
 ```
 
 Used to retrieve multiple parts at the same time.
@@ -114,7 +114,7 @@ Used to retrieve multiple parts at the same time.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
+| parts | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
 
 ### getType
 

--- a/docs/RMRK/equippable/IERC6220.md
+++ b/docs/RMRK/equippable/IERC6220.md
@@ -48,7 +48,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -68,7 +68,7 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### equip
 
@@ -89,7 +89,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -106,12 +106,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -128,12 +128,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -150,7 +150,7 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetAndEquippableData
 
@@ -181,7 +181,7 @@ Used to get the asset and equippable data associated with given `assetId`.
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -199,12 +199,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetWithId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -222,7 +222,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetWithId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
@@ -251,7 +251,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -268,12 +268,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -291,12 +291,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -315,7 +315,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/equippable/IERC6220.md
+++ b/docs/RMRK/equippable/IERC6220.md
@@ -227,7 +227,7 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -246,7 +246,7 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -136,7 +136,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -153,7 +153,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -174,7 +174,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -192,12 +192,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -217,12 +217,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -240,12 +240,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -262,12 +262,12 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -284,7 +284,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -307,7 +307,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -324,12 +324,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -346,12 +346,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -368,34 +368,34 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
-Used to get the address of the user that is approved to manage the specified token from the current  owner.
+Used to retrieve the address of the account approved to manage assets of a given token.
 
-
+*Requirements:  - `tokenId` must exist.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| tokenId | uint256 | ID of the token we are checking |
+| tokenId | uint256 | ID of the token for which to retrieve the approved address |
 
 #### Returns
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -413,15 +413,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -439,12 +439,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -462,12 +462,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -486,12 +486,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -508,12 +508,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -531,12 +531,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -554,12 +554,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -578,7 +578,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### nestTransferFrom
 
@@ -603,7 +603,7 @@ Used to transfer the token into another token.
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -620,12 +620,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -643,12 +643,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -665,7 +665,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -267,7 +267,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -284,9 +284,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/RMRK/equippable/RMRKEquippable.md
+++ b/docs/RMRK/equippable/RMRKEquippable.md
@@ -1325,6 +1325,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/RMRK/equippable/RMRKMinifiedEquippable.md
+++ b/docs/RMRK/equippable/RMRKMinifiedEquippable.md
@@ -267,7 +267,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -284,9 +284,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/RMRK/equippable/RMRKMinifiedEquippable.md
+++ b/docs/RMRK/equippable/RMRKMinifiedEquippable.md
@@ -136,7 +136,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -153,7 +153,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -174,7 +174,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -192,12 +192,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -217,12 +217,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -240,12 +240,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -262,12 +262,12 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -284,7 +284,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -307,7 +307,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -324,12 +324,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -346,12 +346,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -368,12 +368,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -390,12 +390,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -413,15 +413,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -439,12 +439,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -462,12 +462,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -486,12 +486,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -508,12 +508,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -531,12 +531,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -554,12 +554,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -578,7 +578,7 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### nestTransferFrom
 
@@ -603,7 +603,7 @@ Used to transfer the token into another token.
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -620,12 +620,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -643,12 +643,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -665,7 +665,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/equippable/RMRKMinifiedEquippable.md
+++ b/docs/RMRK/equippable/RMRKMinifiedEquippable.md
@@ -1325,6 +1325,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/RMRK/extension/RMRKRoyalties.md
+++ b/docs/RMRK/extension/RMRKRoyalties.md
@@ -13,7 +13,7 @@ Smart contract of the RMRK Royalties module.
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -25,12 +25,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -42,7 +42,7 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### royaltyInfo
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md
@@ -65,7 +65,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -82,12 +82,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -104,12 +104,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -126,12 +126,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -149,12 +149,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetWithId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -172,12 +172,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetWithId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -194,12 +194,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -217,7 +217,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
@@ -116,7 +116,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -133,12 +133,12 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -155,12 +155,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -177,12 +177,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -199,12 +199,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -221,12 +221,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -244,12 +244,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -267,12 +267,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -289,12 +289,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -312,12 +312,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -335,12 +335,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -357,7 +357,7 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
+++ b/docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md
@@ -821,6 +821,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
@@ -136,7 +136,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -153,9 +153,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### nestTransferFrom
 

--- a/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
@@ -91,7 +91,7 @@ Used to burn a given token.
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -109,12 +109,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -131,7 +131,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -180,7 +180,7 @@ Used to transfer the token into another token.
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address owner)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -197,12 +197,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -220,12 +220,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -242,7 +242,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 

--- a/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md
@@ -68,7 +68,7 @@ Used to add a child token to a given parent token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxRecursiveBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxRecursiveBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -86,7 +86,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -225,7 +225,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -242,9 +242,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
+++ b/docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md
@@ -119,7 +119,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -136,7 +136,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -157,7 +157,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -175,12 +175,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -198,12 +198,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -220,12 +220,12 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -242,14 +242,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -266,12 +266,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -289,7 +289,7 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### nestTransferFrom
 
@@ -336,7 +336,7 @@ function ownerOf(uint256 tokenId) external view returns (address)
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -354,12 +354,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -376,7 +376,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 

--- a/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
+++ b/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,12 +202,12 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -224,14 +224,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -248,12 +248,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -271,7 +271,7 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### nestTransferFrom
 
@@ -296,7 +296,7 @@ Used to transfer the token into another token.
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -313,12 +313,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -336,12 +336,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -358,7 +358,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### reclaimChild
 

--- a/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
+++ b/docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md
@@ -207,7 +207,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -224,9 +224,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/RMRK/extension/revealable/IRMRKRevealable.md
+++ b/docs/RMRK/extension/revealable/IRMRKRevealable.md
@@ -13,7 +13,7 @@
 ### getRevealer
 
 ```solidity
-function getRevealer() external view returns (address)
+function getRevealer() external view returns (address revealer)
 ```
 
 Gets the `IRMRKRevealer` associated with the contract.
@@ -25,7 +25,7 @@ Gets the `IRMRKRevealer` associated with the contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | revealer The `IRMRKRevealer` associated with the contract |
+| revealer | address | The `IRMRKRevealer` associated with the contract |
 
 ### reveal
 

--- a/docs/RMRK/extension/revealable/IRMRKRevealer.md
+++ b/docs/RMRK/extension/revealable/IRMRKRevealer.md
@@ -62,7 +62,7 @@ Returns the revealed `assetIds` for the given `tokenIds` and marks them as revea
 ### Revealed
 
 ```solidity
-event Revealed(uint256[] tokenIds, uint64[] revealedAssetsIds, uint64[] assetsToReplaceIds)
+event Revealed(uint256[] indexed tokenIds, uint64[] revealedAssetsIds, uint64[] assetsToReplaceIds)
 ```
 
 
@@ -73,7 +73,7 @@ event Revealed(uint256[] tokenIds, uint64[] revealedAssetsIds, uint64[] assetsTo
 
 | Name | Type | Description |
 |---|---|---|
-| tokenIds  | uint256[] | undefined |
+| tokenIds `indexed` | uint256[] | undefined |
 | revealedAssetsIds  | uint64[] | undefined |
 | assetsToReplaceIds  | uint64[] | undefined |
 

--- a/docs/RMRK/extension/soulbound/IERC6454.md
+++ b/docs/RMRK/extension/soulbound/IERC6454.md
@@ -13,7 +13,7 @@ A minimal extension to identify the transferability of Non-Fungible Tokens.
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256 tokenId, address from, address to) external view returns (bool)
+function isTransferable(uint256 tokenId, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -32,7 +32,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulbound.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulbound.md
@@ -13,7 +13,7 @@ Smart contract of the RMRK Soulbound module.
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -32,7 +32,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.md
@@ -30,7 +30,7 @@ Gets the last block number where transfers are allowed
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address, address) external view returns (bool)
+function isTransferable(uint256, address, address) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -49,7 +49,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.md
@@ -52,7 +52,7 @@ Gets the current number of transfer the specified token.
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256 tokenId, address, address) external view returns (bool)
+function isTransferable(uint256 tokenId, address, address) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -71,7 +71,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/soulbound/RMRKSoulboundPerToken.md
+++ b/docs/RMRK/extension/soulbound/RMRKSoulboundPerToken.md
@@ -13,7 +13,7 @@ Smart contract of the RMRK Soulbound module where the transfers are permitted or
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256 tokenId, address from, address to) external view returns (bool)
+function isTransferable(uint256 tokenId, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -32,7 +32,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### supportsInterface
 

--- a/docs/RMRK/extension/tokenAttributes/IERC7508.md
+++ b/docs/RMRK/extension/tokenAttributes/IERC7508.md
@@ -13,7 +13,7 @@ Interface smart contract of the RMRK token properties extension.
 ### getAddressAttribute
 
 ```solidity
-function getAddressAttribute(address collection, uint256 tokenId, string key) external view returns (address)
+function getAddressAttribute(address collection, uint256 tokenId, string key) external view returns (address attribute)
 ```
 
 Used to retrieve the address type token attributes.
@@ -32,12 +32,12 @@ Used to retrieve the address type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The value of the address attribute |
+| attribute | address | The value of the address attribute |
 
 ### getAddressAttributes
 
 ```solidity
-function getAddressAttributes(address collection, uint256 tokenId, string[] addressKeys) external view returns (struct IERC7508.AddressAttribute[])
+function getAddressAttributes(address collection, uint256 tokenId, string[] addressKeys) external view returns (struct IERC7508.AddressAttribute[] attributes)
 ```
 
 Used to get multiple address parameter values for a token.
@@ -56,7 +56,7 @@ Used to get multiple address parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.AddressAttribute[] | An array of `AddressAttribute` structs |
+| attributes | IERC7508.AddressAttribute[] | An array of `AddressAttribute` structs |
 
 ### getAttributes
 
@@ -93,7 +93,7 @@ Used to retrieve multiple token attributes of any type at once.
 ### getBoolAttribute
 
 ```solidity
-function getBoolAttribute(address collection, uint256 tokenId, string key) external view returns (bool)
+function getBoolAttribute(address collection, uint256 tokenId, string key) external view returns (bool attribute)
 ```
 
 Used to retrieve the bool type token attributes.
@@ -112,12 +112,12 @@ Used to retrieve the bool type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The value of the bool attribute |
+| attribute | bool | The value of the bool attribute |
 
 ### getBoolAttributes
 
 ```solidity
-function getBoolAttributes(address collection, uint256 tokenId, string[] boolKeys) external view returns (struct IERC7508.BoolAttribute[])
+function getBoolAttributes(address collection, uint256 tokenId, string[] boolKeys) external view returns (struct IERC7508.BoolAttribute[] attributes)
 ```
 
 Used to get multiple bool parameter values for a token.
@@ -136,12 +136,12 @@ Used to get multiple bool parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.BoolAttribute[] | An array of `BoolAttribute` structs |
+| attributes | IERC7508.BoolAttribute[] | An array of `BoolAttribute` structs |
 
 ### getBytesAttribute
 
 ```solidity
-function getBytesAttribute(address collection, uint256 tokenId, string key) external view returns (bytes)
+function getBytesAttribute(address collection, uint256 tokenId, string key) external view returns (bytes attribute)
 ```
 
 Used to retrieve the bytes type token attributes.
@@ -160,12 +160,12 @@ Used to retrieve the bytes type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes | The value of the bytes attribute |
+| attribute | bytes | The value of the bytes attribute |
 
 ### getBytesAttributes
 
 ```solidity
-function getBytesAttributes(address collection, uint256 tokenId, string[] bytesKeys) external view returns (struct IERC7508.BytesAttribute[])
+function getBytesAttributes(address collection, uint256 tokenId, string[] bytesKeys) external view returns (struct IERC7508.BytesAttribute[] attributes)
 ```
 
 Used to get multiple bytes parameter values for a token.
@@ -184,12 +184,12 @@ Used to get multiple bytes parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.BytesAttribute[] | An array of `BytesAttribute` structs |
+| attributes | IERC7508.BytesAttribute[] | An array of `BytesAttribute` structs |
 
 ### getStringAttribute
 
 ```solidity
-function getStringAttribute(address collection, uint256 tokenId, string key) external view returns (string)
+function getStringAttribute(address collection, uint256 tokenId, string key) external view returns (string attribute)
 ```
 
 Used to retrieve the string type token attributes.
@@ -208,12 +208,12 @@ Used to retrieve the string type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The value of the string attribute |
+| attribute | string | The value of the string attribute |
 
 ### getStringAttributes
 
 ```solidity
-function getStringAttributes(address collection, uint256 tokenId, string[] stringKeys) external view returns (struct IERC7508.StringAttribute[])
+function getStringAttributes(address collection, uint256 tokenId, string[] stringKeys) external view returns (struct IERC7508.StringAttribute[] attributes)
 ```
 
 Used to get multiple sting parameter values for a token.
@@ -232,12 +232,12 @@ Used to get multiple sting parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.StringAttribute[] | An array of `StringAttribute` structs |
+| attributes | IERC7508.StringAttribute[] | An array of `StringAttribute` structs |
 
 ### getUintAttribute
 
 ```solidity
-function getUintAttribute(address collection, uint256 tokenId, string key) external view returns (uint256)
+function getUintAttribute(address collection, uint256 tokenId, string key) external view returns (uint256 attribute)
 ```
 
 Used to retrieve the uint type token attributes.
@@ -256,12 +256,12 @@ Used to retrieve the uint type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The value of the uint attribute |
+| attribute | uint256 | The value of the uint attribute |
 
 ### getUintAttributes
 
 ```solidity
-function getUintAttributes(address collection, uint256 tokenId, string[] uintKeys) external view returns (struct IERC7508.UintAttribute[])
+function getUintAttributes(address collection, uint256 tokenId, string[] uintKeys) external view returns (struct IERC7508.UintAttribute[] attributes)
 ```
 
 Used to get multiple uint parameter values for a token.
@@ -280,12 +280,12 @@ Used to get multiple uint parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.UintAttribute[] | An array of `UintAttribute` structs |
+| attributes | IERC7508.UintAttribute[] | An array of `UintAttribute` structs |
 
 ### isCollaborator
 
 ```solidity
-function isCollaborator(address collaborator, address collection) external view returns (bool)
+function isCollaborator(address collaborator, address collection) external view returns (bool isCollaborator_)
 ```
 
 Used to check if the specified address is listed as a collaborator of the given collection&#39;s parameter.
@@ -303,12 +303,12 @@ Used to check if the specified address is listed as a collaborator of the given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating if the address is a collaborator of the given collection&#39;s (`true`) or not  (`false`). |
+| isCollaborator_ | bool | Boolean value indicating if the address is a collaborator of the given collection&#39;s (`true`) or not  (`false`). |
 
 ### isSpecificAddress
 
 ```solidity
-function isSpecificAddress(address specificAddress, address collection, string key) external view returns (bool)
+function isSpecificAddress(address specificAddress, address collection, string key) external view returns (bool isSpecificAddress_)
 ```
 
 Used to check if the specified address is listed as a specific address of the given collection&#39;s  parameter.
@@ -327,7 +327,7 @@ Used to check if the specified address is listed as a specific address of the gi
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating if the address is a specific address of the given collection&#39;s parameter  (`true`) or not (`false`). |
+| isSpecificAddress_ | bool | Boolean value indicating if the address is a specific address of the given collection&#39;s parameter  (`true`) or not (`false`). |
 
 ### manageAccessControl
 
@@ -369,7 +369,7 @@ Used to manage the collaborators of a collection.
 ### prepareMessageToPresignAddressAttribute
 
 ```solidity
-function prepareMessageToPresignAddressAttribute(address collection, uint256 tokenId, string key, address value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignAddressAttribute(address collection, uint256 tokenId, string key, address value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned address attribute change.
@@ -390,12 +390,12 @@ Used to retrieve the message to be signed for submitting a presigned address att
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignBoolAttribute
 
 ```solidity
-function prepareMessageToPresignBoolAttribute(address collection, uint256 tokenId, string key, bool value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignBoolAttribute(address collection, uint256 tokenId, string key, bool value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned bool attribute change.
@@ -416,12 +416,12 @@ Used to retrieve the message to be signed for submitting a presigned bool attrib
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignBytesAttribute
 
 ```solidity
-function prepareMessageToPresignBytesAttribute(address collection, uint256 tokenId, string key, bytes value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignBytesAttribute(address collection, uint256 tokenId, string key, bytes value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned bytes attribute change.
@@ -442,12 +442,12 @@ Used to retrieve the message to be signed for submitting a presigned bytes attri
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignStringAttribute
 
 ```solidity
-function prepareMessageToPresignStringAttribute(address collection, uint256 tokenId, string key, string value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignStringAttribute(address collection, uint256 tokenId, string key, string value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned string attribute change.
@@ -468,12 +468,12 @@ Used to retrieve the message to be signed for submitting a presigned string attr
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignUintAttribute
 
 ```solidity
-function prepareMessageToPresignUintAttribute(address collection, uint256 tokenId, string key, uint256 value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignUintAttribute(address collection, uint256 tokenId, string key, uint256 value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned uint attribute change.
@@ -494,7 +494,7 @@ Used to retrieve the message to be signed for submitting a presigned uint attrib
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### presignedSetAddressAttribute
 

--- a/docs/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.md
+++ b/docs/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.md
@@ -115,7 +115,7 @@ function SET_UINT_ATTRIBUTE_TYPEHASH() external view returns (bytes32)
 ### getAddressAttribute
 
 ```solidity
-function getAddressAttribute(address collection, uint256 tokenId, string key) external view returns (address)
+function getAddressAttribute(address collection, uint256 tokenId, string key) external view returns (address attribute)
 ```
 
 Used to retrieve the address type token attributes.
@@ -134,12 +134,12 @@ Used to retrieve the address type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The value of the address attribute |
+| attribute | address | The value of the address attribute |
 
 ### getAddressAttributes
 
 ```solidity
-function getAddressAttributes(address collection, uint256 tokenId, string[] addressKeys) external view returns (struct IERC7508.AddressAttribute[])
+function getAddressAttributes(address collection, uint256 tokenId, string[] addressKeys) external view returns (struct IERC7508.AddressAttribute[] attributes)
 ```
 
 Used to get multiple address parameter values for a token.
@@ -158,7 +158,7 @@ Used to get multiple address parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.AddressAttribute[] | An array of `AddressAttribute` structs |
+| attributes | IERC7508.AddressAttribute[] | An array of `AddressAttribute` structs |
 
 ### getAttributes
 
@@ -195,7 +195,7 @@ Used to retrieve multiple token attributes of any type at once.
 ### getBoolAttribute
 
 ```solidity
-function getBoolAttribute(address collection, uint256 tokenId, string key) external view returns (bool)
+function getBoolAttribute(address collection, uint256 tokenId, string key) external view returns (bool attribute)
 ```
 
 Used to retrieve the bool type token attributes.
@@ -214,12 +214,12 @@ Used to retrieve the bool type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The value of the bool attribute |
+| attribute | bool | The value of the bool attribute |
 
 ### getBoolAttributes
 
 ```solidity
-function getBoolAttributes(address collection, uint256 tokenId, string[] boolKeys) external view returns (struct IERC7508.BoolAttribute[])
+function getBoolAttributes(address collection, uint256 tokenId, string[] boolKeys) external view returns (struct IERC7508.BoolAttribute[] attributes)
 ```
 
 Used to get multiple bool parameter values for a token.
@@ -238,12 +238,12 @@ Used to get multiple bool parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.BoolAttribute[] | An array of `BoolAttribute` structs |
+| attributes | IERC7508.BoolAttribute[] | An array of `BoolAttribute` structs |
 
 ### getBytesAttribute
 
 ```solidity
-function getBytesAttribute(address collection, uint256 tokenId, string key) external view returns (bytes)
+function getBytesAttribute(address collection, uint256 tokenId, string key) external view returns (bytes attribute)
 ```
 
 Used to retrieve the bytes type token attributes.
@@ -262,12 +262,12 @@ Used to retrieve the bytes type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes | The value of the bytes attribute |
+| attribute | bytes | The value of the bytes attribute |
 
 ### getBytesAttributes
 
 ```solidity
-function getBytesAttributes(address collection, uint256 tokenId, string[] bytesKeys) external view returns (struct IERC7508.BytesAttribute[])
+function getBytesAttributes(address collection, uint256 tokenId, string[] bytesKeys) external view returns (struct IERC7508.BytesAttribute[] attributes)
 ```
 
 Used to get multiple bytes parameter values for a token.
@@ -286,12 +286,12 @@ Used to get multiple bytes parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.BytesAttribute[] | An array of `BytesAttribute` structs |
+| attributes | IERC7508.BytesAttribute[] | An array of `BytesAttribute` structs |
 
 ### getStringAttribute
 
 ```solidity
-function getStringAttribute(address collection, uint256 tokenId, string key) external view returns (string)
+function getStringAttribute(address collection, uint256 tokenId, string key) external view returns (string attribute)
 ```
 
 Used to retrieve the string type token attributes.
@@ -310,12 +310,12 @@ Used to retrieve the string type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The value of the string attribute |
+| attribute | string | The value of the string attribute |
 
 ### getStringAttributes
 
 ```solidity
-function getStringAttributes(address collection, uint256 tokenId, string[] stringKeys) external view returns (struct IERC7508.StringAttribute[])
+function getStringAttributes(address collection, uint256 tokenId, string[] stringKeys) external view returns (struct IERC7508.StringAttribute[] attributes)
 ```
 
 Used to get multiple sting parameter values for a token.
@@ -334,12 +334,12 @@ Used to get multiple sting parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.StringAttribute[] | An array of `StringAttribute` structs |
+| attributes | IERC7508.StringAttribute[] | An array of `StringAttribute` structs |
 
 ### getUintAttribute
 
 ```solidity
-function getUintAttribute(address collection, uint256 tokenId, string key) external view returns (uint256)
+function getUintAttribute(address collection, uint256 tokenId, string key) external view returns (uint256 attribute)
 ```
 
 Used to retrieve the uint type token attributes.
@@ -358,12 +358,12 @@ Used to retrieve the uint type token attributes.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The value of the uint attribute |
+| attribute | uint256 | The value of the uint attribute |
 
 ### getUintAttributes
 
 ```solidity
-function getUintAttributes(address collection, uint256 tokenId, string[] uintKeys) external view returns (struct IERC7508.UintAttribute[])
+function getUintAttributes(address collection, uint256 tokenId, string[] uintKeys) external view returns (struct IERC7508.UintAttribute[] attributes)
 ```
 
 Used to get multiple uint parameter values for a token.
@@ -382,12 +382,12 @@ Used to get multiple uint parameter values for a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7508.UintAttribute[] | An array of `UintAttribute` structs |
+| attributes | IERC7508.UintAttribute[] | An array of `UintAttribute` structs |
 
 ### isCollaborator
 
 ```solidity
-function isCollaborator(address collaborator, address collection) external view returns (bool)
+function isCollaborator(address collaborator, address collection) external view returns (bool isCollaborator_)
 ```
 
 Used to check if the specified address is listed as a collaborator of the given collection&#39;s parameter.
@@ -405,12 +405,12 @@ Used to check if the specified address is listed as a collaborator of the given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating if the address is a collaborator of the given collection&#39;s (`true`) or not  (`false`). |
+| isCollaborator_ | bool | Boolean value indicating if the address is a collaborator of the given collection&#39;s (`true`) or not  (`false`). |
 
 ### isSpecificAddress
 
 ```solidity
-function isSpecificAddress(address specificAddress, address collection, string key) external view returns (bool)
+function isSpecificAddress(address specificAddress, address collection, string key) external view returns (bool isSpecificAddress_)
 ```
 
 Used to check if the specified address is listed as a specific address of the given collection&#39;s  parameter.
@@ -429,7 +429,7 @@ Used to check if the specified address is listed as a specific address of the gi
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating if the address is a specific address of the given collection&#39;s parameter  (`true`) or not (`false`). |
+| isSpecificAddress_ | bool | Boolean value indicating if the address is a specific address of the given collection&#39;s parameter  (`true`) or not (`false`). |
 
 ### manageAccessControl
 
@@ -471,7 +471,7 @@ Used to manage the collaborators of a collection.
 ### prepareMessageToPresignAddressAttribute
 
 ```solidity
-function prepareMessageToPresignAddressAttribute(address collection, uint256 tokenId, string key, address value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignAddressAttribute(address collection, uint256 tokenId, string key, address value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned address attribute change.
@@ -492,12 +492,12 @@ Used to retrieve the message to be signed for submitting a presigned address att
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignBoolAttribute
 
 ```solidity
-function prepareMessageToPresignBoolAttribute(address collection, uint256 tokenId, string key, bool value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignBoolAttribute(address collection, uint256 tokenId, string key, bool value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned bool attribute change.
@@ -518,12 +518,12 @@ Used to retrieve the message to be signed for submitting a presigned bool attrib
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignBytesAttribute
 
 ```solidity
-function prepareMessageToPresignBytesAttribute(address collection, uint256 tokenId, string key, bytes value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignBytesAttribute(address collection, uint256 tokenId, string key, bytes value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned bytes attribute change.
@@ -544,12 +544,12 @@ Used to retrieve the message to be signed for submitting a presigned bytes attri
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignStringAttribute
 
 ```solidity
-function prepareMessageToPresignStringAttribute(address collection, uint256 tokenId, string key, string value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignStringAttribute(address collection, uint256 tokenId, string key, string value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned string attribute change.
@@ -570,12 +570,12 @@ Used to retrieve the message to be signed for submitting a presigned string attr
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### prepareMessageToPresignUintAttribute
 
 ```solidity
-function prepareMessageToPresignUintAttribute(address collection, uint256 tokenId, string key, uint256 value, uint256 deadline) external view returns (bytes32)
+function prepareMessageToPresignUintAttribute(address collection, uint256 tokenId, string key, uint256 value, uint256 deadline) external view returns (bytes32 message)
 ```
 
 Used to retrieve the message to be signed for submitting a presigned uint attribute change.
@@ -596,7 +596,7 @@ Used to retrieve the message to be signed for submitting a presigned uint attrib
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bytes32 | Raw message to be signed by the authorized account |
+| message | bytes32 | Raw message to be signed by the authorized account |
 
 ### presignedSetAddressAttribute
 

--- a/docs/RMRK/library/RMRKLib.md
+++ b/docs/RMRK/library/RMRKLib.md
@@ -10,3 +10,17 @@ RMRK library smart contract.
 
 
 
+## Errors
+
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
+

--- a/docs/RMRK/multiasset/AbstractMultiAsset.md
+++ b/docs/RMRK/multiasset/AbstractMultiAsset.md
@@ -48,7 +48,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -65,12 +65,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -87,12 +87,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -109,12 +109,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -132,12 +132,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -155,12 +155,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -177,12 +177,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -200,7 +200,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/multiasset/IERC5773.md
+++ b/docs/RMRK/multiasset/IERC5773.md
@@ -48,7 +48,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -65,12 +65,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -87,12 +87,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -109,12 +109,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -132,12 +132,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetWithId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -155,12 +155,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetWithId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -177,12 +177,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -200,7 +200,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/multiasset/RMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/RMRKMultiAsset.md
@@ -99,7 +99,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -116,12 +116,12 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -138,12 +138,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -160,12 +160,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -182,12 +182,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -204,12 +204,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -227,12 +227,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -250,12 +250,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -272,12 +272,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -295,12 +295,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -318,12 +318,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -340,7 +340,7 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/multiasset/RMRKMultiAsset.md
+++ b/docs/RMRK/multiasset/RMRKMultiAsset.md
@@ -787,6 +787,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/RMRK/nestable/IERC7401.md
+++ b/docs/RMRK/nestable/IERC7401.md
@@ -73,7 +73,7 @@ Used to burn a given token.
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -91,12 +91,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -113,7 +113,7 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
@@ -162,7 +162,7 @@ Used to transfer the token into another token.
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address owner)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -179,12 +179,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -202,12 +202,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -224,7 +224,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 

--- a/docs/RMRK/nestable/IERC7401.md
+++ b/docs/RMRK/nestable/IERC7401.md
@@ -50,7 +50,7 @@ Used to add a child token to a given parent token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxRecursiveBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxRecursiveBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -68,7 +68,7 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 

--- a/docs/RMRK/nestable/IERC7401.md
+++ b/docs/RMRK/nestable/IERC7401.md
@@ -118,7 +118,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -135,9 +135,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### nestTransferFrom
 

--- a/docs/RMRK/nestable/RMRKNestable.md
+++ b/docs/RMRK/nestable/RMRKNestable.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,12 +202,12 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -224,14 +224,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -248,12 +248,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -271,7 +271,7 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### nestTransferFrom
 
@@ -296,7 +296,7 @@ Used to transfer the token into another token.
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -313,12 +313,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -336,12 +336,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -358,7 +358,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 

--- a/docs/RMRK/nestable/RMRKNestable.md
+++ b/docs/RMRK/nestable/RMRKNestable.md
@@ -207,7 +207,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -224,9 +224,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -1132,6 +1132,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -242,7 +242,7 @@ Used to retrieve the active child tokens of a given parent token.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -259,9 +259,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 

--- a/docs/RMRK/nestable/RMRKNestableMultiAsset.md
+++ b/docs/RMRK/nestable/RMRKNestableMultiAsset.md
@@ -136,7 +136,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -153,7 +153,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -174,7 +174,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -192,12 +192,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -215,12 +215,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -237,12 +237,12 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -259,14 +259,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -283,12 +283,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -305,12 +305,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -327,12 +327,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -349,12 +349,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -372,12 +372,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -395,12 +395,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -417,12 +417,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -440,12 +440,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -463,7 +463,7 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### nestTransferFrom
 
@@ -488,7 +488,7 @@ Used to transfer the token into another token.
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -505,12 +505,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -528,12 +528,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -550,7 +550,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 

--- a/docs/RMRK/utils/IERC20.md
+++ b/docs/RMRK/utils/IERC20.md
@@ -36,7 +36,7 @@ Used to grant permission to an account to spend the tokens of another
 ### transfer
 
 ```solidity
-function transfer(address to, uint256 amount) external nonpayable returns (bool)
+function transfer(address to, uint256 amount) external nonpayable returns (bool success)
 ```
 
 Used to transfer tokens from the caller&#39;s account to another.
@@ -54,12 +54,12 @@ Used to transfer tokens from the caller&#39;s account to another.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`) |
+| success | bool | A boolean value signifying whether the transfer was succesful (`true`) or not (`false`) |
 
 ### transferFrom
 
 ```solidity
-function transferFrom(address from, address to, uint256 amount) external nonpayable returns (bool)
+function transferFrom(address from, address to, uint256 amount) external nonpayable returns (bool success)
 ```
 
 Used to transfer tokens from one address to another.
@@ -78,7 +78,7 @@ Used to transfer tokens from one address to another.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the transfer was succesfull (`true`) or not (`false`) |
+| success | bool | A boolean value signifying whether the transfer was succesful (`true`) or not (`false`) |
 
 
 

--- a/docs/RMRK/utils/RMRKBulkWriterPerCollection.md
+++ b/docs/RMRK/utils/RMRKBulkWriterPerCollection.md
@@ -31,7 +31,7 @@ function bulkEquip(uint256 tokenId, RMRKBulkWriterPerCollection.IntakeUnequip[] 
 ### getCollection
 
 ```solidity
-function getCollection() external view returns (address)
+function getCollection() external view returns (address collection)
 ```
 
 Returns the address of the collection that this contract is managing
@@ -43,7 +43,7 @@ Returns the address of the collection that this contract is managing
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the collection that this contract is managing |
+| collection | address | Address of the collection that this contract is managing |
 
 ### replaceEquip
 

--- a/docs/RMRK/utils/RMRKCollectionUtils.md
+++ b/docs/RMRK/utils/RMRKCollectionUtils.md
@@ -125,7 +125,7 @@ Triggers an event to refresh the token metadata.
 ### BatchMetadataUpdate
 
 ```solidity
-event BatchMetadataUpdate(address collection, uint256 fromTokenId, uint256 toTokenId)
+event BatchMetadataUpdate(address indexed collection, uint256 indexed fromTokenId, uint256 indexed toTokenId)
 ```
 
 This event emits when the metadata of a range of tokens is changed. So that the third-party platforms such as NFT market could timely update the images and related attributes of the NFTs. Inspired on ERC4906, but adding collection.
@@ -136,14 +136,14 @@ This event emits when the metadata of a range of tokens is changed. So that the 
 
 | Name | Type | Description |
 |---|---|---|
-| collection  | address | Address of the collection to emit the event from |
-| fromTokenId  | uint256 | ID of the first token to emit the event from |
-| toTokenId  | uint256 | ID of the last token to emit the event from |
+| collection `indexed` | address | Address of the collection to emit the event from |
+| fromTokenId `indexed` | uint256 | ID of the first token to emit the event from |
+| toTokenId `indexed` | uint256 | ID of the last token to emit the event from |
 
 ### MetadataUpdate
 
 ```solidity
-event MetadataUpdate(address collection, uint256 tokenId)
+event MetadataUpdate(address indexed collection, uint256 indexed tokenId)
 ```
 
 This event emits when the metadata of a token is changed. So that the third-party platforms such as NFT market could timely update the images and related attributes of the NFT. Inspired on ERC4906, but adding collection.
@@ -154,8 +154,8 @@ This event emits when the metadata of a token is changed. So that the third-part
 
 | Name | Type | Description |
 |---|---|---|
-| collection  | address | Address of the collection to emit the event from |
-| tokenId  | uint256 | ID of the token to emit the event from |
+| collection `indexed` | address | Address of the collection to emit the event from |
+| tokenId `indexed` | uint256 | ID of the token to emit the event from |
 
 
 

--- a/docs/RMRK/utils/RMRKCollectionUtils.md
+++ b/docs/RMRK/utils/RMRKCollectionUtils.md
@@ -86,7 +86,7 @@ Used to get a list of existing token IDs in the range between `pageStart` and `p
 ### refreshCollectionTokensMetadata
 
 ```solidity
-function refreshCollectionTokensMetadata(address collectionAddress) external nonpayable
+function refreshCollectionTokensMetadata(address collectionAddress, uint256 fromTokenId, uint256 toTokenId) external nonpayable
 ```
 
 Triggers an event to refresh the collection metadata.
@@ -98,6 +98,8 @@ Triggers an event to refresh the collection metadata.
 | Name | Type | Description |
 |---|---|---|
 | collectionAddress | address | Address of the collection to refresh the metadata from |
+| fromTokenId | uint256 | ID of the first token to refresh the metadata from |
+| toTokenId | uint256 | ID of the last token to refresh the metadata from |
 
 ### refreshTokenMetadata
 
@@ -120,13 +122,13 @@ Triggers an event to refresh the token metadata.
 
 ## Events
 
-### CollectionTokensMetadataRefreshTriggered
+### BatchMetadataUpdate
 
 ```solidity
-event CollectionTokensMetadataRefreshTriggered(address indexed collection)
+event BatchMetadataUpdate(address collection, uint256 fromTokenId, uint256 toTokenId)
 ```
 
-
+This event emits when the metadata of a range of tokens is changed. So that the third-party platforms such as NFT market could timely update the images and related attributes of the NFTs. Inspired on ERC4906, but adding collection.
 
 
 
@@ -134,15 +136,17 @@ event CollectionTokensMetadataRefreshTriggered(address indexed collection)
 
 | Name | Type | Description |
 |---|---|---|
-| collection `indexed` | address | undefined |
+| collection  | address | Address of the collection to emit the event from |
+| fromTokenId  | uint256 | ID of the first token to emit the event from |
+| toTokenId  | uint256 | ID of the last token to emit the event from |
 
-### TokenMetadataRefreshTriggered
+### MetadataUpdate
 
 ```solidity
-event TokenMetadataRefreshTriggered(address indexed collection, uint256 indexed tokenId)
+event MetadataUpdate(address collection, uint256 tokenId)
 ```
 
-
+This event emits when the metadata of a token is changed. So that the third-party platforms such as NFT market could timely update the images and related attributes of the NFT. Inspired on ERC4906, but adding collection.
 
 
 
@@ -150,8 +154,8 @@ event TokenMetadataRefreshTriggered(address indexed collection, uint256 indexed 
 
 | Name | Type | Description |
 |---|---|---|
-| collection `indexed` | address | undefined |
-| tokenId `indexed` | uint256 | undefined |
+| collection  | address | Address of the collection to emit the event from |
+| tokenId  | uint256 | ID of the token to emit the event from |
 
 
 

--- a/docs/RMRK/utils/RMRKEquipRenderUtils.md
+++ b/docs/RMRK/utils/RMRKEquipRenderUtils.md
@@ -136,7 +136,7 @@ Used to get the child&#39;s assets and slot parts pairs, identifying parts the s
 ### getAssetIdWithTopPriority
 
 ```solidity
-function getAssetIdWithTopPriority(address target, uint256 tokenId) external view returns (uint64, uint64)
+function getAssetIdWithTopPriority(address target, uint256 tokenId) external view returns (uint64 maxPriorityAssetId, uint64 maxPriority)
 ```
 
 Used to retrieve the ID of the specified token&#39;s asset with the highest priority.
@@ -154,13 +154,13 @@ Used to retrieve the ID of the specified token&#39;s asset with the highest prio
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | The ID of the asset with the highest priority |
-| _1 | uint64 | The priority value of the asset with the highest priority |
+| maxPriorityAssetId | uint64 | The ID of the asset with the highest priority |
+| maxPriority | uint64 | The priority value of the asset with the highest priority |
 
 ### getAssetsById
 
 ```solidity
-function getAssetsById(address target, uint256 tokenId, uint64[] assetIds) external view returns (string[])
+function getAssetsById(address target, uint256 tokenId, uint64[] assetIds) external view returns (string[] assets)
 ```
 
 Used to retrieve the metadata URI of specified assets in the specified token.
@@ -179,12 +179,12 @@ Used to retrieve the metadata URI of specified assets in the specified token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string[] | An array of metadata URIs belonging to specified assets |
+| assets | string[] | An array of metadata URIs belonging to specified assets |
 
 ### getChildIndex
 
 ```solidity
-function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
+function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256 index)
 ```
 
 Used to retrieve the given child&#39;s index in its parent&#39;s child tokens array.
@@ -204,12 +204,12 @@ Used to retrieve the given child&#39;s index in its parent&#39;s child tokens ar
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The index of the child token in the parent token&#39;s child tokens array |
+| index | uint256 | The index of the child token in the parent token&#39;s child tokens array |
 
 ### getChildrenWithTopMetadata
 
 ```solidity
-function getChildrenWithTopMetadata(address parentAddress, uint256 parentId) external view returns (struct RMRKEquipRenderUtils.ChildWithTopAssetMetadata[])
+function getChildrenWithTopMetadata(address parentAddress, uint256 parentId) external view returns (struct RMRKEquipRenderUtils.ChildWithTopAssetMetadata[] childrenWithMetadata)
 ```
 
 
@@ -227,7 +227,7 @@ function getChildrenWithTopMetadata(address parentAddress, uint256 parentId) ext
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKEquipRenderUtils.ChildWithTopAssetMetadata[] | An array of `ChildWithTopAssetMetadata` structs representing the children with their top asset metadata |
+| childrenWithMetadata | RMRKEquipRenderUtils.ChildWithTopAssetMetadata[] | An array of `ChildWithTopAssetMetadata` structs representing the children with their top asset metadata |
 
 ### getEquippableSlotsFromParent
 
@@ -308,7 +308,7 @@ Used to retrieve the equipped parts of the given token.
 ### getExtendedActiveAssets
 
 ```solidity
-function getExtendedActiveAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.ExtendedActiveAsset[])
+function getExtendedActiveAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] activeAssets)
 ```
 
 Used to get the active assets of the given token.
@@ -326,12 +326,12 @@ Used to get the active assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | An array of ActiveAssets present on the given token |
+| activeAssets | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | An array of ActiveAssets present on the given token |
 
 ### getExtendedEquippableActiveAssets
 
 ```solidity
-function getExtendedEquippableActiveAssets(address target, uint256 tokenId) external view returns (struct RMRKEquipRenderUtils.ExtendedEquippableActiveAsset[])
+function getExtendedEquippableActiveAssets(address target, uint256 tokenId) external view returns (struct RMRKEquipRenderUtils.ExtendedEquippableActiveAsset[] activeAssets)
 ```
 
 Used to get extended active assets of the given token.
@@ -349,7 +349,7 @@ Used to get extended active assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKEquipRenderUtils.ExtendedEquippableActiveAsset[] | An array of ExtendedEquippableActiveAssets present on the given token |
+| activeAssets | RMRKEquipRenderUtils.ExtendedEquippableActiveAsset[] | An array of ExtendedEquippableActiveAssets present on the given token |
 
 ### getExtendedNft
 
@@ -377,7 +377,7 @@ Used to get extended information about a specified token.
 ### getExtendedPendingAssets
 
 ```solidity
-function getExtendedPendingAssets(address target, uint256 tokenId) external view returns (struct RMRKEquipRenderUtils.ExtendedPendingAsset[])
+function getExtendedPendingAssets(address target, uint256 tokenId) external view returns (struct RMRKEquipRenderUtils.ExtendedPendingAsset[] pendingAssets)
 ```
 
 Used to get the extended pending assets of the given token.
@@ -395,7 +395,7 @@ Used to get the extended pending assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKEquipRenderUtils.ExtendedPendingAsset[] | An array of ExtendedPendingAssets present on the given token |
+| pendingAssets | RMRKEquipRenderUtils.ExtendedPendingAsset[] | An array of ExtendedPendingAssets present on the given token |
 
 ### getParent
 
@@ -424,7 +424,7 @@ Used to retrieve the contract address and ID of the parent token of the specifie
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.PendingAsset[])
+function getPendingAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.PendingAsset[] pendingAssets)
 ```
 
 Used to get the pending assets of the given token.
@@ -442,12 +442,12 @@ Used to get the pending assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.PendingAsset[] | An array of PendingAssets present on the given token |
+| pendingAssets | RMRKMultiAssetRenderUtils.PendingAsset[] | An array of PendingAssets present on the given token |
 
 ### getPendingChildIndex
 
 ```solidity
-function getPendingChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
+function getPendingChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256 index)
 ```
 
 Used to retrieve the given child&#39;s index in its parent&#39;s pending child tokens array.
@@ -467,7 +467,7 @@ Used to retrieve the given child&#39;s index in its parent&#39;s pending child t
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The index of the child token in the parent token&#39;s pending child tokens array |
+| index | uint256 | The index of the child token in the parent token&#39;s pending child tokens array |
 
 ### getSlotPartsAndCatalog
 
@@ -545,7 +545,7 @@ Used to retrieve the equippable data of the specified token&#39;s asset with the
 ### getTopAssetMetaForToken
 
 ```solidity
-function getTopAssetMetaForToken(address target, uint256 tokenId) external view returns (string)
+function getTopAssetMetaForToken(address target, uint256 tokenId) external view returns (string metadata)
 ```
 
 Used to retrieve the metadata URI of the specified token&#39;s asset with the highest priority.
@@ -563,7 +563,7 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset with the highest priority |
+| metadata | string | The metadata URI of the asset with the highest priority |
 
 ### getTopAssetMetadataForTokens
 
@@ -615,7 +615,7 @@ Used to retrieve the total number of descendants of the given token and whether 
 ### hasMoreThanOneLevelOfNesting
 
 ```solidity
-function hasMoreThanOneLevelOfNesting(address collection, uint256 tokenId) external view returns (bool)
+function hasMoreThanOneLevelOfNesting(address collection, uint256 tokenId) external view returns (bool hasMoreThanOneLevelOfNesting_)
 ```
 
 Used to retrieve whether a token has more than one level of nesting.
@@ -633,7 +633,7 @@ Used to retrieve whether a token has more than one level of nesting.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the given token has more than one level of nesting |
+| hasMoreThanOneLevelOfNesting_ | bool | A boolean value indicating whether the given token has more than one level of nesting |
 
 ### isAssetEquipped
 
@@ -713,7 +713,7 @@ Used to split slot and fixed parts.
 ### validateChildOf
 
 ```solidity
-function validateChildOf(address parentAddress, address childAddress, uint256 parentId, uint256 childId) external view returns (bool)
+function validateChildOf(address parentAddress, address childAddress, uint256 parentId, uint256 childId) external view returns (bool validChild)
 ```
 
 Used to validate whether the specified child token is owned by a given parent token.
@@ -733,12 +733,12 @@ Used to validate whether the specified child token is owned by a given parent to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is owned by the parent token or not |
+| validChild | bool | A boolean value indicating whether the child token is owned by the parent token or not |
 
 ### validateChildrenOf
 
 ```solidity
-function validateChildrenOf(address parentAddress, address[] childAddresses, uint256 parentId, uint256[] childIds) external view returns (bool, bool[])
+function validateChildrenOf(address parentAddress, address[] childAddresses, uint256 parentId, uint256[] childIds) external view returns (bool isValid, bool[] validityOfChildren)
 ```
 
 Used to validate whether the specified child token is owned by a given parent token.
@@ -758,8 +758,8 @@ Used to validate whether the specified child token is owned by a given parent to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether all of the child tokens are owned by the parent token or not |
-| _1 | bool[] | An array of boolean values indicating whether each of the child tokens are owned by the parent token or  not |
+| isValid | bool | A boolean value indicating whether all of the child tokens are owned by the parent token or not |
+| validityOfChildren | bool[] | An array of boolean values indicating whether each of the child tokens are owned by the parent token or  not |
 
 
 

--- a/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
+++ b/docs/RMRK/utils/RMRKMultiAssetRenderUtils.md
@@ -13,7 +13,7 @@
 ### getAssetIdWithTopPriority
 
 ```solidity
-function getAssetIdWithTopPriority(address target, uint256 tokenId) external view returns (uint64, uint64)
+function getAssetIdWithTopPriority(address target, uint256 tokenId) external view returns (uint64 maxPriorityAssetId, uint64 maxPriority)
 ```
 
 Used to retrieve the ID of the specified token&#39;s asset with the highest priority.
@@ -31,13 +31,13 @@ Used to retrieve the ID of the specified token&#39;s asset with the highest prio
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | The ID of the asset with the highest priority |
-| _1 | uint64 | The priority value of the asset with the highest priority |
+| maxPriorityAssetId | uint64 | The ID of the asset with the highest priority |
+| maxPriority | uint64 | The priority value of the asset with the highest priority |
 
 ### getAssetsById
 
 ```solidity
-function getAssetsById(address target, uint256 tokenId, uint64[] assetIds) external view returns (string[])
+function getAssetsById(address target, uint256 tokenId, uint64[] assetIds) external view returns (string[] assets)
 ```
 
 Used to retrieve the metadata URI of specified assets in the specified token.
@@ -56,12 +56,12 @@ Used to retrieve the metadata URI of specified assets in the specified token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string[] | An array of metadata URIs belonging to specified assets |
+| assets | string[] | An array of metadata URIs belonging to specified assets |
 
 ### getExtendedActiveAssets
 
 ```solidity
-function getExtendedActiveAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.ExtendedActiveAsset[])
+function getExtendedActiveAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] activeAssets)
 ```
 
 Used to get the active assets of the given token.
@@ -79,12 +79,12 @@ Used to get the active assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | An array of ActiveAssets present on the given token |
+| activeAssets | RMRKMultiAssetRenderUtils.ExtendedActiveAsset[] | An array of ActiveAssets present on the given token |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.PendingAsset[])
+function getPendingAssets(address target, uint256 tokenId) external view returns (struct RMRKMultiAssetRenderUtils.PendingAsset[] pendingAssets)
 ```
 
 Used to get the pending assets of the given token.
@@ -102,7 +102,7 @@ Used to get the pending assets of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | RMRKMultiAssetRenderUtils.PendingAsset[] | An array of PendingAssets present on the given token |
+| pendingAssets | RMRKMultiAssetRenderUtils.PendingAsset[] | An array of PendingAssets present on the given token |
 
 ### getTopAsset
 
@@ -132,7 +132,7 @@ Used to retrieve ID, priority value and metadata URI of the asset with the highe
 ### getTopAssetMetaForToken
 
 ```solidity
-function getTopAssetMetaForToken(address target, uint256 tokenId) external view returns (string)
+function getTopAssetMetaForToken(address target, uint256 tokenId) external view returns (string metadata)
 ```
 
 Used to retrieve the metadata URI of the specified token&#39;s asset with the highest priority.
@@ -150,7 +150,7 @@ Used to retrieve the metadata URI of the specified token&#39;s asset with the hi
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset with the highest priority |
+| metadata | string | The metadata URI of the asset with the highest priority |
 
 ### getTopAssetMetadataForTokens
 

--- a/docs/RMRK/utils/RMRKNestableRenderUtils.md
+++ b/docs/RMRK/utils/RMRKNestableRenderUtils.md
@@ -59,7 +59,7 @@ Used to retrieve the immediate owner of the given token, and whether it is on th
 ### getChildIndex
 
 ```solidity
-function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
+function getChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256 index)
 ```
 
 Used to retrieve the given child&#39;s index in its parent&#39;s child tokens array.
@@ -79,7 +79,7 @@ Used to retrieve the given child&#39;s index in its parent&#39;s child tokens ar
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The index of the child token in the parent token&#39;s child tokens array |
+| index | uint256 | The index of the child token in the parent token&#39;s child tokens array |
 
 ### getParent
 
@@ -108,7 +108,7 @@ Used to retrieve the contract address and ID of the parent token of the specifie
 ### getPendingChildIndex
 
 ```solidity
-function getPendingChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256)
+function getPendingChildIndex(address parentAddress, uint256 parentId, address childAddress, uint256 childId) external view returns (uint256 index)
 ```
 
 Used to retrieve the given child&#39;s index in its parent&#39;s pending child tokens array.
@@ -128,7 +128,7 @@ Used to retrieve the given child&#39;s index in its parent&#39;s pending child t
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The index of the child token in the parent token&#39;s pending child tokens array |
+| index | uint256 | The index of the child token in the parent token&#39;s pending child tokens array |
 
 ### getTotalDescendants
 
@@ -157,7 +157,7 @@ Used to retrieve the total number of descendants of the given token and whether 
 ### hasMoreThanOneLevelOfNesting
 
 ```solidity
-function hasMoreThanOneLevelOfNesting(address collection, uint256 tokenId) external view returns (bool)
+function hasMoreThanOneLevelOfNesting(address collection, uint256 tokenId) external view returns (bool hasMoreThanOneLevelOfNesting_)
 ```
 
 Used to retrieve whether a token has more than one level of nesting.
@@ -175,7 +175,7 @@ Used to retrieve whether a token has more than one level of nesting.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the given token has more than one level of nesting |
+| hasMoreThanOneLevelOfNesting_ | bool | A boolean value indicating whether the given token has more than one level of nesting |
 
 ### isTokenRejectedOrAbandoned
 
@@ -203,7 +203,7 @@ Used to identify if the given token is rejected or abandoned. That is, it&#39;s 
 ### validateChildOf
 
 ```solidity
-function validateChildOf(address parentAddress, address childAddress, uint256 parentId, uint256 childId) external view returns (bool)
+function validateChildOf(address parentAddress, address childAddress, uint256 parentId, uint256 childId) external view returns (bool validChild)
 ```
 
 Used to validate whether the specified child token is owned by a given parent token.
@@ -223,12 +223,12 @@ Used to validate whether the specified child token is owned by a given parent to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is owned by the parent token or not |
+| validChild | bool | A boolean value indicating whether the child token is owned by the parent token or not |
 
 ### validateChildrenOf
 
 ```solidity
-function validateChildrenOf(address parentAddress, address[] childAddresses, uint256 parentId, uint256[] childIds) external view returns (bool, bool[])
+function validateChildrenOf(address parentAddress, address[] childAddresses, uint256 parentId, uint256[] childIds) external view returns (bool isValid, bool[] validityOfChildren)
 ```
 
 Used to validate whether the specified child token is owned by a given parent token.
@@ -248,8 +248,8 @@ Used to validate whether the specified child token is owned by a given parent to
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether all of the child tokens are owned by the parent token or not |
-| _1 | bool[] | An array of boolean values indicating whether each of the child tokens are owned by the parent token or  not |
+| isValid | bool | A boolean value indicating whether all of the child tokens are owned by the parent token or not |
+| validityOfChildren | bool[] | An array of boolean values indicating whether each of the child tokens are owned by the parent token or  not |
 
 
 

--- a/docs/implementations/RMRKCatalogImpl.md
+++ b/docs/implementations/RMRKCatalogImpl.md
@@ -62,7 +62,7 @@ function addPartList(IRMRKCatalog.IntakeStruct[] intakeStructs) external nonpaya
 ### checkIsEquippable
 
 ```solidity
-function checkIsEquippable(uint64 partId, address targetAddress) external view returns (bool)
+function checkIsEquippable(uint64 partId, address targetAddress) external view returns (bool isEquippable)
 ```
 
 Used to check whether the given address is allowed to equip the desired `Part`.
@@ -80,12 +80,12 @@ Used to check whether the given address is allowed to equip the desired `Part`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
+| isEquippable | bool | The status indicating whether the `targetAddress` can be equipped into `Part` with `partId` or not |
 
 ### checkIsEquippableToAll
 
 ```solidity
-function checkIsEquippableToAll(uint64 partId) external view returns (bool)
+function checkIsEquippableToAll(uint64 partId) external view returns (bool isEquippable)
 ```
 
 Used to check if the part is equippable by all addresses.
@@ -102,12 +102,12 @@ Used to check if the part is equippable by all addresses.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
+| isEquippable | bool | The status indicating whether the part with `partId` can be equipped by any address or not |
 
 ### getLock
 
 ```solidity
-function getLock() external view returns (bool)
+function getLock() external view returns (bool isLocked)
 ```
 
 Used to retrieve the status of a lockable smart contract.
@@ -119,7 +119,7 @@ Used to retrieve the status of a lockable smart contract.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the smart contract has been locked |
+| isLocked | bool | A boolean value signifying whether the smart contract has been locked |
 
 ### getMetadataURI
 
@@ -141,7 +141,7 @@ Used to return the metadata URI of the associated Catalog.
 ### getPart
 
 ```solidity
-function getPart(uint64 partId) external view returns (struct IRMRKCatalog.Part)
+function getPart(uint64 partId) external view returns (struct IRMRKCatalog.Part part)
 ```
 
 Used to retrieve a `Part` with id `partId`
@@ -158,12 +158,12 @@ Used to retrieve a `Part` with id `partId`
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
+| part | IRMRKCatalog.Part | The `Part` struct associated with given `partId` |
 
 ### getParts
 
 ```solidity
-function getParts(uint64[] partIds) external view returns (struct IRMRKCatalog.Part[])
+function getParts(uint64[] partIds) external view returns (struct IRMRKCatalog.Part[] parts)
 ```
 
 Used to retrieve multiple parts at the same time.
@@ -180,7 +180,7 @@ Used to retrieve multiple parts at the same time.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
+| parts | IRMRKCatalog.Part[] | An array of `Part` structs associated with given `partIds` |
 
 ### getType
 
@@ -202,7 +202,7 @@ Used to return the `itemType` of the associated Catalog
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -219,7 +219,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -241,7 +241,7 @@ Adds or removes a contributor to the smart contract.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -253,7 +253,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### renounceOwnership
 

--- a/docs/implementations/abstract/RMRKAbstractEquippable.md
+++ b/docs/implementations/abstract/RMRKAbstractEquippable.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -142,7 +142,7 @@ Used to add a child token to a given parent token.
 ### addEquippableAssetEntry
 
 ```solidity
-function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256)
+function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add an equippable asset entry.
@@ -162,7 +162,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets after this asset has been added |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### approve
 
@@ -201,7 +201,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -218,7 +218,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -239,7 +239,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -257,12 +257,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -282,12 +282,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -305,12 +305,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -327,15 +327,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -344,12 +344,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,7 +366,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -389,7 +389,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -428,12 +428,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -450,12 +450,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -472,12 +472,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -495,15 +495,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -521,12 +521,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -544,12 +544,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -568,12 +568,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -590,12 +590,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -607,12 +607,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -624,12 +624,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -647,12 +647,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -670,12 +670,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -694,12 +694,12 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -716,7 +716,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -738,7 +738,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -750,12 +750,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -767,7 +767,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -792,7 +792,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -804,12 +804,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -826,12 +826,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -849,12 +849,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -871,7 +871,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -1091,7 +1091,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1103,12 +1103,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1120,12 +1120,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1137,7 +1137,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/abstract/RMRKAbstractEquippable.md
+++ b/docs/implementations/abstract/RMRKAbstractEquippable.md
@@ -349,7 +349,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,9 +366,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/implementations/abstract/RMRKAbstractEquippable.md
+++ b/docs/implementations/abstract/RMRKAbstractEquippable.md
@@ -1701,6 +1701,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/abstract/RMRKAbstractMultiAsset.md
+++ b/docs/implementations/abstract/RMRKAbstractMultiAsset.md
@@ -65,7 +65,7 @@ Accepts an asset at from the pending array of given token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -82,7 +82,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -139,7 +139,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -156,7 +156,7 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -177,10 +177,10 @@ Used to destroy the specified token.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -189,12 +189,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -211,12 +211,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -233,12 +233,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -255,12 +255,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -277,12 +277,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -300,12 +300,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -323,12 +323,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -345,12 +345,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -362,12 +362,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -379,12 +379,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -402,12 +402,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -425,12 +425,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -447,7 +447,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -469,7 +469,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -481,12 +481,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -498,12 +498,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -515,12 +515,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -537,7 +537,7 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -722,7 +722,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -734,12 +734,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -751,12 +751,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -768,7 +768,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 

--- a/docs/implementations/abstract/RMRKAbstractMultiAsset.md
+++ b/docs/implementations/abstract/RMRKAbstractMultiAsset.md
@@ -1136,6 +1136,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/abstract/RMRKAbstractNestable.md
+++ b/docs/implementations/abstract/RMRKAbstractNestable.md
@@ -224,7 +224,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,9 +241,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/implementations/abstract/RMRKAbstractNestable.md
+++ b/docs/implementations/abstract/RMRKAbstractNestable.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,15 +202,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -219,12 +219,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,14 +241,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -265,12 +265,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -282,12 +282,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -299,12 +299,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -322,12 +322,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -344,7 +344,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -366,7 +366,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -378,12 +378,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -395,7 +395,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -420,7 +420,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -432,12 +432,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -454,12 +454,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -477,12 +477,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -499,7 +499,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -632,7 +632,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -644,12 +644,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -661,12 +661,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -678,7 +678,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/abstract/RMRKAbstractNestableMultiAsset.md
+++ b/docs/implementations/abstract/RMRKAbstractNestableMultiAsset.md
@@ -1465,6 +1465,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/abstract/RMRKAbstractNestableMultiAsset.md
+++ b/docs/implementations/abstract/RMRKAbstractNestableMultiAsset.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -176,7 +176,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -193,7 +193,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -214,7 +214,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -232,12 +232,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -255,12 +255,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -277,15 +277,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -294,12 +294,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,14 +316,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -340,12 +340,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -362,12 +362,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -384,12 +384,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -429,12 +429,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -452,12 +452,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -474,12 +474,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -491,12 +491,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -508,12 +508,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -531,12 +531,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -554,12 +554,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -576,7 +576,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -598,7 +598,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -610,12 +610,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -627,7 +627,7 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestTransferFrom
 
@@ -652,7 +652,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -664,12 +664,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -686,12 +686,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -709,12 +709,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -731,7 +731,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -933,7 +933,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -945,12 +945,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -962,12 +962,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -979,7 +979,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/abstract/RMRKAbstractNestableMultiAsset.md
+++ b/docs/implementations/abstract/RMRKAbstractNestableMultiAsset.md
@@ -299,7 +299,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,9 +316,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
@@ -1844,6 +1844,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
@@ -349,7 +349,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,9 +366,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -142,7 +142,7 @@ Used to add a child token to a given parent token.
 ### addEquippableAssetEntry
 
 ```solidity
-function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256)
+function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add an equippable asset entry.
@@ -162,7 +162,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets after this asset has been added |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### approve
 
@@ -201,7 +201,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -218,7 +218,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -239,7 +239,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -257,12 +257,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -282,12 +282,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -305,12 +305,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -327,15 +327,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -344,12 +344,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,7 +366,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -389,7 +389,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -401,12 +401,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -423,12 +423,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -445,12 +445,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -467,12 +467,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -489,12 +489,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -512,15 +512,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -538,12 +538,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -561,12 +561,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -585,12 +585,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -607,12 +607,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -624,12 +624,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -641,12 +641,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -664,12 +664,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -687,12 +687,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -711,12 +711,12 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -733,7 +733,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -755,7 +755,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -767,12 +767,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -790,12 +790,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -807,12 +807,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -831,7 +831,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -856,7 +856,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -868,12 +868,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -890,12 +890,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -913,12 +913,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -935,12 +935,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -952,7 +952,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -1172,7 +1172,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1184,12 +1184,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1206,12 +1206,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1223,12 +1223,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1240,7 +1240,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -142,7 +142,7 @@ Used to add a child token to a given parent token.
 ### addEquippableAssetEntry
 
 ```solidity
-function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256)
+function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add an equippable asset entry.
@@ -162,7 +162,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets after this asset has been added |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### approve
 
@@ -201,7 +201,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -218,7 +218,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -239,7 +239,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -257,12 +257,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -282,12 +282,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -305,12 +305,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -327,15 +327,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -344,12 +344,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,7 +366,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -389,7 +389,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -401,12 +401,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -423,12 +423,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -445,12 +445,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -467,12 +467,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -489,12 +489,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -512,15 +512,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -538,12 +538,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -561,12 +561,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -585,12 +585,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -607,12 +607,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -624,12 +624,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -641,12 +641,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -664,12 +664,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -687,12 +687,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -711,12 +711,12 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -733,12 +733,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -757,7 +757,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -779,7 +779,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -791,12 +791,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -814,12 +814,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -831,12 +831,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -855,7 +855,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -880,7 +880,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -892,12 +892,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -914,12 +914,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -937,12 +937,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -959,12 +959,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -976,7 +976,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -1196,7 +1196,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1208,12 +1208,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1230,12 +1230,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1247,12 +1247,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1264,7 +1264,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
@@ -349,7 +349,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,9 +366,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md
@@ -1868,6 +1868,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.md
@@ -65,7 +65,7 @@ Accepts an asset at from the pending array of given token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -82,7 +82,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -139,7 +139,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -156,7 +156,7 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -177,10 +177,10 @@ Used to destroy the specified token.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -189,12 +189,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -206,12 +206,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -228,12 +228,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -250,12 +250,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -272,12 +272,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -294,12 +294,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -317,12 +317,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -340,12 +340,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -362,12 +362,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -379,12 +379,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -396,12 +396,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -419,12 +419,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -442,12 +442,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -464,7 +464,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -486,7 +486,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -498,12 +498,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -521,12 +521,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -538,12 +538,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -555,12 +555,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -577,12 +577,12 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -594,7 +594,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -779,7 +779,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -791,12 +791,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -813,12 +813,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -830,12 +830,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -847,7 +847,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 

--- a/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.md
@@ -1255,6 +1255,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.md
@@ -65,7 +65,7 @@ Accepts an asset at from the pending array of given token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -82,7 +82,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -139,7 +139,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -156,7 +156,7 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -177,10 +177,10 @@ Used to destroy the specified token.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -189,12 +189,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -206,12 +206,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -228,12 +228,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -250,12 +250,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -272,12 +272,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -294,12 +294,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -317,12 +317,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -340,12 +340,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -362,12 +362,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -379,12 +379,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -396,12 +396,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -419,12 +419,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -442,12 +442,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -464,12 +464,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -488,7 +488,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -510,7 +510,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -522,12 +522,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -545,12 +545,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -562,12 +562,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -579,12 +579,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -601,12 +601,12 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -618,7 +618,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -803,7 +803,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -815,12 +815,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -837,12 +837,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -854,12 +854,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -871,7 +871,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 

--- a/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.md
@@ -1279,6 +1279,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,15 +202,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -219,12 +219,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,14 +241,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -260,12 +260,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -282,12 +282,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -299,12 +299,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -316,12 +316,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -339,12 +339,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -361,7 +361,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -383,7 +383,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -395,12 +395,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -418,12 +418,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -435,12 +435,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -459,7 +459,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -484,7 +484,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -496,12 +496,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -518,12 +518,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -541,12 +541,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -563,12 +563,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -580,7 +580,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -713,7 +713,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -725,12 +725,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -747,12 +747,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -764,12 +764,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -781,7 +781,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.md
@@ -224,7 +224,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,9 +241,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 

--- a/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,15 +202,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -219,12 +219,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,14 +241,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -260,12 +260,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -282,12 +282,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -299,12 +299,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -316,12 +316,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -339,12 +339,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -361,12 +361,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -385,7 +385,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -407,7 +407,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -419,12 +419,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -442,12 +442,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -459,12 +459,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -483,7 +483,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -508,7 +508,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -520,12 +520,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -542,12 +542,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -565,12 +565,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -587,12 +587,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -604,7 +604,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -737,7 +737,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -749,12 +749,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -771,12 +771,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -788,12 +788,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -805,7 +805,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.md
@@ -224,7 +224,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,9 +241,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
@@ -1608,6 +1608,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -176,7 +176,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -193,7 +193,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -214,7 +214,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -232,12 +232,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -255,12 +255,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -277,15 +277,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -294,12 +294,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,14 +316,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -335,12 +335,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -357,12 +357,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -379,12 +379,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -401,12 +401,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -423,12 +423,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -446,12 +446,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -469,12 +469,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -491,12 +491,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -508,12 +508,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -525,12 +525,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -548,12 +548,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -571,12 +571,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -593,7 +593,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -615,7 +615,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -627,12 +627,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -650,12 +650,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -667,12 +667,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -691,7 +691,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -716,7 +716,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -728,12 +728,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -750,12 +750,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -773,12 +773,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -795,12 +795,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -812,7 +812,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -1014,7 +1014,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1026,12 +1026,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1048,12 +1048,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1065,12 +1065,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1082,7 +1082,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md
@@ -299,7 +299,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,9 +316,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
@@ -1632,6 +1632,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -176,7 +176,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -193,7 +193,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -214,7 +214,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -232,12 +232,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -255,12 +255,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -277,15 +277,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -294,12 +294,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,14 +316,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 
 ```solidity
-function erc20TokenAddress() external view returns (address)
+function erc20TokenAddress() external view returns (address erc20Token)
 ```
 
 Used to retrieve the address of the ERC20 token this smart contract supports.
@@ -335,12 +335,12 @@ Used to retrieve the address of the ERC20 token this smart contract supports.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the ERC20 token&#39;s smart contract |
+| erc20Token | address | Address of the ERC20 token&#39;s smart contract |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -357,12 +357,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -379,12 +379,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -401,12 +401,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -423,12 +423,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -446,12 +446,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -469,12 +469,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -491,12 +491,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -508,12 +508,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -525,12 +525,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -548,12 +548,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -571,12 +571,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -593,12 +593,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -617,7 +617,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -639,7 +639,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -651,12 +651,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -674,12 +674,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -691,12 +691,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -715,7 +715,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -740,7 +740,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -752,12 +752,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -774,12 +774,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -797,12 +797,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -819,12 +819,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -836,7 +836,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -1038,7 +1038,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1050,12 +1050,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1072,12 +1072,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1089,12 +1089,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1106,7 +1106,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
+++ b/docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md
@@ -299,7 +299,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,9 +316,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### erc20TokenAddress
 

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -142,7 +142,7 @@ Used to add a child token to a given parent token.
 ### addEquippableAssetEntry
 
 ```solidity
-function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256)
+function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add an equippable asset entry.
@@ -162,7 +162,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets after this asset has been added |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### approve
 
@@ -201,7 +201,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -218,7 +218,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -239,7 +239,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -257,12 +257,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -282,12 +282,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -305,12 +305,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -327,15 +327,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -344,12 +344,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,7 +366,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -389,7 +389,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -428,12 +428,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -450,12 +450,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -472,12 +472,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -495,15 +495,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -521,12 +521,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -544,12 +544,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -568,12 +568,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -590,12 +590,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -607,12 +607,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -624,12 +624,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -647,12 +647,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -670,12 +670,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -694,12 +694,12 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -716,7 +716,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -738,7 +738,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -750,12 +750,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -773,12 +773,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -790,12 +790,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -814,7 +814,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -839,7 +839,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -851,12 +851,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -873,12 +873,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -896,12 +896,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -918,12 +918,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -935,7 +935,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -1155,7 +1155,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1167,12 +1167,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1189,12 +1189,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1206,12 +1206,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1223,7 +1223,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
@@ -349,7 +349,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,9 +366,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
@@ -1826,6 +1826,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md
@@ -1316,10 +1316,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -2276,6 +2276,17 @@ Attempting to pay with native token with a value different than expected
 
 ```solidity
 error RentrantCall()
+```
+
+
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
 ```
 
 

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -142,7 +142,7 @@ Used to add a child token to a given parent token.
 ### addEquippableAssetEntry
 
 ```solidity
-function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256)
+function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add an equippable asset entry.
@@ -162,7 +162,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets after this asset has been added |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### approve
 
@@ -201,7 +201,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -218,7 +218,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -239,7 +239,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -257,12 +257,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -282,12 +282,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -305,12 +305,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -327,15 +327,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -344,12 +344,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,7 +366,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -389,7 +389,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -428,12 +428,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -450,12 +450,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -472,12 +472,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -495,15 +495,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -521,12 +521,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -544,12 +544,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -568,12 +568,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -590,12 +590,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -607,12 +607,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -624,12 +624,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -647,12 +647,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -670,12 +670,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -694,12 +694,12 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -716,12 +716,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -740,7 +740,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -762,7 +762,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -774,12 +774,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -797,12 +797,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -814,12 +814,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -838,7 +838,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -863,7 +863,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -875,12 +875,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -897,12 +897,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -920,12 +920,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -942,12 +942,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -959,7 +959,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -1179,7 +1179,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1191,12 +1191,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1213,12 +1213,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1230,12 +1230,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1247,7 +1247,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
@@ -349,7 +349,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,9 +366,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
@@ -1340,10 +1340,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -2311,6 +2311,17 @@ Attempting to pay with native token with a value different than expected
 
 ```solidity
 error RentrantCall()
+```
+
+
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
 ```
 
 

--- a/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md
@@ -1850,6 +1850,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.md
@@ -1237,6 +1237,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.md
@@ -65,7 +65,7 @@ Accepts an asset at from the pending array of given token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -82,7 +82,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -139,7 +139,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -156,7 +156,7 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -177,10 +177,10 @@ Used to destroy the specified token.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -189,12 +189,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -211,12 +211,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -233,12 +233,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -255,12 +255,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -277,12 +277,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -300,12 +300,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -323,12 +323,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -345,12 +345,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -362,12 +362,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -379,12 +379,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -402,12 +402,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -425,12 +425,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -447,7 +447,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -469,7 +469,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -481,12 +481,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -504,12 +504,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -521,12 +521,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -538,12 +538,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -560,12 +560,12 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -577,7 +577,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -762,7 +762,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -774,12 +774,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -796,12 +796,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -813,12 +813,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -830,7 +830,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 

--- a/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.md
@@ -882,10 +882,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -1453,6 +1453,17 @@ error RMRKWrongValueSent()
 ```
 
 Attempting to pay with native token with a value different than expected
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
+```
+
+
 
 
 

--- a/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.md
@@ -906,10 +906,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -1488,6 +1488,17 @@ error RMRKWrongValueSent()
 ```
 
 Attempting to pay with native token with a value different than expected
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
+```
+
+
 
 
 

--- a/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.md
@@ -1261,6 +1261,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.md
@@ -65,7 +65,7 @@ Accepts an asset at from the pending array of given token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -82,7 +82,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -139,7 +139,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -156,7 +156,7 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -177,10 +177,10 @@ Used to destroy the specified token.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -189,12 +189,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -211,12 +211,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -233,12 +233,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -255,12 +255,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -277,12 +277,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -300,12 +300,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -323,12 +323,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -345,12 +345,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -362,12 +362,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -379,12 +379,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -402,12 +402,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -425,12 +425,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -447,12 +447,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -471,7 +471,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -493,7 +493,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -505,12 +505,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -528,12 +528,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -545,12 +545,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -562,12 +562,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -584,12 +584,12 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -601,7 +601,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -786,7 +786,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -798,12 +798,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -820,12 +820,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -837,12 +837,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -854,7 +854,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,15 +202,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -219,12 +219,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,14 +241,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -265,12 +265,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -282,12 +282,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -299,12 +299,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -322,12 +322,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -344,7 +344,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -366,7 +366,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -378,12 +378,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -401,12 +401,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -418,12 +418,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -442,7 +442,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -467,7 +467,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -479,12 +479,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -501,12 +501,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -524,12 +524,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -546,12 +546,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -563,7 +563,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -696,7 +696,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -708,12 +708,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -730,12 +730,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -747,12 +747,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -764,7 +764,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
@@ -224,7 +224,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,9 +241,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md
@@ -839,10 +839,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -1401,6 +1401,17 @@ error RMRKWrongValueSent()
 ```
 
 Attempting to pay with native token with a value different than expected
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
+```
+
+
 
 
 

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
@@ -863,10 +863,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -1436,6 +1436,17 @@ error RMRKWrongValueSent()
 ```
 
 Attempting to pay with native token with a value different than expected
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
+```
+
+
 
 
 

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
@@ -224,7 +224,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,9 +241,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,15 +202,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -219,12 +219,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,14 +241,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -265,12 +265,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -282,12 +282,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -299,12 +299,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -322,12 +322,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -344,12 +344,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -368,7 +368,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -390,7 +390,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -402,12 +402,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -425,12 +425,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -442,12 +442,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -466,7 +466,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -491,7 +491,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -503,12 +503,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -525,12 +525,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -548,12 +548,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -570,12 +570,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -587,7 +587,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllChildren
 
@@ -720,7 +720,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -732,12 +732,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -754,12 +754,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -771,12 +771,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -788,7 +788,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
@@ -1590,6 +1590,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -176,7 +176,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -193,7 +193,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -214,7 +214,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -232,12 +232,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -255,12 +255,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -277,15 +277,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -294,12 +294,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,14 +316,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -340,12 +340,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -362,12 +362,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -384,12 +384,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -429,12 +429,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -452,12 +452,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -474,12 +474,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -491,12 +491,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -508,12 +508,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -531,12 +531,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -554,12 +554,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -576,7 +576,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -598,7 +598,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -610,12 +610,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -633,12 +633,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -650,12 +650,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -674,7 +674,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -699,7 +699,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -711,12 +711,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -733,12 +733,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -756,12 +756,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -778,12 +778,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -795,7 +795,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -997,7 +997,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1009,12 +1009,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1031,12 +1031,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1048,12 +1048,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1065,7 +1065,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
@@ -1140,10 +1140,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -1955,6 +1955,17 @@ error RMRKWrongValueSent()
 ```
 
 Attempting to pay with native token with a value different than expected
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
+```
+
+
 
 
 

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md
@@ -299,7 +299,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,9 +316,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
@@ -1614,6 +1614,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
@@ -1164,10 +1164,10 @@ Used to update recipient of royalties.
 |---|---|---|
 | newRoyaltyRecipient | address | Address of the new recipient of royalties |
 
-### withdrawRaised
+### withdraw
 
 ```solidity
-function withdrawRaised(address to, uint256 amount) external nonpayable
+function withdraw(address to, uint256 amount) external nonpayable
 ```
 
 Used to withdraw the minting proceedings to a specified address.
@@ -1990,6 +1990,17 @@ error RMRKWrongValueSent()
 ```
 
 Attempting to pay with native token with a value different than expected
+
+
+
+
+### TransferFailed
+
+```solidity
+error TransferFailed()
+```
+
+
 
 
 

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
@@ -299,7 +299,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,9 +316,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 

--- a/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
+++ b/docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -176,7 +176,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -193,7 +193,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -214,7 +214,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -232,12 +232,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -255,12 +255,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -277,15 +277,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -294,12 +294,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,14 +316,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -340,12 +340,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -362,12 +362,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -384,12 +384,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -429,12 +429,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -452,12 +452,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -474,12 +474,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -491,12 +491,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -508,12 +508,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -531,12 +531,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -554,12 +554,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -576,12 +576,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -600,7 +600,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -622,7 +622,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -634,12 +634,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint) external payable returns (uint256)
+function mint(address to, uint256 numToMint) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -657,12 +657,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -674,12 +674,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId) external payable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -698,7 +698,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -723,7 +723,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -735,12 +735,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -757,12 +757,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -780,12 +780,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -802,12 +802,12 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### pricePerMint
 
 ```solidity
-function pricePerMint() external view returns (uint256)
+function pricePerMint() external view returns (uint256 price)
 ```
 
 Used to retrieve the price per mint.
@@ -819,7 +819,7 @@ Used to retrieve the price per mint.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
+| price | uint256 | The price per mint of a single token expressed in the lowest denomination of a native currency |
 
 ### rejectAllAssets
 
@@ -1021,7 +1021,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1033,12 +1033,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1055,12 +1055,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1072,12 +1072,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1089,7 +1089,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/premint/RMRKEquippablePreMint.md
+++ b/docs/implementations/premint/RMRKEquippablePreMint.md
@@ -1794,6 +1794,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/premint/RMRKEquippablePreMint.md
+++ b/docs/implementations/premint/RMRKEquippablePreMint.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -142,7 +142,7 @@ Used to add a child token to a given parent token.
 ### addEquippableAssetEntry
 
 ```solidity
-function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256)
+function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add an equippable asset entry.
@@ -162,7 +162,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets after this asset has been added |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### approve
 
@@ -201,7 +201,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -218,7 +218,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -239,7 +239,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -257,12 +257,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -282,12 +282,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -305,12 +305,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -327,15 +327,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -344,12 +344,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,7 +366,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -389,7 +389,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -428,12 +428,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -450,12 +450,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -472,12 +472,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -495,15 +495,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -521,12 +521,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -544,12 +544,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -568,12 +568,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -590,12 +590,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -607,12 +607,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -624,12 +624,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -647,12 +647,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -670,12 +670,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -694,12 +694,12 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -716,7 +716,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -738,7 +738,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -750,12 +750,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -774,12 +774,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -791,12 +791,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -816,7 +816,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -841,7 +841,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -853,12 +853,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -875,12 +875,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -898,12 +898,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -920,7 +920,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -1140,7 +1140,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1152,12 +1152,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1174,12 +1174,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1191,12 +1191,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1208,7 +1208,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/premint/RMRKEquippablePreMint.md
+++ b/docs/implementations/premint/RMRKEquippablePreMint.md
@@ -349,7 +349,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,9 +366,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
@@ -349,7 +349,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,9 +366,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### equip
 

--- a/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -142,7 +142,7 @@ Used to add a child token to a given parent token.
 ### addEquippableAssetEntry
 
 ```solidity
-function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256)
+function addEquippableAssetEntry(uint64 equippableGroupId, address catalogAddress, string metadataURI, uint64[] partIds) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add an equippable asset entry.
@@ -162,7 +162,7 @@ Used to add an equippable asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets after this asset has been added |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### approve
 
@@ -201,7 +201,7 @@ Used to grant approvals for specific tokens to a specified address.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -218,7 +218,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -239,7 +239,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -257,12 +257,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### canTokenBeEquippedWithAssetIntoSlot
 
 ```solidity
-function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool)
+function canTokenBeEquippedWithAssetIntoSlot(address parent, uint256 tokenId, uint64 assetId, uint64 slotId) external view returns (bool canBeEquipped)
 ```
 
 Used to verify whether a token can be equipped into a given parent&#39;s slot.
@@ -282,12 +282,12 @@ Used to verify whether a token can be equipped into a given parent&#39;s slot.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
+| canBeEquipped | bool | A boolean indicating whether the token with the given asset can be equipped into the desired slot |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -305,12 +305,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -327,15 +327,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -344,12 +344,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -366,7 +366,7 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
@@ -389,7 +389,7 @@ function equip(IERC6220.IntakeEquip data) external nonpayable
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -428,12 +428,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -450,12 +450,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to get the address of the user that is approved to manage the specified token from the current  owner.
@@ -472,12 +472,12 @@ Used to get the address of the user that is approved to manage the specified tok
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the token |
+| approved | address | Address of the account that is approved to manage the token |
 
 ### getAssetAndEquippableData
 
 ```solidity
-function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string, uint64, address, uint64[])
+function getAssetAndEquippableData(uint256 tokenId, uint64 assetId) external view returns (string metadataURI, uint64 equippableGroupId, address catalogAddress, uint64[] partIds)
 ```
 
 Used to get the asset and equippable data associated with given `assetId`.
@@ -495,15 +495,15 @@ Used to get the asset and equippable data associated with given `assetId`.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata URI of the asset |
-| _1 | uint64 | ID of the equippable group this asset belongs to |
-| _2 | address | The address of the catalog the part belongs to |
-| _3 | uint64[] | An array of IDs of parts included in the asset |
+| metadataURI | string | The metadata URI of the asset |
+| equippableGroupId | uint64 | ID of the equippable group this asset belongs to |
+| catalogAddress | address | The address of the catalog the part belongs to |
+| partIds | uint64[] | An array of IDs of parts included in the asset |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -521,12 +521,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacedAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -544,12 +544,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacedAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getEquipment
 
 ```solidity
-function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment)
+function getEquipment(uint256 tokenId, address targetCatalogAddress, uint64 slotPartId) external view returns (struct IERC6220.Equipment equipment)
 ```
 
 Used to get the Equipment object equipped into the specified slot of the desired token.
@@ -568,12 +568,12 @@ Used to get the Equipment object equipped into the specified slot of the desired
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
+| equipment | IERC6220.Equipment | The `Equipment` struct containing data about the equipped object |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -590,12 +590,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -607,12 +607,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -624,12 +624,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -647,12 +647,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -670,12 +670,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isChildEquipped
 
 ```solidity
-function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool)
+function isChildEquipped(uint256 tokenId, address childAddress, uint256 childId) external view returns (bool isEquipped)
 ```
 
 Used to check whether the token has a given child equipped.
@@ -694,12 +694,12 @@ Used to check whether the token has a given child equipped.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating whether the child token is equipped into the given token or not |
+| isEquipped | bool | A boolean value indicating whether the child token is equipped into the given token or not |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -716,12 +716,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -740,7 +740,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -762,7 +762,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -774,12 +774,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -798,12 +798,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -815,12 +815,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -840,7 +840,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -865,7 +865,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -877,12 +877,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -899,12 +899,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -922,12 +922,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -944,7 +944,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -1164,7 +1164,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1176,12 +1176,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1198,12 +1198,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1215,12 +1215,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1232,7 +1232,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKEquippablePreMintSoulbound.md
@@ -1818,6 +1818,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/premint/RMRKMultiAssetPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetPreMint.md
@@ -65,7 +65,7 @@ Accepts an asset at from the pending array of given token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -82,7 +82,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -139,7 +139,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -156,7 +156,7 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -177,10 +177,10 @@ Used to destroy the specified token.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -189,12 +189,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -211,12 +211,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -233,12 +233,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -255,12 +255,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -277,12 +277,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -300,12 +300,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -323,12 +323,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -345,12 +345,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -362,12 +362,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -379,12 +379,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -402,12 +402,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -425,12 +425,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -447,7 +447,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -469,7 +469,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -481,12 +481,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -505,12 +505,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -522,12 +522,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -539,12 +539,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -561,7 +561,7 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -746,7 +746,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -758,12 +758,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -780,12 +780,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -797,12 +797,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -814,7 +814,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 

--- a/docs/implementations/premint/RMRKMultiAssetPreMint.md
+++ b/docs/implementations/premint/RMRKMultiAssetPreMint.md
@@ -1204,6 +1204,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/premint/RMRKMultiAssetPreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKMultiAssetPreMintSoulbound.md
@@ -1228,6 +1228,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/premint/RMRKMultiAssetPreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKMultiAssetPreMintSoulbound.md
@@ -65,7 +65,7 @@ Accepts an asset at from the pending array of given token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -82,7 +82,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -139,7 +139,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in ``owner``&#39;s account.
@@ -156,7 +156,7 @@ Used to retrieve the number of tokens in ``owner``&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -177,10 +177,10 @@ Used to destroy the specified token.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -189,12 +189,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -211,12 +211,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -233,12 +233,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -255,12 +255,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -277,12 +277,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -300,12 +300,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -323,12 +323,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -345,12 +345,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -362,12 +362,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -379,12 +379,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -402,12 +402,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -425,12 +425,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -447,12 +447,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -471,7 +471,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -493,7 +493,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -505,12 +505,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -529,12 +529,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -546,12 +546,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -563,12 +563,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner)
 ```
 
 Used to retrieve the owner of the given token.
@@ -585,7 +585,7 @@ Used to retrieve the owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account owning the token |
+| owner | address | Address of the account owning the token |
 
 ### rejectAllAssets
 
@@ -770,7 +770,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -782,12 +782,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -804,12 +804,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -821,12 +821,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -838,7 +838,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferFrom
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
@@ -1558,6 +1558,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -176,7 +176,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -193,7 +193,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -214,7 +214,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -232,12 +232,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -255,12 +255,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -277,15 +277,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -294,12 +294,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,14 +316,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -340,12 +340,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -362,12 +362,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -384,12 +384,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -429,12 +429,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -452,12 +452,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -474,12 +474,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -491,12 +491,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -508,12 +508,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -531,12 +531,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -554,12 +554,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -576,7 +576,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -598,7 +598,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -610,12 +610,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -634,12 +634,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -651,12 +651,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -676,7 +676,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -701,7 +701,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -713,12 +713,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -735,12 +735,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -758,12 +758,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -780,7 +780,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -982,7 +982,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -994,12 +994,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1016,12 +1016,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1033,12 +1033,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1050,7 +1050,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMint.md
@@ -299,7 +299,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,9 +316,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
@@ -1582,6 +1582,17 @@ Attempting to transfer the token to a 0x0 address
 
 
 
+### IndexOutOfBounds
+
+```solidity
+error IndexOutOfBounds()
+```
+
+
+
+
+
+
 ### RMRKApprovalForAssetsToCurrentOwner
 
 ```solidity

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
@@ -84,7 +84,7 @@ Used to accept a pending child token for a given parent token.
 ### addAssetEntry
 
 ```solidity
-function addAssetEntry(string metadataURI) external nonpayable returns (uint256)
+function addAssetEntry(string metadataURI) external nonpayable returns (uint256 assetId)
 ```
 
 Used to add a asset entry.
@@ -101,7 +101,7 @@ Used to add a asset entry.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | ID of the newly added asset |
+| assetId | uint256 | The ID of the newly added asset |
 
 ### addAssetToToken
 
@@ -176,7 +176,7 @@ Used to grant permission to the user to manage token&#39;s assets.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -193,7 +193,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -214,7 +214,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -232,12 +232,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -255,12 +255,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -277,15 +277,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -294,12 +294,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,14 +316,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 
 ```solidity
-function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[])
+function getActiveAssetPriorities(uint256 tokenId) external view returns (uint64[] priorities)
 ```
 
 Used to retrieve the priorities of the active resoources of a given token.
@@ -340,12 +340,12 @@ Used to retrieve the priorities of the active resoources of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of priorities of the active assets of the given token |
+| priorities | uint64[] | An array of priorities of the active assets of the given token |
 
 ### getActiveAssets
 
 ```solidity
-function getActiveAssets(uint256 tokenId) external view returns (uint64[])
+function getActiveAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the active assets of given token.
@@ -362,12 +362,12 @@ Used to retrieve IDs of the active assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of active asset IDs of the given token |
+| assetIds | uint64[] | An array of active asset IDs of the given token |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -384,12 +384,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getApprovedForAssets
 
 ```solidity
-function getApprovedForAssets(uint256 tokenId) external view returns (address)
+function getApprovedForAssets(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the address of the account approved to manage assets of a given token.
@@ -406,12 +406,12 @@ Used to retrieve the address of the account approved to manage assets of a given
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account that is approved to manage the specified token&#39;s assets |
+| approved | address | Address of the account that is approved to manage the specified token&#39;s assets |
 
 ### getAssetMetadata
 
 ```solidity
-function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string)
+function getAssetMetadata(uint256 tokenId, uint64 assetId) external view returns (string metadata)
 ```
 
 Used to fetch the asset metadata of the specified token&#39;s active asset with the given index.
@@ -429,12 +429,12 @@ Used to fetch the asset metadata of the specified token&#39;s active asset with 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
+| metadata | string | The metadata of the asset belonging to the specified index in the token&#39;s active assets  array |
 
 ### getAssetReplacements
 
 ```solidity
-function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64)
+function getAssetReplacements(uint256 tokenId, uint64 newAssetId) external view returns (uint64 replacesAssetId)
 ```
 
 Used to retrieve the asset that will be replaced if a given asset from the token&#39;s pending array  is accepted.
@@ -452,12 +452,12 @@ Used to retrieve the asset that will be replaced if a given asset from the token
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64 | ID of the asset which will be replaced |
+| replacesAssetId | uint64 | ID of the asset which will be replaced |
 
 ### getPendingAssets
 
 ```solidity
-function getPendingAssets(uint256 tokenId) external view returns (uint64[])
+function getPendingAssets(uint256 tokenId) external view returns (uint64[] assetIds)
 ```
 
 Used to retrieve IDs of the pending assets of given token.
@@ -474,12 +474,12 @@ Used to retrieve IDs of the pending assets of given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint64[] | An array of pending asset IDs of the given token |
+| assetIds | uint64[] | An array of pending asset IDs of the given token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -491,12 +491,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -508,12 +508,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -531,12 +531,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isApprovedForAllForAssets
 
 ```solidity
-function isApprovedForAllForAssets(address owner, address operator) external view returns (bool)
+function isApprovedForAllForAssets(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check whether the address has been granted the operator role by a given address or not.
@@ -554,12 +554,12 @@ Used to check whether the address has been granted the operator role by a given 
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value indicating wehter the account we are checking has been granted the operator role |
+| isApproved | bool | A boolean value indicating whether the account we are checking has been granted the operator role |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -576,12 +576,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -600,7 +600,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -622,7 +622,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -634,12 +634,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -658,12 +658,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -675,12 +675,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -700,7 +700,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -725,7 +725,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -737,12 +737,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -759,12 +759,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -782,12 +782,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -804,7 +804,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllAssets
 
@@ -1006,7 +1006,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -1018,12 +1018,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -1040,12 +1040,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -1057,12 +1057,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -1074,7 +1074,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md
@@ -299,7 +299,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -316,9 +316,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getActiveAssetPriorities
 

--- a/docs/implementations/premint/RMRKNestablePreMint.md
+++ b/docs/implementations/premint/RMRKNestablePreMint.md
@@ -224,7 +224,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,9 +241,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/implementations/premint/RMRKNestablePreMint.md
+++ b/docs/implementations/premint/RMRKNestablePreMint.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,15 +202,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -219,12 +219,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,14 +241,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -265,12 +265,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -282,12 +282,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -299,12 +299,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -322,12 +322,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -344,7 +344,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -366,7 +366,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -378,12 +378,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -402,12 +402,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -419,12 +419,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -444,7 +444,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -469,7 +469,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -481,12 +481,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -503,12 +503,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -526,12 +526,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -548,7 +548,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -681,7 +681,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -693,12 +693,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -715,12 +715,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -732,12 +732,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -749,7 +749,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/premint/RMRKNestablePreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKNestablePreMintSoulbound.md
@@ -224,7 +224,7 @@ Used to retrieve the metadata of the collection.
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address, uint256, bool)
+function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,9 +241,9 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the given token&#39;s owner |
-| _1 | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
-| _2 | bool | The boolean value signifying whether the owner is an NFT or not |
+| owner | address | Address of the given token&#39;s owner |
+| parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
+| isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 

--- a/docs/implementations/premint/RMRKNestablePreMintSoulbound.md
+++ b/docs/implementations/premint/RMRKNestablePreMintSoulbound.md
@@ -101,7 +101,7 @@ Used to grant a one-time approval to manage one&#39;s token.
 ### balanceOf
 
 ```solidity
-function balanceOf(address owner) external view returns (uint256)
+function balanceOf(address owner) external view returns (uint256 balance)
 ```
 
 Used to retrieve the number of tokens in `owner`&#39;s account.
@@ -118,7 +118,7 @@ Used to retrieve the number of tokens in `owner`&#39;s account.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The balance of the given account |
+| balance | uint256 | The balance of the given account |
 
 ### burn
 
@@ -139,7 +139,7 @@ Used to burn a given token.
 ### burn
 
 ```solidity
-function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256)
+function burn(uint256 tokenId, uint256 maxChildrenBurns) external nonpayable returns (uint256 burnedChildren)
 ```
 
 Used to burn a given token.
@@ -157,12 +157,12 @@ Used to burn a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | Number of recursively burned children |
+| burnedChildren | uint256 | Number of recursively burned children |
 
 ### childOf
 
 ```solidity
-function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function childOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific active child token for a given parent token.
@@ -180,12 +180,12 @@ Used to retrieve a specific active child token for a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containing data about the specified child |
+| child | IERC7401.Child | A Child struct containing data about the specified child |
 
 ### childrenOf
 
 ```solidity
-function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function childrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the active child tokens of a given parent token.
@@ -202,15 +202,15 @@ Used to retrieve the active child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s active child tokens |
 
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -219,12 +219,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### directOwnerOf
 
 ```solidity
-function directOwnerOf(uint256 tokenId) external view returns (address owner, uint256 parentId, bool isNFT)
+function directOwnerOf(uint256 tokenId) external view returns (address owner_, uint256 parentId, bool isNFT)
 ```
 
 Used to retrieve the immediate owner of the given token.
@@ -241,14 +241,14 @@ Used to retrieve the immediate owner of the given token.
 
 | Name | Type | Description |
 |---|---|---|
-| owner | address | Address of the given token&#39;s owner |
+| owner_ | address | Address of the given token&#39;s owner |
 | parentId | uint256 | The ID of the parent token. Should be `0` if the owner is an externally owned account |
 | isNFT | bool | The boolean value signifying whether the owner is an NFT or not |
 
 ### getApproved
 
 ```solidity
-function getApproved(uint256 tokenId) external view returns (address)
+function getApproved(uint256 tokenId) external view returns (address approved)
 ```
 
 Used to retrieve the account approved to manage given token.
@@ -265,12 +265,12 @@ Used to retrieve the account approved to manage given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the account approved to manage the token |
+| approved | address | Address of the account approved to manage the token |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -282,12 +282,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -299,12 +299,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isApprovedForAll
 
 ```solidity
-function isApprovedForAll(address owner, address operator) external view returns (bool)
+function isApprovedForAll(address owner, address operator) external view returns (bool isApproved)
 ```
 
 Used to check if the given address is allowed to manage the tokens of the specified address.
@@ -322,12 +322,12 @@ Used to check if the given address is allowed to manage the tokens of the specif
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
+| isApproved | bool | A boolean value signifying whether the *operator* is allowed to manage the tokens of the *owner* (`true`)  or not (`false`) |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -344,12 +344,12 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### isTransferable
 
 ```solidity
-function isTransferable(uint256, address from, address to) external view returns (bool)
+function isTransferable(uint256, address from, address to) external view returns (bool isTransferable_)
 ```
 
 Used to check whether the given token is transferable or not.
@@ -368,7 +368,7 @@ Used to check whether the given token is transferable or not.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the given token is transferable |
+| isTransferable_ | bool | Boolean value indicating whether the given token is transferable |
 
 ### manageContributor
 
@@ -390,7 +390,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -402,12 +402,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### mint
 
 ```solidity
-function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256)
+function mint(address to, uint256 numToMint, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint the desired number of tokens to the specified address.
@@ -426,12 +426,12 @@ Used to mint the desired number of tokens to the specified address.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -443,12 +443,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### nestMint
 
 ```solidity
-function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256)
+function nestMint(address to, uint256 numToMint, uint256 destinationId, string tokenURI) external nonpayable returns (uint256 firstTokenId)
 ```
 
 Used to mint a desired number of child tokens to a given parent token.
@@ -468,7 +468,7 @@ Used to mint a desired number of child tokens to a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The ID of the first token to be minted in the current minting cycle |
+| firstTokenId | uint256 | The ID of the first token to be minted in the current minting cycle |
 
 ### nestTransferFrom
 
@@ -493,7 +493,7 @@ Used to transfer the token into another token.
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -505,12 +505,12 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### ownerOf
 
 ```solidity
-function ownerOf(uint256 tokenId) external view returns (address)
+function ownerOf(uint256 tokenId) external view returns (address owner_)
 ```
 
 Used to retrieve the *root* owner of a given token.
@@ -527,12 +527,12 @@ Used to retrieve the *root* owner of a given token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | The *root* owner of the token |
+| owner_ | address | The *root* owner of the token |
 
 ### pendingChildOf
 
 ```solidity
-function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child)
+function pendingChildOf(uint256 parentId, uint256 index) external view returns (struct IERC7401.Child child)
 ```
 
 Used to retrieve a specific pending child token from a given parent token.
@@ -550,12 +550,12 @@ Used to retrieve a specific pending child token from a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child | A Child struct containting data about the specified child |
+| child | IERC7401.Child | A Child struct containting data about the specified child |
 
 ### pendingChildrenOf
 
 ```solidity
-function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[])
+function pendingChildrenOf(uint256 parentId) external view returns (struct IERC7401.Child[] children)
 ```
 
 Used to retrieve the pending child tokens of a given parent token.
@@ -572,7 +572,7 @@ Used to retrieve the pending child tokens of a given parent token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
+| children | IERC7401.Child[] | An array of Child structs containing the parent token&#39;s pending child tokens |
 
 ### rejectAllChildren
 
@@ -705,7 +705,7 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -717,12 +717,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -739,12 +739,12 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -756,12 +756,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -773,7 +773,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferChild
 

--- a/docs/implementations/utils/RMRKImplementationBase.md
+++ b/docs/implementations/utils/RMRKImplementationBase.md
@@ -13,10 +13,10 @@ Smart contract of the RMRK minting utils module.
 ### contractURI
 
 ```solidity
-function contractURI() external view returns (string)
+function contractURI() external view returns (string contractURI_)
 ```
 
-Used to retrieve the metadata of the collection.
+Used to retrieve the metadata URI of the collection.
 
 
 
@@ -25,12 +25,12 @@ Used to retrieve the metadata of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | string The metadata URI of the collection |
+| contractURI_ | string | string The metadata URI of the collection |
 
 ### getRoyaltyPercentage
 
 ```solidity
-function getRoyaltyPercentage() external view returns (uint256)
+function getRoyaltyPercentage() external view returns (uint256 royaltyPercentageBps)
 ```
 
 Used to retrieve the specified royalty percentage.
@@ -42,12 +42,12 @@ Used to retrieve the specified royalty percentage.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The royalty percentage expressed in the basis points |
+| royaltyPercentageBps | uint256 | The royalty percentage expressed in the basis points |
 
 ### getRoyaltyRecipient
 
 ```solidity
-function getRoyaltyRecipient() external view returns (address)
+function getRoyaltyRecipient() external view returns (address recipient)
 ```
 
 Used to retrieve the recipient of royalties.
@@ -59,12 +59,12 @@ Used to retrieve the recipient of royalties.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the recipient of royalties |
+| recipient | address | Address of the recipient of royalties |
 
 ### isContributor
 
 ```solidity
-function isContributor(address contributor) external view returns (bool)
+function isContributor(address contributor) external view returns (bool isContributor_)
 ```
 
 Used to check if the address is one of the contributors.
@@ -81,7 +81,7 @@ Used to check if the address is one of the contributors.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | bool | Boolean value indicating whether the address is a contributor or not |
+| isContributor_ | bool | Boolean value indicating whether the address is a contributor or not |
 
 ### manageContributor
 
@@ -103,7 +103,7 @@ Adds or removes a contributor to the smart contract.
 ### maxSupply
 
 ```solidity
-function maxSupply() external view returns (uint256)
+function maxSupply() external view returns (uint256 maxSupply_)
 ```
 
 Used to retrieve the maximum supply of the collection.
@@ -115,12 +115,12 @@ Used to retrieve the maximum supply of the collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The maximum supply of tokens in the collection |
+| maxSupply_ | uint256 | The maximum supply of tokens in the collection |
 
 ### name
 
 ```solidity
-function name() external view returns (string)
+function name() external view returns (string name_)
 ```
 
 Used to retrieve the collection name.
@@ -132,12 +132,12 @@ Used to retrieve the collection name.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Name of the collection |
+| name_ | string | Name of the collection |
 
 ### owner
 
 ```solidity
-function owner() external view returns (address)
+function owner() external view returns (address owner_)
 ```
 
 Returns the address of the current owner.
@@ -149,7 +149,7 @@ Returns the address of the current owner.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | address | Address of the current owner |
+| owner_ | address | Address of the current owner |
 
 ### renounceOwnership
 
@@ -189,7 +189,7 @@ Used to retrieve the information about who shall receive royalties of a sale of 
 ### symbol
 
 ```solidity
-function symbol() external view returns (string)
+function symbol() external view returns (string symbol_)
 ```
 
 Used to retrieve the collection symbol.
@@ -201,12 +201,12 @@ Used to retrieve the collection symbol.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Symbol of the collection |
+| symbol_ | string | Symbol of the collection |
 
 ### totalAssets
 
 ```solidity
-function totalAssets() external view returns (uint256)
+function totalAssets() external view returns (uint256 totalAssets_)
 ```
 
 Used to retrieve the total number of assets.
@@ -218,12 +218,12 @@ Used to retrieve the total number of assets.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The total number of assets |
+| totalAssets_ | uint256 | The total number of assets |
 
 ### totalSupply
 
 ```solidity
-function totalSupply() external view returns (uint256)
+function totalSupply() external view returns (uint256 totalSupply_)
 ```
 
 Used to retrieve the total supply of the tokens in a collection.
@@ -235,7 +235,7 @@ Used to retrieve the total supply of the tokens in a collection.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | uint256 | The number of tokens in a collection |
+| totalSupply_ | uint256 | The number of tokens in a collection |
 
 ### transferOwnership
 

--- a/docs/implementations/utils/RMRKRoyaltiesSplitter.md
+++ b/docs/implementations/utils/RMRKRoyaltiesSplitter.md
@@ -10,6 +10,23 @@ Smart contract of the RMRK Royalties Spliter module.
 
 ## Methods
 
+### MAX_BPS
+
+```solidity
+function MAX_BPS() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined |
+
 ### distributeERC20
 
 ```solidity

--- a/docs/implementations/utils/RMRKTokenURIEnumerated.md
+++ b/docs/implementations/utils/RMRKTokenURIEnumerated.md
@@ -13,7 +13,7 @@ Implementation of enumerable token URI.
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -30,7 +30,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 
 

--- a/docs/implementations/utils/RMRKTokenURIPerToken.md
+++ b/docs/implementations/utils/RMRKTokenURIPerToken.md
@@ -13,7 +13,7 @@ Implementation of token URI per token.
 ### tokenURI
 
 ```solidity
-function tokenURI(uint256 tokenId) external view returns (string)
+function tokenURI(uint256 tokenId) external view returns (string tokenURI_)
 ```
 
 Used to retrieve the metadata URI of a token.
@@ -30,7 +30,7 @@ Used to retrieve the metadata URI of a token.
 
 | Name | Type | Description |
 |---|---|---|
-| _0 | string | Metadata URI of the specified token |
+| tokenURI_ | string | Metadata URI of the specified token |
 
 
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -36,6 +36,12 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
+    modularium: {
+      url: 'https://fraa-dancebox-3035-rpc.a.dancebox.tanssi.network',
+      chainId: 776877,
+      accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+      gasPrice: 1000000000,
+    },
     moonbaseAlpha: {
       url: process.env.MOONBASE_URL || 'https://rpc.testnet.moonbeam.network',
       chainId: 1287,
@@ -85,7 +91,7 @@ const config: HardhatUserConfig = {
       url: process.env.ETHEREUM_URL || 'https://eth.drpc.org',
       chainId: 1,
       accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
-      gasPrice: 12000000000,
+      gasPrice: 27000000000,
     },
     polygon: {
       url: process.env.POLYGON_URL || 'https://polygon.drpc.org',
@@ -102,6 +108,12 @@ const config: HardhatUserConfig = {
       url: process.env.ASTAR_URL || 'https://evm.astar.network',
       chainId: 592,
       accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+    },
+    bsc: {
+      url: process.env.BSC_URL || 'https://bsc-dataseed.bnbchain.org',
+      chainId: 56,
+      accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+      gasPrice: 3000000000,
     },
   },
   gasReporter: {
@@ -124,6 +136,7 @@ const config: HardhatUserConfig = {
       polygon: process.env.POLYGONSCAN_API_KEY || '', // Polygon Etherscan API Key
       base: process.env.BASESCAN_API_KEY || '', // Base Etherscan API Key
       astar: process.env.ASTAR_BLOCKSCOUT_API_KEY || '', // Astar blockscout API Key
+      bsc: process.env.BSCSCAN_API_KEY || '', // BSC Etherscan API Key
     },
     customChains: [
       {

--- a/test/collectionUtils.ts
+++ b/test/collectionUtils.ts
@@ -221,25 +221,25 @@ describe('Collection Utils', function () {
 
   it('can trigger collection metadata update', async function () {
     await expect(
-      collectionUtils.connect(issuer).refreshCollectionTokensMetadata(multiAsset.address),
+      collectionUtils.connect(issuer).refreshCollectionTokensMetadata(multiAsset.address, 1, 100),
     )
-      .to.emit(collectionUtils, 'CollectionTokensMetadataRefreshTriggered')
-      .withArgs(multiAsset.address);
+      .to.emit(collectionUtils, 'BatchMetadataUpdate')
+      .withArgs(multiAsset.address, 1, 100);
   });
 
   it('can trigger token metadata update', async function () {
     await expect(collectionUtils.connect(issuer).refreshTokenMetadata(multiAsset.address, 1))
-      .to.emit(collectionUtils, 'TokenMetadataRefreshTriggered')
+      .to.emit(collectionUtils, 'MetadataUpdate')
       .withArgs(multiAsset.address, 1);
   });
 
   it('does not emit event if contract address is not a contract', async function () {
     await expect(
-      collectionUtils.connect(issuer).refreshCollectionTokensMetadata(ADDRESS_ZERO),
-    ).to.not.emit(collectionUtils, 'CollectionTokensMetadataRefreshTriggered');
+      collectionUtils.connect(issuer).refreshCollectionTokensMetadata(ADDRESS_ZERO, 1, 100),
+    ).to.not.emit(collectionUtils, 'BatchMetadataUpdate');
     await expect(collectionUtils.connect(issuer).refreshTokenMetadata(ADDRESS_ZERO, 1)).to.not.emit(
       collectionUtils,
-      'TokenMetadataRefreshTriggered',
+      'MetadataUpdate',
     );
   });
 });

--- a/test/implementations/generalBehavior.ts
+++ b/test/implementations/generalBehavior.ts
@@ -885,7 +885,7 @@ async function testGeneralBehavior(mintingType: MintingType) {
       await mint(holder.address, contract, owner, rmrkERC20, mintingType);
       if (mintingType == MintingType.RMRKLazyMintNativeToken) {
         const balanceBefore = await holder.getBalance();
-        await contract.connect(owner).withdrawRaised(holder.address, pricePerMint.mul(2));
+        await contract.connect(owner).withdraw(holder.address, pricePerMint.mul(2));
         const balanceAfter = await holder.getBalance();
         expect(balanceAfter).to.eql(balanceBefore.add(pricePerMint.mul(2)));
       } else if (mintingType == MintingType.RMRKLazyMintERC20) {
@@ -904,7 +904,7 @@ async function testGeneralBehavior(mintingType: MintingType) {
       await mint(holder.address, contract, owner, rmrkERC20, mintingType);
       if (mintingType == MintingType.RMRKLazyMintNativeToken) {
         await expect(
-          contract.connect(holder).withdrawRaised(holder.address, pricePerMint),
+          contract.connect(holder).withdraw(holder.address, pricePerMint),
         ).to.be.revertedWithCustomError(contract, 'RMRKNotOwner');
       } else if (mintingType == MintingType.RMRKLazyMintERC20) {
         await expect(


### PR DESCRIPTION
# Description

Describe the additions/improvements this PR contains.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the code structure and imports in various files within the project.

### Detailed summary:
- Added `IndexOutOfBounds` error in `RMRKLib.md`
- Changed event `Revealed` in `IRMRKRevealer.sol` to have indexed `tokenIds`
- Updated imports in `ERC1155Mock.sol` to use curly braces
- Updated imports in `RMRKEmotesRepository.sol` to use curly braces
- Updated imports in `IRMRKNestableAutoIndex.sol` to use curly braces
- Updated imports in `IRMRKMultiAssetAutoIndex.sol` to use curly braces
- Updated imports in `IERC7409.sol` to use curly braces
- Updated imports in `RMRKRevealable.sol` to use curly braces
- Updated imports in `ERC20Mock.sol` to use curly braces
- Updated imports in `IRMRKTokenHolder.sol` to use curly braces
- Updated imports in `OwnableLockMock.sol` to use curly braces
- Added new method `MAX_BPS` in `RMRKRoyaltiesSplitter.md`
- Updated imports in `RMRKNestableMock.sol` to use curly braces
- Updated imports in `IRMRKReclaimableChild.sol` to use curly braces
- Updated imports in `RMRKMultiAssetMock.sol` to use curly braces
- Updated imports in `RMRKEquippableMock.sol` to use curly braces
- Updated imports in `RMRKCatalogImpl.sol` to use curly braces
- Updated imports in `RMRKTypedMultiAsset.sol` to use curly braces
- Updated imports in `IRMRKRevealable.sol` to use curly braces
- Updated imports in `RMRKMinifiedEquippableMock.sol` to use curly braces
- Updated imports in `RMRKNestableMultiAssetMock.sol` to use curly braces
- Updated imports in `OwnableMintableERC721Mock.sol` to use curly braces
- Updated imports in `RMRKNestableAutoIndexMock.sol` to use curly braces
- Updated imports in `IRMRKTypedMultiAsset.sol` to use curly braces
- Updated imports in `RMRKMultiAssetAutoIndexMock.sol` to use curly braces
- Updated imports in `ERC721Mock.sol` to use curly braces
- Updated imports in `ChildAdder.sol` to use curly braces
- Updated imports in `RMRKNestableAutoIndex.sol` to use curly braces
- Updated method signature in `RMRKTokenURIPerToken.md` to include return parameter name
- Updated method signature in `RMRKTokenURIEnumerated.md` to include return parameter name
- Updated imports in `RMRKTypedMultiAssetMock.sol` to use curly braces
- Updated method signature in `RMRKTokenURIPerToken.sol` to include return parameter name
- Updated imports in `RMRKSoulboundNestableMock.sol` to use curly braces
- Updated imports in `RMRKImplementationBaseMock.sol` to use curly braces
- Removed incomplete line in `RMRKMultiAssetAutoIndex.sol`

> The following files were skipped due to too many changes: `contracts/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.sol`, `docs/RMRK/extension/revealable/IRMRKRevealable.md`, `contracts/mocks/extensions/soulbound/RMRKSoulboundMultiAssetMock.sol`, `contracts/implementations/premint/RMRKNestablePreMintSoulbound.sol`, `contracts/implementations/premint/RMRKEquippablePreMintSoulbound.sol`, `contracts/implementations/premint/RMRKMultiAssetPreMintSoulbound.sol`, `contracts/mocks/extensions/claimableChild/RMRKNestableClaimableChildMock.sol`, `contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.sol`, `docs/RMRK/utils/RMRKBulkWriterPerCollection.md`, `contracts/RMRK/library/RMRKLib.sol`, `contracts/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.sol`, `contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.sol`, `contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.sol`, `docs/RMRK/extension/revealable/IRMRKRevealer.md`, `contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.sol`, `contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.sol`, `contracts/RMRK/extension/reclaimableChild/RMRKReclaimableChild.sol`, `contracts/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.sol`, `contracts/mocks/extensions/typedMultiAsset/RMRKTypedEquippableMock.sol`, `contracts/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.sol`, `contracts/mocks/extensions/soulbound/RMRKSoulboundNestableMultiAssetMock.sol`, `contracts/mocks/extensions/typedMultiAsset/RMRKNestableTypedMultiAssetMock.sol`, `contracts/mocks/extensions/revealable/RMRKMultiAssetRevealableMock.sol`, `contracts/RMRK/access/OwnableLock.sol`, `contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.sol`, `docs/RMRK/extension/soulbound/RMRKSoulbound.md`, `docs/RMRK/extension/soulbound/RMRKSoulboundAfterBlockNumber.md`, `contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.sol`, `contracts/RMRK/extension/soulbound/RMRKSoulboundPerToken.sol`, `docs/RMRK/extension/soulbound/IERC6454.md`, `contracts/mocks/extensions/soulbound/RMRKSoulboundEquippableMock.sol`, `docs/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.md`, `docs/RMRK/extension/soulbound/RMRKSoulboundPerToken.md`, `contracts/implementations/abstract/RMRKAbstractNestable.sol`, `contracts/RMRK/extension/soulbound/RMRKSoulbound.sol`, `contracts/RMRK/extension/soulbound/IERC6454.sol`, `contracts/implementations/utils/RMRKTokenURIEnumerated.sol`, `contracts/RMRK/utils/RMRKCatalogUtils.sol`, `contracts/RMRK/extension/soulbound/RMRKSoulboundAfterTransactions.sol`, `contracts/RMRK/extension/tokenHolder/RMRKTokenHolder.sol`, `contracts/RMRK/nestable/RMRKNestableMultiAsset.sol`, `test/implementations/generalBehavior.ts`, `contracts/RMRK/utils/RMRKBulkWriter.sol`, `docs/RMRK/extension/RMRKRoyalties.md`, `docs/RMRK/access/Ownable.md`, `contracts/mocks/extensions/tokenHolder/RMRKTokenHolderMock.sol`, `.env.example`, `contracts/RMRK/utils/RMRKRenderUtils.sol`, `contracts/RMRK/access/Ownable.sol`, `contracts/RMRK/utils/IERC20.sol`, `docs/RMRK/utils/IERC20.md`, `contracts/implementations/premint/RMRKMultiAssetPreMint.sol`, `test/collectionUtils.ts`, `contracts/implementations/abstract/RMRKAbstractMultiAsset.sol`, `contracts/implementations/abstract/RMRKAbstractNestableMultiAsset.sol`, `contracts/mocks/ERC721ReceiverMock.sol`, `hardhat.config.ts`, `contracts/RMRK/extension/RMRKRoyalties.sol`, `docs/RMRK/access/OwnableLock.md`, `contracts/RMRK/utils/RMRKBulkWriterPerCollection.sol`, `contracts/mocks/extensions/revealable/RMRKRevealerMock.sol`, `contracts/mocks/extensions/soulbound/RMRKSoulboundVariantMocks.sol`, `contracts/implementations/utils/RMRKRoyaltiesSplitter.sol`, `contracts/RMRK/catalog/RMRKCatalog.sol`, `contracts/implementations/premint/RMRKNestableMultiAssetPreMint.sol`, `contracts/implementations/abstract/RMRKAbstractEquippable.sol`, `contracts/implementations/premint/RMRKNestablePreMint.sol`, `contracts/implementations/premint/RMRKEquippablePreMint.sol`, `contracts/RMRK/catalog/IRMRKCatalog.sol`, `contracts/RMRK/equippable/IERC6220.sol`, `contracts/RMRK/multiasset/AbstractMultiAsset.sol`, `docs/RMRK/catalog/RMRKCatalog.md`, `docs/RMRK/catalog/IRMRKCatalog.md`, `docs/RMRK/utils/RMRKCollectionUtils.md`, `contracts/implementations/utils/RMRKImplementationBase.sol`, `contracts/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.sol`, `contracts/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.sol`, `contracts/RMRK/equippable/RMRKEquippable.sol`, `contracts/implementations/lazyMintNative/RMRKNestableLazyMintNative.sol`, `contracts/implementations/lazyMintNative/RMRKEquippableLazyMintNative.sol`, `contracts/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.sol`, `contracts/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.sol`, `contracts/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.sol`, `docs/RMRK/utils/RMRKMultiAssetRenderUtils.md`, `contracts/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.sol`, `contracts/RMRK/utils/RMRKCollectionUtils.sol`, `contracts/RMRK/library/RMRKErrors.sol`, `docs/implementations/RMRKCatalogImpl.md`, `docs/RMRK/multiasset/IERC5773.md`, `docs/RMRK/multiasset/AbstractMultiAsset.md`, `contracts/RMRK/multiasset/IERC5773.sol`, `docs/RMRK/extension/multiAssetAutoIndex/IRMRKMultiAssetAutoIndex.md`, `docs/RMRK/utils/RMRKNestableRenderUtils.md`, `docs/RMRK/nestable/IERC7401.md`, `docs/RMRK/extension/nestableAutoIndex/IRMRKNestableAutoIndex.md`, `contracts/RMRK/nestable/IERC7401.sol`, `docs/implementations/utils/RMRKImplementationBase.md`, `contracts/RMRK/utils/RMRKMultiAssetRenderUtils.sol`, `contracts/RMRK/utils/RMRKEquipRenderUtils.sol`, `contracts/RMRK/multiasset/RMRKMultiAsset.sol`, `contracts/RMRK/utils/RMRKNestableRenderUtils.sol`, `docs/RMRK/extension/nestableAutoIndex/RMRKNestableAutoIndex.md`, `docs/RMRK/nestable/RMRKNestable.md`, `docs/RMRK/extension/reclaimableChild/RMRKReclaimableChild.md`, `docs/RMRK/multiasset/RMRKMultiAsset.md`, `docs/RMRK/equippable/IERC6220.md`, `docs/RMRK/extension/multiAssetAutoIndex/RMRKMultiAssetAutoIndex.md`, `contracts/RMRK/nestable/RMRKNestable.sol`, `contracts/RMRK/extension/tokenAttributes/IERC7508.sol`, `docs/RMRK/utils/RMRKEquipRenderUtils.md`, `docs/RMRK/nestable/RMRKNestableMultiAsset.md`, `docs/implementations/abstract/RMRKAbstractNestable.md`, `docs/RMRK/extension/tokenAttributes/IERC7508.md`, `docs/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.md`, `docs/implementations/abstract/RMRKAbstractMultiAsset.md`, `docs/implementations/premint/RMRKNestablePreMint.md`, `docs/implementations/premint/RMRKMultiAssetPreMint.md`, `docs/implementations/premint/RMRKNestablePreMintSoulbound.md`, `docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20.md`, `contracts/RMRK/equippable/RMRKMinifiedEquippable.sol`, `docs/implementations/lazyMintNative/RMRKNestableLazyMintNative.md`, `docs/implementations/premint/RMRKMultiAssetPreMintSoulbound.md`, `docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20.md`, `docs/RMRK/equippable/RMRKMinifiedEquippable.md`, `docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNative.md`, `docs/implementations/lazyMintErc20/RMRKNestableLazyMintErc20Soulbound.md`, `docs/implementations/lazyMintNative/RMRKNestableLazyMintNativeSoulbound.md`, `docs/RMRK/equippable/RMRKEquippable.md`, `docs/implementations/lazyMintErc20/RMRKMultiAssetLazyMintErc20Soulbound.md`, `docs/implementations/lazyMintNative/RMRKMultiAssetLazyMintNativeSoulbound.md`, `docs/implementations/abstract/RMRKAbstractNestableMultiAsset.md`, `contracts/RMRK/extension/tokenAttributes/RMRKTokenAttributesRepository.sol`, `docs/implementations/premint/RMRKNestableMultiAssetPreMint.md`, `docs/implementations/premint/RMRKNestableMultiAssetPreMintSoulbound.md`, `docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20.md`, `docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNative.md`, `docs/implementations/lazyMintErc20/RMRKNestableMultiAssetLazyMintErc20Soulbound.md`, `docs/implementations/lazyMintNative/RMRKNestableMultiAssetLazyMintNativeSoulbound.md`, `docs/implementations/abstract/RMRKAbstractEquippable.md`, `docs/implementations/premint/RMRKEquippablePreMint.md`, `docs/implementations/premint/RMRKEquippablePreMintSoulbound.md`, `docs/implementations/lazyMintNative/RMRKEquippableLazyMintNative.md`, `docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20.md`, `docs/implementations/lazyMintNative/RMRKEquippableLazyMintNativeSoulbound.md`, `docs/implementations/lazyMintErc20/RMRKEquippableLazyMintErc20Soulbound.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->