### PR TITLE
Orphan equipments detection

### DIFF
--- a/contracts/RMRK/utils/RMRKCatalogUtils.sol
+++ b/contracts/RMRK/utils/RMRKCatalogUtils.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.21;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IRMRKCatalog} from "../catalog/IRMRKCatalog.sol";
+import {IERC6220} from "../equippable/IERC6220.sol";
+import {IERC5773} from "../multiasset/IERC5773.sol";
+import {IERC7401} from "../nestable/IERC7401.sol";
+import {RMRKLib} from "../library/RMRKLib.sol";
+import "../library/RMRKErrors.sol";
 
 /**
  * @title RMRKCatalogUtils
@@ -12,6 +17,25 @@ import {IRMRKCatalog} from "../catalog/IRMRKCatalog.sol";
  * @dev Extra utility functions for RMRK contracts.
  */
 contract RMRKCatalogUtils {
+    using RMRKLib for uint64[];
+    using RMRKLib for uint256[];
+
+    /**
+     * @notice Used to store the core structure of the `Equippable` RMRK lego.
+     * @return parentAssetId The ID of the parent asset equipping a child
+     * @return slotId The ID of the slot part
+     * @return childAddress Address of the collection to which the child asset belongs to
+     * @return childId The ID of token that is equipped
+     * @return childAssetId The ID of the asset used as equipment
+     */
+    struct ExtendedEquipment {
+        uint64 parentAssetId;
+        uint64 slotId;
+        address childAddress;
+        uint256 childId;
+        uint64 childAssetId;
+    }
+
     /**
      * @notice Structure used to represent the extended part data.
      * @return partId The part ID
@@ -110,5 +134,223 @@ contract RMRKCatalogUtils {
     {
         (owner, type_, metadataURI) = getCatalogData(catalog);
         parts = getExtendedParts(catalog, partIds);
+    }
+
+    /**
+     * @notice Used to get data about children equipped to a specified token, where the parent asset has been replaced.
+     * @param parentAddress Address of the collection smart contract of parent token
+     * @param parentId ID of the parent token
+     * @param catalogAddress Address of the catalog the slot part Ids belong to
+     * @param slotPartIds Array of slot part IDs of the parent token's assets to search for orphan equipments
+     * @return equipments Array of extended equipment data structs containing the equipment data, including the slot part ID
+     */
+    function getOrphanedEquipmentsFromParentAsset(
+        address parentAddress,
+        uint256 parentId,
+        address catalogAddress,
+        uint64[] memory slotPartIds
+    ) public view returns (ExtendedEquipment[] memory equipments) {
+        uint256 length = slotPartIds.length;
+        ExtendedEquipment[] memory tempEquipments = new ExtendedEquipment[](
+            length
+        );
+        uint64[] memory parentAssetIds = IERC5773(parentAddress)
+            .getActiveAssets(parentId);
+        uint256 orphansFound;
+
+        for (uint256 i; i < length; ) {
+            uint64 slotPartId = slotPartIds[i];
+            IERC6220.Equipment memory equipment = IERC6220(parentAddress)
+                .getEquipment(parentId, catalogAddress, slotPartId);
+            if (equipment.assetId != 0) {
+                (, bool assetFound) = parentAssetIds.indexOf(equipment.assetId);
+                if (!assetFound) {
+                    tempEquipments[orphansFound] = ExtendedEquipment({
+                        parentAssetId: equipment.assetId,
+                        slotId: slotPartId,
+                        childAddress: equipment.childEquippableAddress,
+                        childId: equipment.childId,
+                        childAssetId: equipment.childAssetId
+                    });
+                    unchecked {
+                        ++orphansFound;
+                    }
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        equipments = new ExtendedEquipment[](orphansFound);
+        for (uint256 i; i < orphansFound; ) {
+            equipments[i] = tempEquipments[i];
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice Used to get data about children equipped to a specified token, where the child asset has been replaced.
+     * @param parentAddress Address of the collection smart contract of parent token
+     * @param parentId ID of the parent token
+     * @return equipments Array of extended equipment data structs containing the equipment data, including the slot part ID
+     */
+    function getOrphanedEquipmentFromChildAsset(
+        address parentAddress,
+        uint256 parentId
+    ) public view returns (ExtendedEquipment[] memory equipments) {
+        uint64[] memory parentAssetIds = IERC5773(parentAddress)
+            .getActiveAssets(parentId);
+
+        // In practice, there could be more equips than children, but this is a decent approximate since the real number cannot be known, also we do not expect a lot of orphans
+        uint256 totalChildren = IERC7401(parentAddress)
+            .childrenOf(parentId)
+            .length;
+        ExtendedEquipment[] memory tempEquipments = new ExtendedEquipment[](
+            totalChildren
+        );
+        uint256 orphansFound;
+
+        uint256 totalParentAssets = parentAssetIds.length;
+        for (uint256 i; i < totalParentAssets; ) {
+            (
+                uint64[] memory parentSlotPartIds,
+                address catalogAddress
+            ) = getSlotPartsAndCatalog(
+                    parentAddress,
+                    parentId,
+                    parentAssetIds[i]
+                );
+            uint256 totalSlots = parentSlotPartIds.length;
+            for (uint256 j; j < totalSlots; ) {
+                IERC6220.Equipment memory equipment = IERC6220(parentAddress)
+                    .getEquipment(
+                        parentId,
+                        catalogAddress,
+                        parentSlotPartIds[j]
+                    );
+                if (equipment.assetId != 0) {
+                    uint64[] memory childAssetIds = IERC5773(
+                        equipment.childEquippableAddress
+                    ).getActiveAssets(equipment.childId);
+                    (, bool assetFound) = childAssetIds.indexOf(
+                        equipment.childAssetId
+                    );
+                    if (!assetFound) {
+                        tempEquipments[orphansFound] = ExtendedEquipment({
+                            parentAssetId: equipment.assetId,
+                            slotId: parentSlotPartIds[j],
+                            childAddress: equipment.childEquippableAddress,
+                            childId: equipment.childId,
+                            childAssetId: equipment.childAssetId
+                        });
+                        unchecked {
+                            ++orphansFound;
+                        }
+                    }
+                }
+                unchecked {
+                    ++j;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+
+        equipments = new ExtendedEquipment[](orphansFound);
+        for (uint256 i; i < orphansFound; ) {
+            equipments[i] = tempEquipments[i];
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice Used to retrieve the parent address and its slot part IDs for a given target child, and the catalog of the parent asset.
+     * @param tokenAddress Address of the collection smart contract of parent token
+     * @param tokenId ID of the parent token
+     * @param assetId ID of the parent asset from which to get the slot parts
+     * @return parentSlotPartIds Array of slot part IDs of the parent token's asset
+     * @return catalogAddress Address of the catalog the parent asset belongs to
+     */
+    function getSlotPartsAndCatalog(
+        address tokenAddress,
+        uint256 tokenId,
+        uint64 assetId
+    )
+        public
+        view
+        returns (uint64[] memory parentSlotPartIds, address catalogAddress)
+    {
+        uint64[] memory parentPartIds;
+        (, , catalogAddress, parentPartIds) = IERC6220(tokenAddress)
+            .getAssetAndEquippableData(tokenId, assetId);
+        if (catalogAddress == address(0)) revert RMRKNotComposableAsset();
+
+        (parentSlotPartIds, ) = splitSlotAndFixedParts(
+            parentPartIds,
+            catalogAddress
+        );
+    }
+
+    /**
+     * @notice Used to split slot and fixed parts.
+     * @param allPartIds[] An array of `Part` IDs containing both, `Slot` and `Fixed` parts
+     * @param catalogAddress An address of the catalog to which the given `Part`s belong to
+     * @return slotPartIds An array of IDs of the `Slot` parts included in the `allPartIds`
+     * @return fixedPartIds An array of IDs of the `Fixed` parts included in the `allPartIds`
+     */
+    function splitSlotAndFixedParts(
+        uint64[] memory allPartIds,
+        address catalogAddress
+    )
+        public
+        view
+        returns (uint64[] memory slotPartIds, uint64[] memory fixedPartIds)
+    {
+        IRMRKCatalog.Part[] memory allParts = IRMRKCatalog(catalogAddress)
+            .getParts(allPartIds);
+        uint256 numFixedParts;
+        uint256 numSlotParts;
+
+        uint256 numParts = allPartIds.length;
+        // This for loop is just to discover the right size of the split arrays, since we can't create them dynamically
+        for (uint256 i; i < numParts; ) {
+            if (allParts[i].itemType == IRMRKCatalog.ItemType.Fixed)
+                numFixedParts += 1;
+                // We could just take the numParts - numFixedParts, but it doesn't hurt to double check it's not an uninitialized part:
+            else if (allParts[i].itemType == IRMRKCatalog.ItemType.Slot)
+                numSlotParts += 1;
+            unchecked {
+                ++i;
+            }
+        }
+
+        slotPartIds = new uint64[](numSlotParts);
+        fixedPartIds = new uint64[](numFixedParts);
+        uint256 slotPartsIndex;
+        uint256 fixedPartsIndex;
+
+        // This for loop is to actually fill the split arrays
+        for (uint256 i; i < numParts; ) {
+            if (allParts[i].itemType == IRMRKCatalog.ItemType.Fixed) {
+                fixedPartIds[fixedPartsIndex] = allPartIds[i];
+                unchecked {
+                    ++fixedPartsIndex;
+                }
+            } else if (allParts[i].itemType == IRMRKCatalog.ItemType.Slot) {
+                slotPartIds[slotPartsIndex] = allPartIds[i];
+                unchecked {
+                    ++slotPartsIndex;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
     }
 }

--- a/contracts/RMRK/utils/RMRKCatalogUtils.sol
+++ b/contracts/RMRK/utils/RMRKCatalogUtils.sol
@@ -144,7 +144,7 @@ contract RMRKCatalogUtils {
      * @param slotPartIds Array of slot part IDs of the parent token's assets to search for orphan equipments
      * @return equipments Array of extended equipment data structs containing the equipment data, including the slot part ID
      */
-    function getOrphanedEquipmentsFromParentAsset(
+    function getOrphanEquipmentsFromParentAsset(
         address parentAddress,
         uint256 parentId,
         address catalogAddress,
@@ -197,7 +197,7 @@ contract RMRKCatalogUtils {
      * @param parentId ID of the parent token
      * @return equipments Array of extended equipment data structs containing the equipment data, including the slot part ID
      */
-    function getOrphanedEquipmentFromChildAsset(
+    function getOrphanEquipmentsFromChildAsset(
         address parentAddress,
         uint256 parentId
     ) public view returns (ExtendedEquipment[] memory equipments) {

--- a/contracts/RMRK/utils/RMRKCatalogUtils.sol
+++ b/contracts/RMRK/utils/RMRKCatalogUtils.sol
@@ -18,7 +18,6 @@ import "../library/RMRKErrors.sol";
  */
 contract RMRKCatalogUtils {
     using RMRKLib for uint64[];
-    using RMRKLib for uint256[];
 
     /**
      * @notice Used to store the core structure of the `Equippable` RMRK lego.

--- a/docs/RMRK/utils/RMRKCatalogUtils.md
+++ b/docs/RMRK/utils/RMRKCatalogUtils.md
@@ -83,6 +83,117 @@ Used to get the extended part data of many parts from the specified catalog in a
 |---|---|---|
 | parts | RMRKCatalogUtils.ExtendedPart[] | Array of extended part data structs containing the part data |
 
+### getOrphanedEquipmentFromChildAsset
+
+```solidity
+function getOrphanedEquipmentFromChildAsset(address parentAddress, uint256 parentId) external view returns (struct RMRKCatalogUtils.ExtendedEquipment[] equipments)
+```
+
+Used to get data about children equipped to a specified token, where the child asset has been replaced.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| parentAddress | address | Address of the collection smart contract of parent token |
+| parentId | uint256 | ID of the parent token |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| equipments | RMRKCatalogUtils.ExtendedEquipment[] | Array of extended equipment data structs containing the equipment data, including the slot part ID |
+
+### getOrphanedEquipmentsFromParentAsset
+
+```solidity
+function getOrphanedEquipmentsFromParentAsset(address parentAddress, uint256 parentId, address catalogAddress, uint64[] slotPartIds) external view returns (struct RMRKCatalogUtils.ExtendedEquipment[] equipments)
+```
+
+Used to get data about children equipped to a specified token, where the parent asset has been replaced.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| parentAddress | address | Address of the collection smart contract of parent token |
+| parentId | uint256 | ID of the parent token |
+| catalogAddress | address | Address of the catalog the slot part Ids belong to |
+| slotPartIds | uint64[] | Array of slot part IDs of the parent token&#39;s assets to search for orphan equipments |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| equipments | RMRKCatalogUtils.ExtendedEquipment[] | Array of extended equipment data structs containing the equipment data, including the slot part ID |
+
+### getSlotPartsAndCatalog
+
+```solidity
+function getSlotPartsAndCatalog(address tokenAddress, uint256 tokenId, uint64 assetId) external view returns (uint64[] parentSlotPartIds, address catalogAddress)
+```
+
+Used to retrieve the parent address and its slot part IDs for a given target child, and the catalog of the parent asset.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenAddress | address | Address of the collection smart contract of parent token |
+| tokenId | uint256 | ID of the parent token |
+| assetId | uint64 | ID of the parent asset from which to get the slot parts |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| parentSlotPartIds | uint64[] | Array of slot part IDs of the parent token&#39;s asset |
+| catalogAddress | address | Address of the catalog the parent asset belongs to |
+
+### splitSlotAndFixedParts
+
+```solidity
+function splitSlotAndFixedParts(uint64[] allPartIds, address catalogAddress) external view returns (uint64[] slotPartIds, uint64[] fixedPartIds)
+```
+
+Used to split slot and fixed parts.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| allPartIds | uint64[] | [] An array of `Part` IDs containing both, `Slot` and `Fixed` parts |
+| catalogAddress | address | An address of the catalog to which the given `Part`s belong to |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| slotPartIds | uint64[] | An array of IDs of the `Slot` parts included in the `allPartIds` |
+| fixedPartIds | uint64[] | An array of IDs of the `Fixed` parts included in the `allPartIds` |
+
+
+
+
+## Errors
+
+### RMRKNotComposableAsset
+
+```solidity
+error RMRKNotComposableAsset()
+```
+
+Attempting to compose an asset wihtout having an associated Catalog
+
+
 
 
 

--- a/docs/RMRK/utils/RMRKCatalogUtils.md
+++ b/docs/RMRK/utils/RMRKCatalogUtils.md
@@ -83,10 +83,10 @@ Used to get the extended part data of many parts from the specified catalog in a
 |---|---|---|
 | parts | RMRKCatalogUtils.ExtendedPart[] | Array of extended part data structs containing the part data |
 
-### getOrphanedEquipmentFromChildAsset
+### getOrphanEquipmentsFromChildAsset
 
 ```solidity
-function getOrphanedEquipmentFromChildAsset(address parentAddress, uint256 parentId) external view returns (struct RMRKCatalogUtils.ExtendedEquipment[] equipments)
+function getOrphanEquipmentsFromChildAsset(address parentAddress, uint256 parentId) external view returns (struct RMRKCatalogUtils.ExtendedEquipment[] equipments)
 ```
 
 Used to get data about children equipped to a specified token, where the child asset has been replaced.
@@ -106,10 +106,10 @@ Used to get data about children equipped to a specified token, where the child a
 |---|---|---|
 | equipments | RMRKCatalogUtils.ExtendedEquipment[] | Array of extended equipment data structs containing the equipment data, including the slot part ID |
 
-### getOrphanedEquipmentsFromParentAsset
+### getOrphanEquipmentsFromParentAsset
 
 ```solidity
-function getOrphanedEquipmentsFromParentAsset(address parentAddress, uint256 parentId, address catalogAddress, uint64[] slotPartIds) external view returns (struct RMRKCatalogUtils.ExtendedEquipment[] equipments)
+function getOrphanEquipmentsFromParentAsset(address parentAddress, uint256 parentId, address catalogAddress, uint64[] slotPartIds) external view returns (struct RMRKCatalogUtils.ExtendedEquipment[] equipments)
 ```
 
 Used to get data about children equipped to a specified token, where the parent asset has been replaced.

--- a/scripts/deploy_catalogUtils.ts
+++ b/scripts/deploy_catalogUtils.ts
@@ -1,0 +1,39 @@
+import { ethers, run } from 'hardhat';
+
+export const sleep = (ms: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(), ms);
+  });
+};
+
+async function main() {
+  // We get the contract to deploy
+  // // Send eth to this address:0xfbea1b97406c6945d07f50f588e54144ea8b684f
+  // let tx = {
+  //   to: '0xfbea1b97406c6945d07f50f588e54144ea8b684f',
+  //   value: ethers.utils.parseEther('0.03'),
+  //   nonce: 235,
+  // };
+  // const [signer] = await ethers.getSigners();
+  // const txResponse = await signer.sendTransaction(tx);
+  // await txResponse.wait();
+  // return;
+
+  const catalogUtilsFactory = await ethers.getContractFactory('RMRKCatalogUtils');
+  const catalogUtils = await catalogUtilsFactory.deploy();
+  await catalogUtils.deployed();
+  console.log('RMRK Catalog Utils deployed to:', catalogUtils.address);
+  await sleep(1000);
+
+  await run('verify:verify', {
+    address: catalogUtils.address,
+    constructorArguments: [],
+  });
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/behavior/equippableSlots.ts
+++ b/test/behavior/equippableSlots.ts
@@ -33,13 +33,9 @@ async function shouldBehaveLikeEquippableWithSlots(
 ) {
   let catalog: Contract;
   let soldier: Contract;
-  let soldierEquip: Contract;
   let weapon: Contract;
-  let weaponEquip: Contract;
   let weaponGem: Contract;
-  let weaponGemEquip: Contract;
   let background: Contract;
-  let backgroundEquip: Contract;
   let view: Contract;
 
   let addrs: SignerWithAddress[];
@@ -50,13 +46,9 @@ async function shouldBehaveLikeEquippableWithSlots(
 
     catalog = this.catalog;
     soldier = this.soldier;
-    soldierEquip = this.soldierEquip;
     weapon = this.weapon;
-    weaponEquip = this.weaponEquip;
     weaponGem = this.weaponGem;
-    weaponGemEquip = this.weaponGemEquip;
     background = this.background;
-    backgroundEquip = this.backgroundEquip;
     view = this.view;
   });
 
@@ -64,8 +56,8 @@ async function shouldBehaveLikeEquippableWithSlots(
     it('can validate equips of weapons into soldiers', async function () {
       // This asset is not equippable
       expect(
-        await weaponEquip.canTokenBeEquippedWithAssetIntoSlot(
-          soldierEquip.address,
+        await weapon.canTokenBeEquippedWithAssetIntoSlot(
+          soldier.address,
           weaponsIds[0],
           weaponAssetsFull[0],
           partIdForWeapon,
@@ -74,8 +66,8 @@ async function shouldBehaveLikeEquippableWithSlots(
 
       // This asset is equippable into weapon part
       expect(
-        await weaponEquip.canTokenBeEquippedWithAssetIntoSlot(
-          soldierEquip.address,
+        await weapon.canTokenBeEquippedWithAssetIntoSlot(
+          soldier.address,
           weaponsIds[0],
           weaponAssetsEquip[0],
           partIdForWeapon,
@@ -84,8 +76,8 @@ async function shouldBehaveLikeEquippableWithSlots(
 
       // This asset is NOT equippable into weapon gem part
       expect(
-        await weaponEquip.canTokenBeEquippedWithAssetIntoSlot(
-          soldierEquip.address,
+        await weapon.canTokenBeEquippedWithAssetIntoSlot(
+          soldier.address,
           weaponsIds[0],
           weaponAssetsEquip[0],
           partIdForWeaponGem,
@@ -96,8 +88,8 @@ async function shouldBehaveLikeEquippableWithSlots(
     it('can validate equips of weapon gems into weapons', async function () {
       // This asset is not equippable
       expect(
-        await weaponGemEquip.canTokenBeEquippedWithAssetIntoSlot(
-          weaponEquip.address,
+        await weaponGem.canTokenBeEquippedWithAssetIntoSlot(
+          weapon.address,
           weaponGemsIds[0],
           weaponGemAssetFull,
           partIdForWeaponGem,
@@ -106,8 +98,8 @@ async function shouldBehaveLikeEquippableWithSlots(
 
       // This asset is equippable into weapon gem slot
       expect(
-        await weaponGemEquip.canTokenBeEquippedWithAssetIntoSlot(
-          weaponEquip.address,
+        await weaponGem.canTokenBeEquippedWithAssetIntoSlot(
+          weapon.address,
           weaponGemsIds[0],
           weaponGemAssetEquip,
           partIdForWeaponGem,
@@ -116,8 +108,8 @@ async function shouldBehaveLikeEquippableWithSlots(
 
       // This asset is NOT equippable into background slot
       expect(
-        await weaponGemEquip.canTokenBeEquippedWithAssetIntoSlot(
-          weaponEquip.address,
+        await weaponGem.canTokenBeEquippedWithAssetIntoSlot(
+          weapon.address,
           weaponGemsIds[0],
           weaponGemAssetEquip,
           partIdForBackground,
@@ -128,8 +120,8 @@ async function shouldBehaveLikeEquippableWithSlots(
     it('can validate equips of backgrounds into soldiers', async function () {
       // This asset is equippable into background slot
       expect(
-        await backgroundEquip.canTokenBeEquippedWithAssetIntoSlot(
-          soldierEquip.address,
+        await background.canTokenBeEquippedWithAssetIntoSlot(
+          soldier.address,
           backgroundsIds[0],
           backgroundAssetId,
           partIdForBackground,
@@ -138,8 +130,8 @@ async function shouldBehaveLikeEquippableWithSlots(
 
       // This asset is NOT equippable into weapon slot
       expect(
-        await backgroundEquip.canTokenBeEquippedWithAssetIntoSlot(
-          soldierEquip.address,
+        await background.canTokenBeEquippedWithAssetIntoSlot(
+          soldier.address,
           backgroundsIds[0],
           backgroundAssetId,
           partIdForWeapon,
@@ -182,10 +174,10 @@ async function shouldBehaveLikeEquippableWithSlots(
       const weaponChildIndex = 0;
       const backgroundChildIndex = 1;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
-      await soldierEquip
+      await soldier
         .connect(addrs[0])
         .equip([soldiersIds[0], weaponChildIndex, soldierResId, partIdForWeapon, weaponResId]);
-      await soldierEquip
+      await soldier
         .connect(addrs[0])
         .equip([
           soldiersIds[0],
@@ -197,22 +189,22 @@ async function shouldBehaveLikeEquippableWithSlots(
 
       const expectedSlots = [bn(partIdForWeapon), bn(partIdForBackground)];
       const expectedEquips = [
-        [bn(soldierResId), bn(weaponResId), weaponsIds[0], weaponEquip.address],
-        [bn(soldierResId), bn(backgroundAssetId), backgroundsIds[0], backgroundEquip.address],
+        [bn(soldierResId), bn(weaponResId), weaponsIds[0], weapon.address],
+        [bn(soldierResId), bn(backgroundAssetId), backgroundsIds[0], background.address],
       ];
       const expectedMetadata = ['ipfs:weapon/equip/5', 'ipfs:background/'];
-      expect(await view.getEquipped(soldierEquip.address, soldiersIds[0], soldierResId)).to.eql([
+      expect(await view.getEquipped(soldier.address, soldiersIds[0], soldierResId)).to.eql([
         expectedSlots,
         expectedEquips,
         expectedMetadata,
       ]);
 
       // Children are marked as equipped:
+      expect(await soldier.isChildEquipped(soldiersIds[0], weapon.address, weaponsIds[0])).to.eql(
+        true,
+      );
       expect(
-        await soldierEquip.isChildEquipped(soldiersIds[0], weapon.address, weaponsIds[0]),
-      ).to.eql(true);
-      expect(
-        await soldierEquip.isChildEquipped(soldiersIds[0], background.address, backgroundsIds[0]),
+        await soldier.isChildEquipped(soldiersIds[0], background.address, backgroundsIds[0]),
       ).to.eql(true);
     });
 
@@ -221,7 +213,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       const badChildIndex = 3;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[0])
           .equip([soldiersIds[0], badChildIndex, soldierResId, partIdForWeapon, weaponResId]),
       ).to.be.reverted; // Bad index
@@ -231,12 +223,12 @@ async function shouldBehaveLikeEquippableWithSlots(
       const equippableGroupId = 0;
       // The malicious child indicates it can be equipped into soldier:
       await expect(
-        weaponGemEquip.setValidParentForEquippableGroup(
+        weaponGem.setValidParentForEquippableGroup(
           equippableGroupId,
-          soldierEquip.address,
+          soldier.address,
           partIdForWeaponGem,
         ),
-      ).to.be.revertedWithCustomError(weaponGemEquip, 'RMRKIdZeroForbidden');
+      ).to.be.revertedWithCustomError(weaponGem, 'RMRKIdZeroForbidden');
     });
 
     it('cannot set a valid equippable group with part id 0', async function () {
@@ -244,12 +236,8 @@ async function shouldBehaveLikeEquippableWithSlots(
       const partId = 0;
       // The malicious child indicates it can be equipped into soldier:
       await expect(
-        weaponGemEquip.setValidParentForEquippableGroup(
-          equippableGroupId,
-          soldierEquip.address,
-          partId,
-        ),
-      ).to.be.revertedWithCustomError(weaponGemEquip, 'RMRKIdZeroForbidden');
+        weaponGem.setValidParentForEquippableGroup(equippableGroupId, soldier.address, partId),
+      ).to.be.revertedWithCustomError(weaponGem, 'RMRKIdZeroForbidden');
     });
 
     it('cannot equip into a slot not set on the parent asset (gem into soldier)', async function () {
@@ -263,26 +251,24 @@ async function shouldBehaveLikeEquippableWithSlots(
         .acceptChild(soldierId, 0, weaponGem.address, newWeaponGemId);
 
       // Add assets to weapon
-      await weaponGemEquip.addAssetToToken(newWeaponGemId, weaponGemAssetFull, 0);
-      await weaponGemEquip.addAssetToToken(newWeaponGemId, weaponGemAssetEquip, 0);
-      await weaponGemEquip.connect(soldierOwner).acceptAsset(newWeaponGemId, 0, weaponGemAssetFull);
-      await weaponGemEquip
-        .connect(soldierOwner)
-        .acceptAsset(newWeaponGemId, 0, weaponGemAssetEquip);
+      await weaponGem.addAssetToToken(newWeaponGemId, weaponGemAssetFull, 0);
+      await weaponGem.addAssetToToken(newWeaponGemId, weaponGemAssetEquip, 0);
+      await weaponGem.connect(soldierOwner).acceptAsset(newWeaponGemId, 0, weaponGemAssetFull);
+      await weaponGem.connect(soldierOwner).acceptAsset(newWeaponGemId, 0, weaponGemAssetEquip);
 
       // The malicious child indicates it can be equipped into soldier:
-      await weaponGemEquip.setValidParentForEquippableGroup(
+      await weaponGem.setValidParentForEquippableGroup(
         1, // equippableGroupId for gems
-        soldierEquip.address,
+        soldier.address,
         partIdForWeaponGem,
       );
 
       // Weapon is child on index 0, background on index 1
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[0])
           .equip([soldierId, childIndex, soldierResId, partIdForWeaponGem, weaponGemAssetEquip]),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKTargetAssetCannotReceiveSlot');
+      ).to.be.revertedWithCustomError(soldier, 'RMRKTargetAssetCannotReceiveSlot');
     });
 
     it('cannot equip wrong child in slot (weapon in background)', async function () {
@@ -290,7 +276,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       const backgroundChildIndex = 1;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[0])
           .equip([
             soldiersIds[0],
@@ -299,26 +285,26 @@ async function shouldBehaveLikeEquippableWithSlots(
             partIdForWeapon,
             weaponResId,
           ]),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKTokenCannotBeEquippedWithAssetIntoSlot');
+      ).to.be.revertedWithCustomError(soldier, 'RMRKTokenCannotBeEquippedWithAssetIntoSlot');
     });
 
     it('cannot equip child in wrong slot (weapon in background)', async function () {
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[0])
           .equip([soldiersIds[0], childIndex, soldierResId, partIdForBackground, weaponResId]),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKTokenCannotBeEquippedWithAssetIntoSlot');
+      ).to.be.revertedWithCustomError(soldier, 'RMRKTokenCannotBeEquippedWithAssetIntoSlot');
     });
 
     it('cannot equip child with wrong asset (weapon in background)', async function () {
       const childIndex = 0;
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[0])
           .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, backgroundAssetId]),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKTokenCannotBeEquippedWithAssetIntoSlot');
+      ).to.be.revertedWithCustomError(soldier, 'RMRKTokenCannotBeEquippedWithAssetIntoSlot');
     });
 
     it('cannot equip if not owner', async function () {
@@ -326,17 +312,17 @@ async function shouldBehaveLikeEquippableWithSlots(
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[1]) // Owner is addrs[0]
           .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKNotApprovedForAssetsOrOwner');
+      ).to.be.revertedWithCustomError(soldier, 'RMRKNotApprovedForAssetsOrOwner');
     });
 
     it('cannot equip 2 children into the same slot', async function () {
       // Weapon is child on index 0, background on index 1
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
-      await soldierEquip
+      await soldier
         .connect(addrs[0])
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
@@ -346,7 +332,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       const newWeaponChildIndex = 2;
       const newWeaponResId = weaponAssetsEquip[weaponAssetIndex];
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[0])
           .equip([
             soldiersIds[0],
@@ -355,7 +341,7 @@ async function shouldBehaveLikeEquippableWithSlots(
             partIdForWeapon,
             newWeaponResId,
           ]),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKSlotAlreadyUsed');
+      ).to.be.revertedWithCustomError(soldier, 'RMRKSlotAlreadyUsed');
     });
 
     it('cannot equip if not intented on catalog', async function () {
@@ -366,10 +352,10 @@ async function shouldBehaveLikeEquippableWithSlots(
       // Remove equippable addresses for part.
       await catalog.resetEquippableAddresses(partIdForWeapon);
       await expect(
-        soldierEquip
+        soldier
           .connect(addrs[0]) // Owner is addrs[0]
           .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKEquippableEquipNotAllowedByCatalog');
+      ).to.be.revertedWithCustomError(soldier, 'RMRKEquippableEquipNotAllowedByCatalog');
     });
 
     describe('With equipped children', async function () {
@@ -383,10 +369,10 @@ async function shouldBehaveLikeEquippableWithSlots(
         soldierID = soldiersIds[0];
         soldierOwner = addrs[0];
 
-        await soldierEquip
+        await soldier
           .connect(soldierOwner)
           .equip([soldierID, weaponChildIndex, soldierResId, partIdForWeapon, weaponResId]);
-        await soldierEquip
+        await soldier
           .connect(soldierOwner)
           .equip([
             soldierID,
@@ -400,33 +386,31 @@ async function shouldBehaveLikeEquippableWithSlots(
       it('can replace parent equipped asset and still unequip it', async function () {
         // Weapon is child on index 0, background on index 1
         const newSoldierResId = soldierResId + 1;
-        await soldierEquip.addEquippableAssetEntry(
+        await soldier.addEquippableAssetEntry(
           newSoldierResId,
           0,
           catalog.address,
           'ipfs:soldier/',
           [partIdForBody, partIdForWeapon, partIdForBackground],
         );
-        await soldierEquip.addAssetToToken(soldierID, newSoldierResId, soldierResId);
-        await soldierEquip.connect(soldierOwner).acceptAsset(soldierID, 0, newSoldierResId);
+        await soldier.addAssetToToken(soldierID, newSoldierResId, soldierResId);
+        await soldier.connect(soldierOwner).acceptAsset(soldierID, 0, newSoldierResId);
 
         // Children still marked as equipped, so the cannot be transferred
-        expect(await soldierEquip.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
+        expect(await soldier.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
           true,
         );
         expect(
-          await soldierEquip.isChildEquipped(soldierID, background.address, backgroundsIds[0]),
+          await soldier.isChildEquipped(soldierID, background.address, backgroundsIds[0]),
         ).to.eql(true);
 
-        await soldierEquip.connect(soldierOwner).unequip(soldierID, soldierResId, partIdForWeapon);
-        await soldierEquip
-          .connect(soldierOwner)
-          .unequip(soldierID, soldierResId, partIdForBackground);
-        expect(await soldierEquip.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
+        await soldier.connect(soldierOwner).unequip(soldierID, soldierResId, partIdForWeapon);
+        await soldier.connect(soldierOwner).unequip(soldierID, soldierResId, partIdForBackground);
+        expect(await soldier.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
           false,
         );
         expect(
-          await soldierEquip.isChildEquipped(soldierID, background.address, backgroundsIds[0]),
+          await soldier.isChildEquipped(soldierID, background.address, backgroundsIds[0]),
         ).to.eql(false);
       });
 
@@ -434,24 +418,24 @@ async function shouldBehaveLikeEquippableWithSlots(
         // Weapon is child on index 0, background on index 1
         const newWeaponAssetId = weaponAssetsEquip[0] + 10;
         const weaponId = weaponsIds[0];
-        await weaponEquip.addEquippableAssetEntry(
+        await weapon.addEquippableAssetEntry(
           newWeaponAssetId,
           1, // equippableGroupId
           catalog.address,
           'ipfs:weapon/new',
           [],
         );
-        await weaponEquip.addAssetToToken(weaponId, newWeaponAssetId, weaponAssetsEquip[0]);
-        await weaponEquip.connect(soldierOwner).acceptAsset(weaponId, 0, newWeaponAssetId);
+        await weapon.addAssetToToken(weaponId, newWeaponAssetId, weaponAssetsEquip[0]);
+        await weapon.connect(soldierOwner).acceptAsset(weaponId, 0, newWeaponAssetId);
 
         // Children still marked as equipped, so the cannot be transferred
-        expect(await soldierEquip.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
+        expect(await soldier.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
           true,
         );
 
-        await soldierEquip.connect(soldierOwner).unequip(soldierID, soldierResId, partIdForWeapon);
+        await soldier.connect(soldierOwner).unequip(soldierID, soldierResId, partIdForWeapon);
 
-        expect(await soldierEquip.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
+        expect(await soldier.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(
           false,
         );
       });
@@ -459,21 +443,21 @@ async function shouldBehaveLikeEquippableWithSlots(
       it('can replace parent equipped asset and cannot not re-equip on top', async function () {
         // Weapon is child on index 0, background on index 1
         const newSoldierResId = soldierResId + 1;
-        await soldierEquip.addEquippableAssetEntry(
+        await soldier.addEquippableAssetEntry(
           newSoldierResId,
           0,
           catalog.address,
           'ipfs:soldier/',
           [partIdForBody, partIdForWeapon, partIdForBackground],
         );
-        await soldierEquip.addAssetToToken(soldierID, newSoldierResId, soldierResId);
-        await soldierEquip.connect(soldierOwner).acceptAsset(soldierID, 0, newSoldierResId);
+        await soldier.addAssetToToken(soldierID, newSoldierResId, soldierResId);
+        await soldier.connect(soldierOwner).acceptAsset(soldierID, 0, newSoldierResId);
 
         await expect(
-          soldierEquip
+          soldier
             .connect(soldierOwner)
             .equip([soldierID, weaponChildIndex, newSoldierResId, partIdForWeapon, weaponResId]),
-        ).to.be.revertedWithCustomError(soldierEquip, 'RMRKSlotAlreadyUsed');
+        ).to.be.revertedWithCustomError(soldier, 'RMRKSlotAlreadyUsed');
       });
     });
   });
@@ -485,7 +469,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
 
-      await soldierEquip
+      await soldier
         .connect(soldierOwner)
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
@@ -499,7 +483,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
       const approved = addrs[1];
 
-      await soldierEquip
+      await soldier
         .connect(soldierOwner)
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
@@ -514,7 +498,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
       const approved = addrs[1];
 
-      await soldierEquip
+      await soldier
         .connect(soldierOwner)
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
@@ -524,21 +508,21 @@ async function shouldBehaveLikeEquippableWithSlots(
 
     it('cannot unequip if not equipped', async function () {
       await expect(
-        soldierEquip.connect(addrs[0]).unequip(soldiersIds[0], soldierResId, partIdForWeapon),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKNotEquipped');
+        soldier.connect(addrs[0]).unequip(soldiersIds[0], soldierResId, partIdForWeapon),
+      ).to.be.revertedWithCustomError(soldier, 'RMRKNotEquipped');
     });
 
     it('cannot unequip if not owner', async function () {
       // Weapon is child on index 0, background on index 1
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
-      await soldierEquip
+      await soldier
         .connect(addrs[0])
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
       await expect(
-        soldierEquip.connect(addrs[1]).unequip(soldiersIds[0], soldierResId, partIdForWeapon),
-      ).to.be.revertedWithCustomError(soldierEquip, 'RMRKNotApprovedForAssetsOrOwner');
+        soldier.connect(addrs[1]).unequip(soldiersIds[0], soldierResId, partIdForWeapon),
+      ).to.be.revertedWithCustomError(soldier, 'RMRKNotApprovedForAssetsOrOwner');
     });
   });
 
@@ -549,7 +533,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
 
-      await soldierEquip
+      await soldier
         .connect(soldierOwner)
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
@@ -573,7 +557,7 @@ async function shouldBehaveLikeEquippableWithSlots(
       // Weapon is child on index 0
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
-      await soldierEquip
+      await soldier
         .connect(addrs[0])
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
@@ -598,7 +582,7 @@ async function shouldBehaveLikeEquippableWithSlots(
     it('can compose equippables for soldier', async function () {
       const childIndex = 0;
       const weaponResId = weaponAssetsEquip[0]; // This asset is assigned to weapon first weapon
-      await soldierEquip
+      await soldier
         .connect(addrs[0])
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]);
 
@@ -614,7 +598,7 @@ async function shouldBehaveLikeEquippableWithSlots(
           bn(partIdForWeapon), // partId
           bn(weaponAssetsEquip[0]), // childAssetId
           2, // z
-          weaponEquip.address, // childAddress
+          weapon.address, // childAddress
           weaponsIds[0], // childTokenId
           'ipfs:weapon/equip/5', // childAssetMetadata
           '', // partMetadata
@@ -631,7 +615,7 @@ async function shouldBehaveLikeEquippableWithSlots(
         ],
       ];
       const allAssets = await view.composeEquippables(
-        soldierEquip.address,
+        soldier.address,
         soldiersIds[0],
         soldierResId,
       );
@@ -646,7 +630,7 @@ async function shouldBehaveLikeEquippableWithSlots(
 
     it('can compose equippables for simple asset', async function () {
       const allAssets = await view.composeEquippables(
-        backgroundEquip.address,
+        background.address,
         backgroundsIds[0],
         backgroundAssetId,
       );
@@ -662,8 +646,8 @@ async function shouldBehaveLikeEquippableWithSlots(
     it('cannot compose equippables for soldier with not associated asset', async function () {
       const wrongResId = weaponAssetsEquip[1];
       await expect(
-        view.composeEquippables(weaponEquip.address, weaponsIds[0], wrongResId),
-      ).to.be.revertedWithCustomError(weaponEquip, 'RMRKTokenDoesNotHaveAsset');
+        view.composeEquippables(weapon.address, weaponsIds[0], wrongResId),
+      ).to.be.revertedWithCustomError(weapon, 'RMRKTokenDoesNotHaveAsset');
     });
   });
 
@@ -674,7 +658,7 @@ async function shouldBehaveLikeEquippableWithSlots(
   ): Promise<void> {
     // It's ok if nothing equipped
     const expectedSlots = [bn(partIdForWeapon), bn(partIdForBackground)];
-    expect(await view.getEquipped(soldierEquip.address, soldiersIds[0], soldierResId)).to.eql([
+    expect(await view.getEquipped(soldier.address, soldiersIds[0], soldierResId)).to.eql([
       expectedSlots,
       [
         [bn(0), bn(0), bn(0), ethers.constants.AddressZero],
@@ -684,47 +668,47 @@ async function shouldBehaveLikeEquippableWithSlots(
     ]);
 
     await expect(
-      soldierEquip
+      soldier
         .connect(from)
         .equip([soldiersIds[0], childIndex, soldierResId, partIdForWeapon, weaponResId]),
     )
-      .to.emit(soldierEquip, 'ChildAssetEquipped')
+      .to.emit(soldier, 'ChildAssetEquipped')
       .withArgs(
         soldiersIds[0],
         soldierResId,
         partIdForWeapon,
         weaponsIds[0],
-        weaponEquip.address,
+        weapon.address,
         weaponAssetsEquip[0],
       );
     // All part slots are included on the response:
     // If a slot has nothing equipped, it returns an empty equip:
     const expectedEquips = [
-      [bn(soldierResId), bn(weaponResId), weaponsIds[0], weaponEquip.address],
+      [bn(soldierResId), bn(weaponResId), weaponsIds[0], weapon.address],
       [bn(0), bn(0), bn(0), ethers.constants.AddressZero],
     ];
     const expectedMetadata = ['ipfs:weapon/equip/5', ''];
-    expect(await view.getEquipped(soldierEquip.address, soldiersIds[0], soldierResId)).to.eql([
+    expect(await view.getEquipped(soldier.address, soldiersIds[0], soldierResId)).to.eql([
       expectedSlots,
       expectedEquips,
       expectedMetadata,
     ]);
 
     // Child is marked as equipped:
-    expect(
-      await soldierEquip.isChildEquipped(soldiersIds[0], weapon.address, weaponsIds[0]),
-    ).to.eql(true);
+    expect(await soldier.isChildEquipped(soldiersIds[0], weapon.address, weaponsIds[0])).to.eql(
+      true,
+    );
   }
 
   async function unequipWeaponAndCheckFromAddress(from: SignerWithAddress): Promise<void> {
-    await expect(soldierEquip.connect(from).unequip(soldiersIds[0], soldierResId, partIdForWeapon))
-      .to.emit(soldierEquip, 'ChildAssetUnequipped')
+    await expect(soldier.connect(from).unequip(soldiersIds[0], soldierResId, partIdForWeapon))
+      .to.emit(soldier, 'ChildAssetUnequipped')
       .withArgs(
         soldiersIds[0],
         soldierResId,
         partIdForWeapon,
         weaponsIds[0],
-        weaponEquip.address,
+        weapon.address,
         weaponAssetsEquip[0],
       );
 
@@ -735,16 +719,16 @@ async function shouldBehaveLikeEquippableWithSlots(
       [bn(0), bn(0), bn(0), ethers.constants.AddressZero],
     ];
     const expectedMetadata = ['', ''];
-    expect(await view.getEquipped(soldierEquip.address, soldiersIds[0], soldierResId)).to.eql([
+    expect(await view.getEquipped(soldier.address, soldiersIds[0], soldierResId)).to.eql([
       expectedSlots,
       expectedEquips,
       expectedMetadata,
     ]);
 
     // Child is marked as not equipped:
-    expect(
-      await soldierEquip.isChildEquipped(soldiersIds[0], weapon.address, weaponsIds[0]),
-    ).to.eql(false);
+    expect(await soldier.isChildEquipped(soldiersIds[0], weapon.address, weaponsIds[0])).to.eql(
+      false,
+    );
   }
 
   async function mintWeaponToSoldier(
@@ -757,14 +741,10 @@ async function shouldBehaveLikeEquippableWithSlots(
     await soldier.connect(soldierOwner).acceptChild(soldierId, 0, weapon.address, newWeaponId);
 
     // Add assets to weapon
-    await weaponEquip.addAssetToToken(newWeaponId, weaponAssetsFull[assetIndex], 0);
-    await weaponEquip.addAssetToToken(newWeaponId, weaponAssetsEquip[assetIndex], 0);
-    await weaponEquip
-      .connect(soldierOwner)
-      .acceptAsset(newWeaponId, 0, weaponAssetsFull[assetIndex]);
-    await weaponEquip
-      .connect(soldierOwner)
-      .acceptAsset(newWeaponId, 0, weaponAssetsEquip[assetIndex]);
+    await weapon.addAssetToToken(newWeaponId, weaponAssetsFull[assetIndex], 0);
+    await weapon.addAssetToToken(newWeaponId, weaponAssetsEquip[assetIndex], 0);
+    await weapon.connect(soldierOwner).acceptAsset(newWeaponId, 0, weaponAssetsFull[assetIndex]);
+    await weapon.connect(soldierOwner).acceptAsset(newWeaponId, 0, weaponAssetsEquip[assetIndex]);
 
     return newWeaponId;
   }

--- a/test/catalogUtils.ts
+++ b/test/catalogUtils.ts
@@ -258,7 +258,7 @@ describe('Collection Utils For Orphans', function () {
       true,
     );
 
-    const equipments = await catalogUtils.getOrphanedEquipmentsFromParentAsset(
+    const equipments = await catalogUtils.getOrphanEquipmentsFromParentAsset(
       soldier.address,
       soldierID,
       catalog.address,
@@ -300,16 +300,16 @@ describe('Collection Utils For Orphans', function () {
     // Children still marked as equipped, so it cannot be transferred or equip something else into the slot
     expect(await soldier.isChildEquipped(soldierID, weapon.address, weaponsIds[0])).to.eql(true);
 
-    expect(
-      await catalogUtils.getOrphanedEquipmentFromChildAsset(soldier.address, soldierID),
-    ).to.eql([
+    expect(await catalogUtils.getOrphanEquipmentsFromChildAsset(soldier.address, soldierID)).to.eql(
       [
-        bn(soldierResId),
-        bn(partIdForWeapon),
-        weapon.address,
-        weaponsIds[0],
-        bn(weaponAssetsEquip[0]),
+        [
+          bn(soldierResId),
+          bn(partIdForWeapon),
+          weapon.address,
+          weaponsIds[0],
+          bn(weaponAssetsEquip[0]),
+        ],
       ],
-    ]);
+    );
   });
 });

--- a/test/equippable.ts
+++ b/test/equippable.ts
@@ -26,12 +26,6 @@ async function partsFixture() {
   const catalogSymbol = 'NCB';
   const catalogType = 'mixed';
 
-  const neonName = 'NeonCrisis';
-  const neonSymbol = 'NC';
-
-  const maskName = 'NeonMask';
-  const maskSymbol = 'NM';
-
   const catalogFactory = await ethers.getContractFactory('RMRKCatalogImpl');
   const equipFactory = await ethers.getContractFactory('RMRKEquippableMock');
   const viewFactory = await ethers.getContractFactory('RMRKEquipRenderUtils');
@@ -52,25 +46,13 @@ async function partsFixture() {
   const view = <RMRKEquipRenderUtils>await viewFactory.deploy();
   await view.deployed();
 
-  await setupContextForParts(catalog, neon, neon, mask, mask, mintFromMock, nestMintFromMock);
+  await setupContextForParts(catalog, neon, mask, mintFromMock, nestMintFromMock);
   return { catalog, neon, mask, view };
 }
 
 async function slotsFixture() {
   const catalogSymbol = 'SSB';
   const catalogType = 'mixed';
-
-  const soldierName = 'SnakeSoldier';
-  const soldierSymbol = 'SS';
-
-  const weaponName = 'SnakeWeapon';
-  const weaponSymbol = 'SW';
-
-  const weaponGemName = 'SnakeWeaponGem';
-  const weaponGemSymbol = 'SWG';
-
-  const backgroundName = 'SnakeBackground';
-  const backgroundSymbol = 'SB';
 
   const catalogFactory = await ethers.getContractFactory('RMRKCatalogImpl');
   const equipFactory = await ethers.getContractFactory('RMRKEquippableMock');
@@ -106,12 +88,8 @@ async function slotsFixture() {
     catalog,
     catalogForWeapon,
     soldier,
-    soldier,
-    weapon,
     weapon,
     weaponGem,
-    weaponGem,
-    background,
     background,
     mintFromMock,
     nestMintFromMock,
@@ -143,9 +121,7 @@ describe('MinifiedEquippableMock with Parts', async () => {
 
     this.catalog = catalog;
     this.neon = neon;
-    this.neonEquip = neon;
     this.mask = mask;
-    this.maskEquip = mask;
     this.view = view;
   });
 
@@ -160,13 +136,9 @@ describe('MinifiedEquippableMock with Slots', async () => {
 
     this.catalog = catalog;
     this.soldier = soldier;
-    this.soldierEquip = soldier;
     this.weapon = weapon;
-    this.weaponEquip = weapon;
     this.weaponGem = weaponGem;
-    this.weaponGemEquip = weaponGem;
     this.background = background;
-    this.backgroundEquip = background;
     this.view = view;
   });
 

--- a/test/minifiedEquippable.ts
+++ b/test/minifiedEquippable.ts
@@ -60,25 +60,13 @@ async function partsFixture() {
   const view = <RMRKEquipRenderUtils>await viewFactory.deploy();
   await view.deployed();
 
-  await setupContextForParts(catalog, neon, neon, mask, mask, mintFromMock, nestMintFromMock);
+  await setupContextForParts(catalog, neon, mask, mintFromMock, nestMintFromMock);
   return { catalog, neon, mask, view };
 }
 
 async function slotsFixture() {
   const catalogSymbol = 'SSC';
   const catalogType = 'mixed';
-
-  const soldierName = 'SnakeSoldier';
-  const soldierSymbol = 'SS';
-
-  const weaponName = 'SnakeWeapon';
-  const weaponSymbol = 'SW';
-
-  const weaponGemName = 'SnakeWeaponGem';
-  const weaponGemSymbol = 'SWG';
-
-  const backgroundName = 'SnakeBackground';
-  const backgroundSymbol = 'SB';
 
   const catalogFactory = await ethers.getContractFactory('RMRKCatalogImpl');
   const equipFactory = await ethers.getContractFactory('RMRKMinifiedEquippableMock');
@@ -114,12 +102,8 @@ async function slotsFixture() {
     catalog,
     catalogForWeapon,
     soldier,
-    soldier,
-    weapon,
     weapon,
     weaponGem,
-    weaponGem,
-    background,
     background,
     mintFromMock,
     nestMintFromMock,
@@ -153,9 +137,7 @@ describe('MinifiedEquippableMock with Fixed Parts', async () => {
 
     this.catalog = catalog;
     this.neon = neon;
-    this.neonEquip = neon;
     this.mask = mask;
-    this.maskEquip = mask;
     this.view = view;
   });
 
@@ -170,13 +152,9 @@ describe('MinifiedEquippableMock with Slot Parts', async () => {
 
     this.catalog = catalog;
     this.soldier = soldier;
-    this.soldierEquip = soldier;
     this.weapon = weapon;
-    this.weaponEquip = weapon;
     this.weaponGem = weaponGem;
-    this.weaponGemEquip = weaponGem;
     this.background = background;
-    this.backgroundEquip = background;
     this.view = view;
   });
 

--- a/test/setup/equippableParts.ts
+++ b/test/setup/equippableParts.ts
@@ -50,9 +50,7 @@ enum ItemType {
 async function setupContextForParts(
   catalog: Contract,
   neon: Contract,
-  neonEquip: Contract,
   mask: Contract,
-  maskEquip: Contract,
   mint: (token: Contract, to: string) => Promise<BigNumber>,
   nestMint: (token: Contract, to: string, parentId: BigNumber) => Promise<BigNumber>,
 ) {
@@ -215,7 +213,7 @@ async function setupContextForParts(
     const partForMask = {
       itemType: ItemType.Slot,
       z: 2,
-      equippable: [maskEquip.address],
+      equippable: [mask.address],
       metadataURI: '',
     };
 
@@ -270,31 +268,31 @@ async function setupContextForParts(
   }
 
   async function addAssetsToNeon(): Promise<void> {
-    await neonEquip.addEquippableAssetEntry(neonResIds[0], 0, catalog.address, 'ipfs:neonRes/1', [
+    await neon.addEquippableAssetEntry(neonResIds[0], 0, catalog.address, 'ipfs:neonRes/1', [
       partIdForHead1,
       partIdForBody1,
       partIdForHair1,
       partIdForMask,
     ]);
-    await neonEquip.addEquippableAssetEntry(neonResIds[1], 0, catalog.address, 'ipfs:neonRes/2', [
+    await neon.addEquippableAssetEntry(neonResIds[1], 0, catalog.address, 'ipfs:neonRes/2', [
       partIdForHead2,
       partIdForBody2,
       partIdForHair2,
       partIdForMask,
     ]);
-    await neonEquip.addEquippableAssetEntry(neonResIds[2], 0, catalog.address, 'ipfs:neonRes/3', [
+    await neon.addEquippableAssetEntry(neonResIds[2], 0, catalog.address, 'ipfs:neonRes/3', [
       partIdForHead3,
       partIdForBody1,
       partIdForHair3,
       partIdForMask,
     ]);
-    await neonEquip.addEquippableAssetEntry(neonResIds[3], 0, catalog.address, 'ipfs:neonRes/4', [
+    await neon.addEquippableAssetEntry(neonResIds[3], 0, catalog.address, 'ipfs:neonRes/4', [
       partIdForHead1,
       partIdForBody2,
       partIdForHair2,
       partIdForMask,
     ]);
-    await neonEquip.addEquippableAssetEntry(neonResIds[4], 0, catalog.address, 'ipfs:neonRes/1', [
+    await neon.addEquippableAssetEntry(neonResIds[4], 0, catalog.address, 'ipfs:neonRes/1', [
       partIdForHead2,
       partIdForBody1,
       partIdForHair1,
@@ -302,37 +300,35 @@ async function setupContextForParts(
     ]);
 
     for (let i = 0; i < uniqueNeons; i++) {
-      await neonEquip.addAssetToToken(neons[i], neonResIds[i % neonResIds.length], 0);
-      await neonEquip
-        .connect(addrs[i % 3])
-        .acceptAsset(neons[i], 0, neonResIds[i % neonResIds.length]);
+      await neon.addAssetToToken(neons[i], neonResIds[i % neonResIds.length], 0);
+      await neon.connect(addrs[i % 3]).acceptAsset(neons[i], 0, neonResIds[i % neonResIds.length]);
     }
   }
 
   async function addAssetsToMask(): Promise<void> {
     // Assets for full view, composed with fixed parts
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsFull[0],
       0, // Not meant to equip
       catalog.address, // Not meant to equip, but catalog needed for parts
       `ipfs:weapon/full/${maskAssetsFull[0]}`,
       [partIdForMaskCatalog1, partIdForHorns1, partIdForEars1],
     );
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsFull[1],
       0, // Not meant to equip
       catalog.address, // Not meant to equip, but catalog needed for parts
       `ipfs:weapon/full/${maskAssetsFull[1]}`,
       [partIdForMaskCatalog2, partIdForHorns2, partIdForEars2],
     );
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsFull[2],
       0, // Not meant to equip
       catalog.address, // Not meant to equip, but catalog needed for parts
       `ipfs:weapon/full/${maskAssetsFull[2]}`,
       [partIdForMaskCatalog3, partIdForHorns1, partIdForEars2],
     );
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsFull[3],
       0, // Not meant to equip
       catalog.address, // Not meant to equip, but catalog needed for parts
@@ -341,7 +337,7 @@ async function setupContextForParts(
     );
 
     // Assets for equipping view, also composed with fixed parts
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsEquip[0],
       maskEquippableGroupId,
       catalog.address,
@@ -350,7 +346,7 @@ async function setupContextForParts(
     );
 
     // Assets for equipping view, also composed with fixed parts
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsEquip[1],
       maskEquippableGroupId,
       catalog.address,
@@ -359,7 +355,7 @@ async function setupContextForParts(
     );
 
     // Assets for equipping view, also composed with fixed parts
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsEquip[2],
       maskEquippableGroupId,
       catalog.address,
@@ -368,7 +364,7 @@ async function setupContextForParts(
     );
 
     // Assets for equipping view, also composed with fixed parts
-    await maskEquip.addEquippableAssetEntry(
+    await mask.addEquippableAssetEntry(
       maskAssetsEquip[3],
       maskEquippableGroupId,
       catalog.address,
@@ -377,23 +373,15 @@ async function setupContextForParts(
     );
 
     // Can be equipped into neons
-    await maskEquip.setValidParentForEquippableGroup(
-      maskEquippableGroupId,
-      neonEquip.address,
-      partIdForMask,
-    );
+    await mask.setValidParentForEquippableGroup(maskEquippableGroupId, neon.address, partIdForMask);
 
     // Add 2 assets to each weapon, one full, one for equip
     // There are 10 weapon tokens for 4 unique assets so we use %
     for (let i = 0; i < masks.length; i++) {
-      await maskEquip.addAssetToToken(masks[i], maskAssetsFull[i % uniqueMasks], 0);
-      await maskEquip.addAssetToToken(masks[i], maskAssetsEquip[i % uniqueMasks], 0);
-      await maskEquip
-        .connect(addrs[i % 3])
-        .acceptAsset(masks[i], 0, maskAssetsFull[i % uniqueMasks]);
-      await maskEquip
-        .connect(addrs[i % 3])
-        .acceptAsset(masks[i], 0, maskAssetsEquip[i % uniqueMasks]);
+      await mask.addAssetToToken(masks[i], maskAssetsFull[i % uniqueMasks], 0);
+      await mask.addAssetToToken(masks[i], maskAssetsEquip[i % uniqueMasks], 0);
+      await mask.connect(addrs[i % 3]).acceptAsset(masks[i], 0, maskAssetsFull[i % uniqueMasks]);
+      await mask.connect(addrs[i % 3]).acceptAsset(masks[i], 0, maskAssetsEquip[i % uniqueMasks]);
     }
   }
 }


### PR DESCRIPTION
# Description

Adds methods to identify equipments where the parent or child asset was replaced.
Refactor on equippable tests.

# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding new functions and fixing existing ones in the `RMRKCatalogUtils` contract. 

### Detailed summary
- Added `sleep` function to delay execution in `deploy_catalogUtils.ts`
- Added `getOrphanEquipmentsFromChildAsset` function to retrieve data about children equipped to a specified token where the child asset has been replaced
- Added `getOrphanEquipmentsFromParentAsset` function to retrieve data about children equipped to a specified token where the parent asset has been replaced
- Added `getSlotPartsAndCatalog` function to retrieve the parent address and slot part IDs for a given target child and the catalog of the parent asset
- Added `splitSlotAndFixedParts` function to split slot and fixed parts
- Added `RMRKNotComposableAsset` error for attempting to compose an asset without an associated Catalog
- Updated tests and documentation

> The following files were skipped due to too many changes: `test/behavior/equippableParts.ts`, `test/setup/equippableParts.ts`, `test/catalogUtils.ts`, `test/setup/equippableSlots.ts`, `contracts/RMRK/utils/RMRKCatalogUtils.sol`, `test/behavior/equippableSlots.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->