### PR TITLE
Implements BulkWriter.transferAndEquip.

### DIFF
--- a/docs/RMRK/utils/RMRKBulkWriter.md
+++ b/docs/RMRK/utils/RMRKBulkWriter.md
@@ -85,6 +85,27 @@ function replaceEquip(address collection, IERC6220.IntakeEquip data) external no
 | collection | address | undefined |
 | data | IERC6220.IntakeEquip | undefined |
 
+### transferAndEquip
+
+```solidity
+function transferAndEquip(address collection, uint256 tokenId, address destinationCollection, uint256 destinationTokenId, RMRKBulkWriter.ParentData parentData, IERC6220.IntakeEquip equipData) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| collection | address | undefined |
+| tokenId | uint256 | undefined |
+| destinationCollection | address | undefined |
+| destinationTokenId | uint256 | undefined |
+| parentData | RMRKBulkWriter.ParentData | undefined |
+| equipData | IERC6220.IntakeEquip | undefined |
+
 
 
 


### PR DESCRIPTION
# Description

The NFT to transfer can be equipped, nested or free. The destination must be an NFT.
The NFT can be equipped into the destination.
If destination slot is occupied, it will be unequipped. 
All these operations happen under a single transactions, given the right approvals.



# Checklist

- [x] Verified code additions
- [x] Updated NatSpec comments (if applicable)
- [x] Regenerated docs
- [x] Ran prettier
- [x] Added tests to fully cover the changes
